### PR TITLE
Properly print para id in error message

### DIFF
--- a/pallets/author-noting/src/lib.rs
+++ b/pallets/author-noting/src/lib.rs
@@ -108,7 +108,11 @@ pub mod pallet {
             for para_id in para_ids {
                 match Self::fetch_author_slot_from_proof(&relay_state_proof, para_id) {
                     Ok(author) => LatestAuthor::<T>::insert(para_id, author),
-                    Err(e) => log::warn!("Author-noting error {:?} found in para {:?}", e, u32::from(para_id)),
+                    Err(e) => log::warn!(
+                        "Author-noting error {:?} found in para {:?}",
+                        e,
+                        u32::from(para_id)
+                    ),
                 }
             }
 


### PR DESCRIPTION
It is very annoying that we are forced to do this just to see a number in logs.

Before:

```
2023-04-19 12:22:31 [Tanssi] Author-noting error AuraDigestFirstItem found in para <wasm:stripped>    
```

After:

```
2023-04-19 12:44:18 [Tanssi] Author-noting error AuraDigestFirstItem found in para 2001    
```