### PR TITLE
Upload zombienet logs in case of failure

### DIFF
--- a/test/suites/para/test_tanssi_containers.ts
+++ b/test/suites/para/test_tanssi_containers.ts
@@ -123,8 +123,6 @@ describeSuite({
       title: "Test author noting is correct for both containers",
       timeout: 60000,
       test: async function () {
-	expect(false).to.be.true;
-
         const assignment = (await paraApi.query.collatorAssignment.collatorContainerChain());
         const paraId2000 = (await container2000Api.query.parachainInfo.parachainId());
         const paraId2001 = (await container2001Api.query.parachainInfo.parachainId());


### PR DESCRIPTION
So it is easier to debug test failures. The logs are only uploaded in case of test failure, if we want them to always be uploaded, change `if: failure()` to `if: always()`.

You can find the logs in the "artifacts" section:

https://github.com/moondance-labs/moondance/actions/runs/4883290965