### PR TITLE
Use Weight::zero instead of Weight::MAX

### DIFF
--- a/pallets/configuration/src/lib.rs
+++ b/pallets/configuration/src/lib.rs
@@ -92,24 +92,25 @@ pub trait WeightInfo {
     fn set_hrmp_open_request_ttl() -> Weight;
 }
 
+// TODO: set proper weights
 impl WeightInfo for () {
     fn set_config_with_block_number() -> Weight {
-        Weight::MAX
+        Weight::zero()
     }
     fn set_config_with_u32() -> Weight {
-        Weight::MAX
+        Weight::zero()
     }
     fn set_config_with_option_u32() -> Weight {
-        Weight::MAX
+        Weight::zero()
     }
     fn set_config_with_weight() -> Weight {
-        Weight::MAX
+        Weight::zero()
     }
     fn set_config_with_balance() -> Weight {
-        Weight::MAX
+        Weight::zero()
     }
     fn set_hrmp_open_request_ttl() -> Weight {
-        Weight::MAX
+        Weight::zero()
     }
 }
 


### PR DESCRIPTION
To allow changing the configuration, Weight::MAX results in an error that the extrinsic doesn't fit in a block