### PR TITLE
Add isEthereum ChainSpec property

### DIFF
--- a/container-chains/templates/frontier/node/src/chain_spec.rs
+++ b/container-chains/templates/frontier/node/src/chain_spec.rs
@@ -91,6 +91,7 @@ pub fn development_config(para_id: ParaId, seeds: Option<Vec<String>>) -> ChainS
     properties.insert("tokenSymbol".into(), "UNIT".into());
     properties.insert("tokenDecimals".into(), 12.into());
     properties.insert("ss58Format".into(), 42.into());
+    properties.insert("isEthereum".into(), true.into());
 
     let initial_collator_seeds = seeds.unwrap_or(vec!["Alice".to_string(), "Bob".to_string()]);
     let collator_accounts: Vec<AccountId> = initial_collator_seeds
@@ -127,7 +128,7 @@ pub fn development_config(para_id: ParaId, seeds: Option<Vec<String>>) -> ChainS
         None,
         None,
         None,
-        None,
+        Some(properties),
         Extensions {
             relay_chain: "rococo-local".into(), // You MUST set this to the correct network!
             para_id: para_id.into(),
@@ -141,6 +142,7 @@ pub fn local_testnet_config(para_id: ParaId, seeds: Option<Vec<String>>) -> Chai
     properties.insert("tokenSymbol".into(), "UNIT".into());
     properties.insert("tokenDecimals".into(), 12.into());
     properties.insert("ss58Format".into(), 42.into());
+    properties.insert("isEthereum".into(), true.into());
     let protocol_id = Some(format!("container-chain-{}", para_id));
 
     let initial_collator_seeds = seeds.unwrap_or(vec!["Alice".to_string(), "Bob".to_string()]);

--- a/container-chains/templates/simple/node/src/chain_spec.rs
+++ b/container-chains/templates/simple/node/src/chain_spec.rs
@@ -87,6 +87,7 @@ pub fn development_config(para_id: ParaId, seeds: Option<Vec<String>>) -> ChainS
     properties.insert("tokenSymbol".into(), "UNIT".into());
     properties.insert("tokenDecimals".into(), 12.into());
     properties.insert("ss58Format".into(), 42.into());
+    properties.insert("isEthereum".into(), false.into());
 
     let initial_collator_seeds = seeds.unwrap_or(vec!["Alice".to_string(), "Bob".to_string()]);
     let collator_accounts: Vec<AccountId> = initial_collator_seeds
@@ -123,7 +124,7 @@ pub fn development_config(para_id: ParaId, seeds: Option<Vec<String>>) -> ChainS
         None,
         None,
         None,
-        None,
+        Some(properties),
         Extensions {
             relay_chain: "rococo-local".into(), // You MUST set this to the correct network!
             para_id: para_id.into(),
@@ -137,6 +138,7 @@ pub fn local_testnet_config(para_id: ParaId, seeds: Option<Vec<String>>) -> Chai
     properties.insert("tokenSymbol".into(), "UNIT".into());
     properties.insert("tokenDecimals".into(), 12.into());
     properties.insert("ss58Format".into(), 42.into());
+    properties.insert("isEthereum".into(), false.into());
     let protocol_id = Some(format!("container-chain-{}", para_id));
 
     let initial_collator_seeds = seeds.unwrap_or(vec!["Alice".to_string(), "Bob".to_string()]);

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -154,6 +154,7 @@ pub fn development_config(
     properties.insert("tokenSymbol".into(), "UNIT".into());
     properties.insert("tokenDecimals".into(), 12.into());
     properties.insert("ss58Format".into(), 42.into());
+    properties.insert("isEthereum".into(), false.into());
 
     ChainSpec::from_genesis(
         // Name
@@ -197,7 +198,7 @@ pub fn development_config(
         None,
         None,
         None,
-        None,
+        Some(properties),
         Extensions {
             relay_chain: "rococo-local".into(), // You MUST set this to the correct network!
             para_id: para_id.into(),
@@ -215,6 +216,7 @@ pub fn local_testnet_config(
     properties.insert("tokenSymbol".into(), "UNIT".into());
     properties.insert("tokenDecimals".into(), 12.into());
     properties.insert("ss58Format".into(), 42.into());
+    properties.insert("isEthereum".into(), false.into());
 
     ChainSpec::from_genesis(
         // Name

--- a/pallets/registrar/src/tests.rs
+++ b/pallets/registrar/src/tests.rs
@@ -288,7 +288,7 @@ fn genesis_error_on_duplicate() {
 }
 
 #[test]
-#[should_panic = "genesis data for para_id 2 is too large: 5000023 bytes"]
+#[should_panic = "genesis data for para_id 2 is too large: 5000024 bytes"]
 fn genesis_error_genesis_data_size_too_big() {
     let genesis_data = ContainerChainGenesisData {
         storage: vec![(vec![], vec![0; 5_000_000]).into()],

--- a/primitives/container-chain-genesis-data/src/json.rs
+++ b/primitives/container-chain-genesis-data/src/json.rs
@@ -151,6 +151,18 @@ pub fn properties_from_chainspec_json(properties_json: &serde_json::Value) -> To
     }) {
         properties.token_symbol = x;
     }
+    if let Some(x) = properties_json.get("isEthereum").and_then(|x| {
+        x.as_bool()
+    }).or_else(|| {
+        log::warn!(
+            "Failed to read properties.isEthereum from container chain chain spec, using default value instead. Invalid value was: {:?}",
+            properties_json.get("isEthereum")
+        );
+
+        None
+    }) {
+        properties.is_ethereum = x;
+    }
 
     properties
 }
@@ -177,6 +189,7 @@ pub fn properties_to_map(
                     .map_err(|e| format!("tokenSymbol is not valid UTF8: {}", e))?,
             ),
         ),
+        ("isEthereum", serde_json::Value::from(false)),
     ]
     .into_iter()
     .map(|(k, v)| (k.to_string(), v))

--- a/primitives/container-chain-genesis-data/src/lib.rs
+++ b/primitives/container-chain-genesis-data/src/lib.rs
@@ -88,6 +88,7 @@ pub struct TokenMetadata {
     pub token_symbol: BoundedVec<u8, MaxLengthTokenSymbol>,
     pub ss58_format: u32,
     pub token_decimals: u32,
+    pub is_ethereum: bool,
 }
 
 impl Default for TokenMetadata {
@@ -97,6 +98,7 @@ impl Default for TokenMetadata {
             token_symbol: BoundedVec::truncate_from(b"UNIT".to_vec()),
             ss58_format: 42,
             token_decimals: 12,
+            is_ethereum: false,
         }
     }
 }

--- a/primitives/container-chain-genesis-data/src/lib.rs
+++ b/primitives/container-chain-genesis-data/src/lib.rs
@@ -65,7 +65,7 @@ pub struct ContainerChainGenesisData {
     pub fork_id: Option<Vec<u8>>,
     #[cfg_attr(feature = "std", serde(with = "sp_core::bytes"))]
     pub extensions: Vec<u8>,
-    pub properties: TokenMetadata,
+    pub properties: Properties,
 }
 
 // TODO: turn this into a Config type parameter
@@ -83,12 +83,20 @@ impl Get<u32> for MaxLengthTokenSymbol {
 }
 
 #[cfg_attr(feature = "std", derive(serde::Deserialize, serde::Serialize))]
+#[derive(
+    Debug, Default, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, scale_info::TypeInfo,
+)]
+pub struct Properties {
+    pub token_metadata: TokenMetadata,
+    pub is_ethereum: bool,
+}
+
+#[cfg_attr(feature = "std", derive(serde::Deserialize, serde::Serialize))]
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, scale_info::TypeInfo)]
 pub struct TokenMetadata {
     pub token_symbol: BoundedVec<u8, MaxLengthTokenSymbol>,
     pub ss58_format: u32,
     pub token_decimals: u32,
-    pub is_ethereum: bool,
 }
 
 impl Default for TokenMetadata {
@@ -98,7 +106,6 @@ impl Default for TokenMetadata {
             token_symbol: BoundedVec::truncate_from(b"UNIT".to_vec()),
             ss58_format: 42,
             token_decimals: 12,
-            is_ethereum: false,
         }
     }
 }

--- a/test/suites/para/test_tanssi_containers.ts
+++ b/test/suites/para/test_tanssi_containers.ts
@@ -177,5 +177,16 @@ describeSuite({
         expect(authorities.toJSON().includes(author.toString())).to.be.true;
       },
     });
+
+    it({
+      id: "T10",
+      title: "Test frontier template isEthereum",
+      test: async function () {
+        const genesisData2000 = (await paraApi.query.registrar.paraGenesisData(2000));
+        expect(genesisData2000.toJSON().properties.isEthereum).to.be.false;
+        const genesisData2001 = (await paraApi.query.registrar.paraGenesisData(2001));
+        expect(genesisData2001.toJSON().properties.isEthereum).to.be.true;
+      },
+    });
   },
 });


### PR DESCRIPTION
Add `isEthereum` field to ChainSpec properties. In the future this will allow polkadot.js and similar apps to detect whether a parachain is using ethereum-style addresses, but for now it does nothing. The default value is `true` for the frontier template, and `false` for the simple template and for the orchestrator chain.