### PR TITLE
Pin stable version

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "stable"
+channel = "1.68.2"
 components = [ "rustfmt", "clippy" ]
 targets = [ "wasm32-unknown-unknown" ]
 profile = "minimal"


### PR DESCRIPTION
Currently `cargo test` doesn't compile with Rust 1.70, so let's pin to the stable version used in CI.