### PR TITLE
Add test for block weight on session change

### DIFF
--- a/test/suites/dev/weights/test_on_session_change_weight.ts
+++ b/test/suites/dev/weights/test_on_session_change_weight.ts
@@ -1,0 +1,46 @@
+import { describeSuite, expect, beforeAll} from "@moonwall/cli";
+import { setupLogger } from "@moonwall/util";
+import { ApiPromise } from "@polkadot/api";
+import { jumpSessions } from "../../../util/block";
+
+import "@polkadot/api-augment";
+
+describeSuite({
+  id: "D06",
+  title: "On session change weights suite",
+  foundationMethods: "dev",
+  testCases: ({ it, context, log }) => {
+    let polkadotJs: ApiPromise;
+    const anotherLogger = setupLogger("anotherLogger");
+    beforeAll(() => {
+      polkadotJs = context.polkadotJs();
+    });
+
+    it({
+        id: "E01",
+        title: "Block weight on session change should be max",
+        test: async function () {
+            // Let's jump one session
+            await jumpSessions(context, 1);
+
+            const blockWeight = (await polkadotJs.query.system.blockWeight()).toJSON();
+            expect(blockWeight.normal).to.deep.equal({ refTime: 0, proofSize: 0 });
+            expect(blockWeight.operational).to.deep.equal({ refTime: 0, proofSize: 0 });
+            expect(blockWeight.mandatory.refTime).to.be.greaterThan(500000000000);
+        },
+    });
+
+    it({
+        id: "E02",
+        title: "Block weight not on session change should be small",
+        test: async function () {
+            await context.createBlock();
+
+            const blockWeight = (await polkadotJs.query.system.blockWeight()).toJSON();
+            expect(blockWeight.normal).to.deep.equal({ refTime: 0, proofSize: 0 });
+            expect(blockWeight.operational).to.deep.equal({ refTime: 0, proofSize: 0 });
+            expect(blockWeight.mandatory.refTime).to.be.lessThan(500000000000);
+        },
+    });
+    },
+});

--- a/test/suites/dev/weights/test_on_session_change_weight.ts
+++ b/test/suites/dev/weights/test_on_session_change_weight.ts
@@ -11,9 +11,11 @@ describeSuite({
   foundationMethods: "dev",
   testCases: ({ it, context, log }) => {
     let polkadotJs: ApiPromise;
+    let maxBlock: number;
     const anotherLogger = setupLogger("anotherLogger");
     beforeAll(() => {
       polkadotJs = context.polkadotJs();
+      maxBlock = polkadotJs.consts.system.blockWeights.maxBlock.refTime.toNumber();
     });
 
     it({
@@ -26,7 +28,7 @@ describeSuite({
             const blockWeight = (await polkadotJs.query.system.blockWeight()).toJSON();
             expect(blockWeight.normal).to.deep.equal({ refTime: 0, proofSize: 0 });
             expect(blockWeight.operational).to.deep.equal({ refTime: 0, proofSize: 0 });
-            expect(blockWeight.mandatory.refTime).to.be.greaterThan(500000000000);
+            expect(blockWeight.mandatory.refTime).to.be.greaterThan(maxBlock);
         },
     });
 
@@ -39,7 +41,7 @@ describeSuite({
             const blockWeight = (await polkadotJs.query.system.blockWeight()).toJSON();
             expect(blockWeight.normal).to.deep.equal({ refTime: 0, proofSize: 0 });
             expect(blockWeight.operational).to.deep.equal({ refTime: 0, proofSize: 0 });
-            expect(blockWeight.mandatory.refTime).to.be.lessThan(500000000000);
+            expect(blockWeight.mandatory.refTime).to.be.lessThan(maxBlock);
         },
     });
     },


### PR DESCRIPTION
This is on session change:

```
{
  normal: { refTime: 0, proofSize: 0 },
  operational: { refTime: 0, proofSize: 0 },
  mandatory: { refTime: 503740332000, proofSize: 5243886 }
}
```

And this is a normal block:

```
{
  normal: { refTime: 0, proofSize: 0 },
  operational: { refTime: 0, proofSize: 0 },
  mandatory: { refTime: 3740332000, proofSize: 1006 }
}
```

In the tests I only check that the value is greater or smaller than 500_000_000_000, which is the max weight used in pallet session.