### PR TITLE
Adapt tests to pass rregardless if they run with fast or slow runtime

### DIFF
--- a/runtime/test/tests/common/mod.rs
+++ b/runtime/test/tests/common/mod.rs
@@ -22,18 +22,19 @@ use {
         traits::{GenesisBuild, OnFinalize, OnInitialize},
     },
     nimbus_primitives::NimbusId,
+    pallet_collator_assignment_runtime_api::runtime_decl_for_collator_assignment_api::CollatorAssignmentApi,
     pallet_registrar_runtime_api::ContainerChainGenesisData,
     parity_scale_codec::Encode,
     polkadot_parachain::primitives::HeadData,
     sp_consensus_aura::AURA_ENGINE_ID,
-    sp_core::Pair,
+    sp_core::{Get, Pair},
     sp_runtime::{Digest, DigestItem},
     test_relay_sproof_builder::ParaHeaderSproofBuilder,
 };
 
 pub use orchestrator_runtime::{
-    AccountId, Aura, Authorship, Balance, Balances, Initializer, Registrar, Runtime, RuntimeCall,
-    RuntimeEvent, Session, System,
+    AccountId, Aura, Authorship, Balance, Balances, Initializer, ParachainInfo, Registrar, Runtime,
+    RuntimeCall, RuntimeEvent, Session, System,
 };
 
 pub fn run_to_session(n: u32, add_author: bool) {
@@ -229,6 +230,13 @@ pub fn get_aura_id_from_seed(seed: &str) -> NimbusId {
         .into()
 }
 
+pub fn get_orchestrator_current_author() -> Option<AccountId> {
+    let slot: u64 = Aura::current_slot().into();
+    let orchestrator_collators = Runtime::parachain_collators(ParachainInfo::get())?;
+    let author_index = slot % orchestrator_collators.len() as u64;
+    let account = orchestrator_collators.get(author_index as usize)?;
+    Some(account.clone())
+}
 /// Mocks the author noting inherent to insert the data we
 pub fn set_author_noting_inherent_data(builder: ParaHeaderSproofBuilder) {
     let (relay_storage_root, relay_storage_proof) = builder.into_state_root_and_proof();

--- a/runtime/test/tests/integration_test.rs
+++ b/runtime/test/tests/integration_test.rs
@@ -345,15 +345,17 @@ fn test_author_collation_aura_change_of_authorities_on_session() {
 
             // SESSION CHANGE. First session. it takes 2 sessions to see the change
             run_to_session(1u32, true);
-            // Session boundary even slot, ALICE.
-            assert!(Authorship::author().unwrap() == AccountId::from(ALICE));
+            let author = get_orchestrator_current_author().unwrap();
+
+            assert_eq!(Authorship::author().unwrap(), author);
             assert!(Aura::authorities() == vec![alice_id, bob_id]);
 
             // Invulnerables should have triggered on new session authorities change
             run_to_session(2u32, true);
-            assert!(Authorship::author().unwrap() == AccountId::from(CHARLIE));
-            // Session boundary even slot, CHARLIE.
-            assert!(Aura::authorities() == vec![charlie_id, dave_id]);
+            let author_after_changes = get_orchestrator_current_author().unwrap();
+
+            assert_eq!(Authorship::author().unwrap(), author_after_changes);
+            assert_eq!(Aura::authorities(), vec![charlie_id, dave_id]);
         });
 }
 
@@ -420,14 +422,15 @@ fn test_author_collation_aura_add_assigned_to_paras() {
 
             // SESSION CHANGE. First session. it takes 2 sessions to see the change
             run_to_session(1u32, true);
-            // Session boundary even slot, ALICE.
-            assert!(Authorship::author().unwrap() == AccountId::from(ALICE));
-            assert!(Aura::authorities() == vec![alice_id.clone(), bob_id.clone()]);
+            let author = get_orchestrator_current_author().unwrap();
+
+            assert_eq!(Authorship::author().unwrap(), author);
+            assert_eq!(Aura::authorities(), vec![alice_id.clone(), bob_id.clone()]);
 
             // Invulnerables should have triggered on new session authorities change
             // However charlie and dave shoudl have gone to one para (1001)
             run_to_session(2u32, true);
-            assert!(Aura::authorities() == vec![alice_id, bob_id]);
+            assert_eq!(Aura::authorities(), vec![alice_id, bob_id]);
             let assignment = CollatorAssignment::collator_container_chain();
             assert_eq!(
                 assignment.container_chains[&1001u32.into()],
@@ -948,9 +951,10 @@ fn test_author_collation_aura_add_assigned_to_paras_runtime_api() {
 
             // SESSION CHANGE. First session. it takes 2 sessions to see the change
             run_to_session(1u32, true);
-            // Session boundary even slot, ALICE.
-            assert!(Authorship::author().unwrap() == AccountId::from(ALICE));
-            assert!(Aura::authorities() == vec![alice_id.clone(), bob_id.clone()]);
+            let author = get_orchestrator_current_author().unwrap();
+
+            assert_eq!(Authorship::author().unwrap(), author);
+            assert_eq!(Aura::authorities(), vec![alice_id.clone(), bob_id.clone()]);
             assert_eq!(
                 Runtime::parachain_collators(100.into()),
                 Some(vec![ALICE.into(), BOB.into()])
@@ -968,7 +972,7 @@ fn test_author_collation_aura_add_assigned_to_paras_runtime_api() {
             // Invulnerables should have triggered on new session authorities change
             // However charlie and dave shoudl have gone to one para (1001)
             run_to_session(2u32, true);
-            assert!(Aura::authorities() == vec![alice_id, bob_id]);
+            assert_eq!(Aura::authorities(), vec![alice_id, bob_id]);
             let assignment = CollatorAssignment::collator_container_chain();
             assert_eq!(
                 assignment.container_chains[&1001u32.into()],


### PR DESCRIPTION
Fixes the fact that when you do `cargo test --features=fast-runtime` the tests fail. This is because certain author verification (which is slot dependent) happens at even slots numbers with slow sessions and at odd slot numbers with fast sessions. I re-adapted the tests to work regardless of which one we are using