### PR TITLE
[MD-107] Add typescript tests for pallet-configuration and pallet-cc-authorities-noting

### DIFF
--- a/test/suites/dev-frontier-template/test-pallet-cc-authorities-noting/test-orchestrator-para-id.ts
+++ b/test/suites/dev-frontier-template/test-pallet-cc-authorities-noting/test-orchestrator-para-id.ts
@@ -1,0 +1,57 @@
+import { expect, describeSuite } from "@moonwall/cli";
+
+describeSuite({
+  id: "D0504",
+  title: "AuthoritiesNoting - OrchestratorParaId",
+  foundationMethods: "dev",
+  testCases: ({ context, log, it }) => {
+    it({
+      id: "T01",
+      title: "should not set storage item if not sudo",
+      test: async function () {
+        const orchestratorParaId = await context
+          .polkadotJs()
+          .query.authoritiesNoting.orchestratorParaId();
+        expect(orchestratorParaId.toString()).toBe("1000");
+
+        const { result } = await context.createBlock(
+          context.polkadotJs().tx.authoritiesNoting.setOrchestratorParaId(2000),
+          { allowFailures: true }
+        );
+
+        expect(result.successful).toBe(false);
+
+        const newOrchestratorParaId = await context
+          .polkadotJs()
+          .query.authoritiesNoting.orchestratorParaId();
+        expect(newOrchestratorParaId.toString()).toBe("1000");
+      },
+    });
+
+    it({
+      id: "T02",
+      title: "should set storage item via sudo",
+      test: async function () {
+        const orchestratorParaId = await context
+          .polkadotJs()
+          .query.authoritiesNoting.orchestratorParaId();
+        expect(orchestratorParaId.toString()).toBe("1000");
+
+        await context.createBlock(
+          context
+            .polkadotJs()
+            .tx.sudo.sudo(
+              context
+                .polkadotJs()
+                .tx.authoritiesNoting.setOrchestratorParaId(2000)
+            )
+        );
+
+        const newOrchestratorParaId = await context
+          .polkadotJs()
+          .query.authoritiesNoting.orchestratorParaId();
+        expect(newOrchestratorParaId.toString()).toBe("2000");
+      },
+    });
+  },
+});

--- a/test/suites/dev/test-pallet-configuration/test-active-config-collators-per-container.ts
+++ b/test/suites/dev/test-pallet-configuration/test-active-config-collators-per-container.ts
@@ -1,0 +1,44 @@
+import { expect, beforeAll, describeSuite } from "@moonwall/cli";
+import { Keyring } from "@polkadot/api";
+import { jumpSessions } from "../../../util/block.js";
+
+describeSuite({
+  id: "D0517",
+  title: "Configuration - ActiveConfig - CollatorsPerContainer",
+  foundationMethods: "dev",
+  testCases: ({ context, log, it }) => {
+    let alice;
+    beforeAll(async function () {
+      const keyring = new Keyring({ type: "sr25519" });
+      alice = keyring.addFromUri("//Alice", { name: "Alice  default" });
+
+      const config = await context
+        .polkadotJs()
+        .query.configuration.activeConfig();
+      expect(config["collatorsPerContainer"].toString()).toBe("2");
+
+      const { result } = await context.createBlock(
+        context
+          .polkadotJs()
+          .tx.sudo.sudo(
+            context.polkadotJs().tx.configuration.setCollatorsPerContainer(5)
+          )
+          .signAsync(alice)
+      );
+      expect(result!.successful, result!.error?.name).to.be.true;
+
+      await jumpSessions(context, 2);
+    });
+
+    it({
+      id: "T01",
+      title: "should set collators per container after 2 sessions",
+      test: async function () {
+        const config = await context
+          .polkadotJs()
+          .query.configuration.activeConfig();
+        expect(config["collatorsPerContainer"].toString()).toBe("5");
+      },
+    });
+  },
+});

--- a/test/suites/dev/test-pallet-configuration/test-active-config-max-collators.ts
+++ b/test/suites/dev/test-pallet-configuration/test-active-config-max-collators.ts
@@ -1,0 +1,44 @@
+import { expect, beforeAll, describeSuite } from "@moonwall/cli";
+import { Keyring } from "@polkadot/api";
+import { jumpSessions } from "../../../util/block.ts";
+
+describeSuite({
+  id: "D0515",
+  title: "Configuration - ActiveConfig - MaxCollators",
+  foundationMethods: "dev",
+  testCases: ({ context, log, it }) => {
+    let alice;
+    beforeAll(async function () {
+      const keyring = new Keyring({ type: "sr25519" });
+      alice = keyring.addFromUri("//Alice", { name: "Alice  default" });
+
+      const config = await context
+        .polkadotJs()
+        .query.configuration.activeConfig();
+      expect(config["maxCollators"].toString()).toBe("100");
+
+      const { result } = await context.createBlock(
+        context
+          .polkadotJs()
+          .tx.sudo.sudo(
+            context.polkadotJs().tx.configuration.setMaxCollators(200)
+          )
+          .signAsync(alice)
+      );
+      expect(result!.successful, result!.error?.name).to.be.true;
+
+      await jumpSessions(context, 2);
+    });
+
+    it({
+      id: "T01",
+      title: "should set max collators after 2 sessions",
+      test: async function () {
+        const config = await context
+          .polkadotJs()
+          .query.configuration.activeConfig();
+        expect(config["maxCollators"].toString()).toBe("200");
+      },
+    });
+  },
+});

--- a/test/suites/dev/test-pallet-configuration/test-active-config-max-orchestrator-collators.ts
+++ b/test/suites/dev/test-pallet-configuration/test-active-config-max-orchestrator-collators.ts
@@ -1,0 +1,44 @@
+import { expect, beforeAll, describeSuite } from "@moonwall/cli";
+import { Keyring } from "@polkadot/api";
+import { jumpSessions } from "../../../util/block.js";
+
+describeSuite({
+  id: "D0517",
+  title: "Configuration - ActiveConfig - MaxOrchestratorCollators",
+  foundationMethods: "dev",
+  testCases: ({ context, log, it }) => {
+    let alice;
+    beforeAll(async function () {
+      const keyring = new Keyring({ type: "sr25519" });
+      alice = keyring.addFromUri("//Alice", { name: "Alice  default" });
+
+      const config = await context
+        .polkadotJs()
+        .query.configuration.activeConfig();
+      expect(config["maxOrchestratorCollators"].toString()).toBe("1");
+
+      const { result } = await context.createBlock(
+        context
+          .polkadotJs()
+          .tx.sudo.sudo(
+            context.polkadotJs().tx.configuration.setMaxOrchestratorCollators(2)
+          )
+          .signAsync(alice)
+      );
+      expect(result!.successful, result!.error?.name).to.be.true;
+
+      await jumpSessions(context, 2);
+    });
+
+    it({
+      id: "T01",
+      title: "should set max orchestrator collators after 2 sessions",
+      test: async function () {
+        const config = await context
+          .polkadotJs()
+          .query.configuration.activeConfig();
+        expect(config["maxOrchestratorCollators"].toString()).toBe("2");
+      },
+    });
+  },
+});

--- a/test/suites/dev/test-pallet-configuration/test-active-config-min-orchestrator-collators.ts
+++ b/test/suites/dev/test-pallet-configuration/test-active-config-min-orchestrator-collators.ts
@@ -1,0 +1,44 @@
+import { expect, beforeAll, describeSuite } from "@moonwall/cli";
+import { Keyring } from "@polkadot/api";
+import { jumpSessions } from "../../../util/block.js";
+
+describeSuite({
+  id: "D0516",
+  title: "Configuration - ActiveConfig - MinOrchestratorCollators",
+  foundationMethods: "dev",
+  testCases: ({ context, log, it }) => {
+    let alice;
+    beforeAll(async function () {
+      const keyring = new Keyring({ type: "sr25519" });
+      alice = keyring.addFromUri("//Alice", { name: "Alice  default" });
+
+      const config = await context
+        .polkadotJs()
+        .query.configuration.activeConfig();
+      expect(config["minOrchestratorCollators"].toString()).toBe("1");
+
+      const { result } = await context.createBlock(
+        context
+          .polkadotJs()
+          .tx.sudo.sudo(
+            context.polkadotJs().tx.configuration.setMinOrchestratorCollators(2)
+          )
+          .signAsync(alice)
+      );
+      expect(result!.successful, result!.error?.name).to.be.true;
+
+      await jumpSessions(context, 2);
+    });
+
+    it({
+      id: "T01",
+      title: "should set max orchestrator collators after 2 sessions",
+      test: async function () {
+        const config = await context
+          .polkadotJs()
+          .query.configuration.activeConfig();
+        expect(config["minOrchestratorCollators"].toString()).toBe("2");
+      },
+    });
+  },
+});

--- a/test/suites/dev/test-pallet-configuration/test-active-config-origin.ts
+++ b/test/suites/dev/test-pallet-configuration/test-active-config-origin.ts
@@ -1,0 +1,79 @@
+import { expect, describeSuite, beforeAll } from "@moonwall/cli";
+import { Keyring } from "@polkadot/api";
+
+describeSuite({
+  id: "D0520",
+  title: "Configuration - ActiveConfig - Origin",
+  foundationMethods: "dev",
+  testCases: ({ context, log, it }) => {
+    let bob;
+    beforeAll(() => {
+      const keyring = new Keyring({ type: "sr25519" });
+      bob = keyring.addFromUri("//Bob", { name: "Bob  default" });
+    });
+
+    it({
+      id: "T01",
+      title: "should fail on setMaxCollators if not sudo",
+      test: async function () {
+        const { result } = await context.createBlock(
+          context
+            .polkadotJs()
+            .tx.configuration.setMaxCollators(200)
+            .signAsync(bob),
+          { allowFailures: true }
+        );
+
+        expect(result.successful).toBe(false);
+      },
+    });
+
+    it({
+      id: "T02",
+      title: "should fail on setMinOrchestratorCollators if not sudo",
+      test: async function () {
+        const { result } = await context.createBlock(
+          context
+            .polkadotJs()
+            .tx.configuration.setMinOrchestratorCollators(2)
+            .signAsync(bob),
+          { allowFailures: true }
+        );
+
+        expect(result.successful).toBe(false);
+      },
+    });
+
+    it({
+      id: "T03",
+      title: "should fail on setMaxOrchestratorCollators if not sudo",
+      test: async function () {
+        const { result } = await context.createBlock(
+          context
+            .polkadotJs()
+            .tx.configuration.setMaxOrchestratorCollators(2)
+            .signAsync(bob),
+          { allowFailures: true }
+        );
+
+        expect(result.successful).toBe(false);
+      },
+    });
+
+    it({
+      id: "T04",
+      title: "should fail on setCollatorsPerContainer if not sudo",
+      test: async function () {
+        const { result } = await context.createBlock(
+          context
+            .polkadotJs()
+            .tx.configuration.setCollatorsPerContainer(5)
+            .signAsync(bob),
+          { allowFailures: true }
+        );
+
+        expect(result.successful).toBe(false);
+      },
+    });
+  },
+});


### PR DESCRIPTION
add typescript tests for pallet-configuration and pallet-cc-authorities-noting