### PR TITLE
harmonize canAuthor between both templates

### DIFF
--- a/container-chains/templates/simple/runtime/src/lib.rs
+++ b/container-chains/templates/simple/runtime/src/lib.rs
@@ -392,6 +392,11 @@ pub struct CanAuthor;
 impl nimbus_primitives::CanAuthor<NimbusId> for CanAuthor {
     fn can_author(author: &NimbusId, slot: &u32) -> bool {
         let authorities = AuthoritiesNoting::authorities();
+
+        if authorities.is_empty() {
+            return false;
+        }
+
         let expected_author = &authorities[(*slot as usize) % authorities.len()];
 
         expected_author == author


### PR DESCRIPTION
harmonize the implementation across both runtimes. We should at some point move this into a primtives crate