### PR TITLE
Improve test by executing 2 transactions at the same time

### DIFF
--- a/test/suites/para/test_tanssi_containers.ts
+++ b/test/suites/para/test_tanssi_containers.ts
@@ -248,9 +248,9 @@ describeSuite({
             "/ip4/127.0.0.1/tcp/33051/ws/p2p/12D3KooWSDsmAa7iFbHdQW4X8B2KbeRYPDLarK6EbevUSYfGkeQw"
         ];
         const tx2 = paraApi.tx.registrar.setBootNodes(2002, bootNodes);
-        await signAndSendAndInclude(paraApi.tx.sudo.sudo(tx2), alice);
         const tx3 = paraApi.tx.registrar.markValidForCollating(2002);
-        await signAndSendAndInclude(paraApi.tx.sudo.sudo(tx3), alice);
+        const tx2tx3 = paraApi.tx.utility.batchAll([tx2, tx3]);
+        await signAndSendAndInclude(paraApi.tx.sudo.sudo(tx2tx3), alice);
         const session1 = (await paraApi.query.session.currentIndex()).toNumber();
         await waitSessions(context, paraApi, 2);
         const session2 = (await paraApi.query.session.currentIndex()).toNumber();


### PR DESCRIPTION
This should make the test wait for 1 block less, reducing the time it takes to run all the tests.