### PR TITLE
Add pallet that allows manual trigger of session end

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2263,6 +2263,7 @@ dependencies = [
  "pallet-root-testing",
  "pallet-session",
  "pallet-sudo",
+ "pallet-test-session",
  "pallet-timestamp",
  "pallet-utility",
  "parachain-info",
@@ -7609,6 +7610,21 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-test-session"
+version = "0.1.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "pallet-session",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
  "sp-io",
  "sp-runtime",
  "sp-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ pallet-configuration = { path = "pallets/configuration", default-features = fals
 pallet-initializer = { path = "pallets/initializer", default-features = false }
 pallet-registrar = { path = "pallets/registrar", default-features = false }
 pallet-registrar-runtime-api = { path = "pallets/registrar/rpc/runtime-api", default-features = false }
+pallet-test-session = { path = "pallets/test-session", default-features = false }
 
 ccp-authorities-noting-inherent = { path = "container-chains/primitives/authorities-noting-inherent", default-features = false }
 

--- a/pallets/test-session/Cargo.toml
+++ b/pallets/test-session/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "pallet-test-session"
+authors = { workspace = true }
+description = "Test pallet that allows root to force an instant session change"
+edition = "2021"
+license = "GPL-3.0-only"
+version = "0.1.0"
+
+[package.metadata.docs.rs]
+targets = [ "x86_64-unknown-linux-gnu" ]
+[dependencies]
+frame-support = { workspace = true, default-features = false }
+frame-system = { workspace = true, default-features = false }
+pallet-session = { workspace = true, default-features = false }
+parity-scale-codec = { workspace = true, default-features = false }
+scale-info = { workspace = true, default-features = false }
+sp-runtime = { workspace = true, default-features = false }
+sp-std = { workspace = true, default-features = false }
+
+[dev-dependencies]
+sp-core = { workspace = true, default-features = false }
+sp-io = { workspace = true, default-features = false }
+
+[features]
+default = [ "std" ]
+std = [
+	"frame-support/std",
+	"frame-system/std",
+	"pallet-session/std",
+	"parity-scale-codec/std",
+	"scale-info/std",
+	"sp-runtime/std",
+	"sp-std/std",
+]
+try-runtime = [ "frame-support/try-runtime" ]

--- a/pallets/test-session/src/lib.rs
+++ b/pallets/test-session/src/lib.rs
@@ -1,0 +1,185 @@
+// Copyright (C) Moondance Labs Ltd.
+// This file is part of Tanssi.
+
+// Tanssi is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Tanssi is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Tanssi.  If not, see <http://www.gnu.org/licenses/>
+
+//! # Initializer Pallet
+//!
+//! This pallet is in charge of organizing what happens on session changes.
+//! In particular this pallet has implemented the OneSessionHandler trait
+//! which will be called upon a session change. This pallet will then store
+//! the bufferedSessionChanges (collators, new session index, etc) in the
+//! BufferedSessionChanges storage item. This storage item gets read on_finalize
+//! and calls the  SessionHandler config trait
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(test)]
+mod mock;
+
+#[cfg(test)]
+mod tests;
+
+pub use pallet::*;
+use {
+    frame_support::{pallet_prelude::*, traits::OneSessionHandler},
+    frame_system::pallet_prelude::*,
+    parity_scale_codec::{Decode, Encode},
+    scale_info::TypeInfo,
+    sp_runtime::{
+        traits::{AtLeast32BitUnsigned, One, Saturating, Zero},
+        RuntimeAppPublic,
+    },
+    sp_std::prelude::*,
+};
+
+#[frame_support::pallet]
+pub mod pallet {
+    use super::*;
+
+    #[pallet::pallet]
+    //#[pallet::without_storage_info]
+    pub struct Pallet<T>(_);
+
+    #[pallet::config]
+    pub trait Config: frame_system::Config {
+        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+    }
+
+    #[pallet::event]
+    #[pallet::generate_deposit(pub(super) fn deposit_event)]
+    pub enum Event<T: Config> {
+        SessionEndChanged {
+            first_block_of_next_session: T::BlockNumber,
+        },
+    }
+
+    #[pallet::storage]
+    pub type CurrentSessionEnd<T: Config> = StorageValue<_, T::BlockNumber, OptionQuery>;
+
+    #[pallet::storage]
+    pub type CurrentSessionStart<T: Config> = StorageValue<_, T::BlockNumber, ValueQuery>;
+
+    #[pallet::call]
+    impl<T: Config> Pallet<T> {
+        #[pallet::call_index(0)]
+        #[pallet::weight(0)]
+        pub fn set_current_session_end(
+            origin: OriginFor<T>,
+            first_block_of_next_session: T::BlockNumber,
+        ) -> DispatchResult {
+            ensure_root(origin)?;
+            CurrentSessionEnd::<T>::put(first_block_of_next_session);
+            Self::deposit_event(Event::SessionEndChanged {
+                first_block_of_next_session,
+            });
+            Ok(())
+        }
+    }
+
+    impl<T: Config> Pallet<T> {
+        pub fn initializer_on_new_session(block_number: T::BlockNumber) {
+            CurrentSessionEnd::<T>::kill();
+            CurrentSessionStart::<T>::put(block_number);
+        }
+    }
+}
+
+pub struct OverridablePeriodicSessions<T, Period>(PhantomData<(T, Period)>);
+
+mod session_impls {
+    use core::ops::{Rem, Sub};
+    use frame_support::{traits::EstimateNextSessionRotation, traits::Get, weights::Weight};
+    use pallet_session::ShouldEndSession;
+    use sp_runtime::{
+        traits::{AtLeast32BitUnsigned, One, Zero},
+        Permill, Saturating,
+    };
+
+    use crate::{Config, CurrentSessionEnd, CurrentSessionStart, OverridablePeriodicSessions};
+
+    impl<T: Config, Period: Get<T::BlockNumber>> ShouldEndSession<T::BlockNumber>
+        for OverridablePeriodicSessions<T, Period>
+    {
+        fn should_end_session(now: T::BlockNumber) -> bool {
+            let offset = CurrentSessionStart::<T>::get();
+
+            match CurrentSessionEnd::<T>::get() {
+                Some(end) => now >= end,
+                None => now >= offset && ((now - offset) % Period::get()).is_zero(),
+            }
+        }
+    }
+
+    impl<T: Config, Period: Get<T::BlockNumber>> EstimateNextSessionRotation<T::BlockNumber>
+        for OverridablePeriodicSessions<T, Period>
+    {
+        fn average_session_length() -> T::BlockNumber {
+            Period::get()
+        }
+
+        fn estimate_current_session_progress(now: T::BlockNumber) -> (Option<Permill>, Weight) {
+            let offset = CurrentSessionStart::<T>::get();
+            let period = CurrentSessionEnd::<T>::get()
+                .map(|end| end.saturating_sub(offset))
+                .map(|period| if period.is_zero() { One::one() } else { period })
+                .unwrap_or(Period::get());
+
+            // NOTE: we add one since we assume that the current block has already elapsed,
+            // i.e. when evaluating the last block in the session the progress should be 100%
+            // (0% is never returned).
+            let progress = if now >= offset {
+                let current = (now - offset) % period.clone() + One::one();
+                Some(Permill::from_rational(current, period))
+            } else {
+                Some(Permill::from_rational(now + One::one(), offset))
+            };
+
+            // Weight note: `estimate_current_session_progress` has no storage reads and trivial
+            // computational overhead. There should be no risk to the chain having this weight value be
+            // zero for now. However, this value of zero was not properly calculated, and so it would be
+            // reasonable to come back here and properly calculate the weight of this function.
+            (progress, Zero::zero())
+        }
+
+        fn estimate_next_session_rotation(now: T::BlockNumber) -> (Option<T::BlockNumber>, Weight) {
+            let offset = CurrentSessionStart::<T>::get();
+            let period = CurrentSessionEnd::<T>::get()
+                .map(|end| end.saturating_sub(offset))
+                .map(|period| if period.is_zero() { One::one() } else { period })
+                .unwrap_or(Period::get());
+
+            let next_session = if now > offset {
+                let block_after_last_session = (now.clone() - offset) % period.clone();
+                if block_after_last_session > Zero::zero() {
+                    now.saturating_add(period.saturating_sub(block_after_last_session))
+                } else {
+                    // this branch happens when the session is already rotated or will rotate in this
+                    // block (depending on being called before or after `session::on_initialize`). Here,
+                    // we assume the latter, namely that this is called after `session::on_initialize`,
+                    // and thus we add period to it as well.
+                    now + period
+                }
+            } else {
+                offset
+            };
+
+            // Weight note: `estimate_next_session_rotation` has no storage reads and trivial
+            // computational overhead. There should be no risk to the chain having this weight value be
+            // zero for now. However, this value of zero was not properly calculated, and so it would be
+            // reasonable to come back here and properly calculate the weight of this function.
+            (Some(next_session), Zero::zero())
+        }
+    }
+}

--- a/pallets/test-session/src/mock.rs
+++ b/pallets/test-session/src/mock.rs
@@ -1,0 +1,88 @@
+// Copyright (C) Moondance Labs Ltd.
+// This file is part of Tanssi.
+
+// Tanssi is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Tanssi is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Tanssi.  If not, see <http://www.gnu.org/licenses/>
+
+use {
+    crate as pallet_initializer,
+    frame_support::traits::{ConstU16, ConstU64},
+    frame_system as system,
+    sp_core::H256,
+    sp_runtime::{
+        testing::{Header, UintAuthorityId},
+        traits::{BlakeTwo256, IdentityLookup},
+    },
+    sp_std::cell::RefCell,
+};
+
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
+
+// Configure a mock runtime to test the pallet.
+frame_support::construct_runtime!(
+    pub enum Test where
+        Block = Block,
+        NodeBlock = Block,
+        UncheckedExtrinsic = UncheckedExtrinsic,
+    {
+        System: frame_system,
+        Initializer: pallet_initializer,
+    }
+);
+
+impl system::Config for Test {
+    type BaseCallFilter = frame_support::traits::Everything;
+    type BlockWeights = ();
+    type BlockLength = ();
+    type DbWeight = ();
+    type RuntimeOrigin = RuntimeOrigin;
+    type RuntimeCall = RuntimeCall;
+    type Index = u64;
+    type BlockNumber = u64;
+    type Hash = H256;
+    type Hashing = BlakeTwo256;
+    type AccountId = u64;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type Header = Header;
+    type RuntimeEvent = RuntimeEvent;
+    type BlockHashCount = ConstU64<250>;
+    type Version = ();
+    type PalletInfo = PalletInfo;
+    type AccountData = ();
+    type OnNewAccount = ();
+    type OnKilledAccount = ();
+    type SystemWeightInfo = ();
+    type SS58Prefix = ConstU16<42>;
+    type OnSetCode = ();
+    type MaxConsumers = frame_support::traits::ConstU32<16>;
+}
+
+thread_local! {
+    pub static SESSION_CHANGE_VALIDATORS: RefCell<Option<(u32, Vec<u64>)>> = RefCell::new(None);
+}
+
+pub fn session_change_validators() -> Option<(u32, Vec<u64>)> {
+    SESSION_CHANGE_VALIDATORS.with(|q| (*q.borrow()).clone())
+}
+
+// Build genesis storage according to the mock runtime.
+pub fn new_test_ext() -> sp_io::TestExternalities {
+    // Start with None in the global var
+    SESSION_CHANGE_VALIDATORS.with(|r| *r.borrow_mut() = None);
+
+    system::GenesisConfig::default()
+        .build_storage::<Test>()
+        .unwrap()
+        .into()
+}

--- a/pallets/test-session/src/tests.rs
+++ b/pallets/test-session/src/tests.rs
@@ -1,0 +1,20 @@
+// Copyright (C) Moondance Labs Ltd.
+// This file is part of Tanssi.
+
+// Tanssi is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Tanssi is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Tanssi.  If not, see <http://www.gnu.org/licenses/>
+
+use {
+    super::*,
+    crate::mock::{new_test_ext, Test},
+};

--- a/runtime/dancebox/Cargo.toml
+++ b/runtime/dancebox/Cargo.toml
@@ -28,6 +28,7 @@ pallet-initializer = { workspace = true }
 pallet-registrar = { workspace = true }
 pallet-registrar-runtime-api = { workspace = true }
 pallet-proxy = { workspace = true }
+pallet-test-session = { workspace = true }
 tp-core = { workspace = true }
 
 # Nimbus
@@ -115,6 +116,7 @@ std = [
 	"pallet-sudo/std",
 	"pallet-timestamp/std",
 	"pallet-utility/std",
+	"pallet-test-session/std",
 	"parachain-info/std",
 	"parity-scale-codec/std",
 	"polkadot-parachain/std",


### PR DESCRIPTION
The `OverridablePeriodicSessions` struct is very similar to the `pallet_session::PeriodicSessions` we used previously, but it reads the period and offset from storage instead of having them hardcoded. This allows root to change the session end to an arbitrary block.