### PR TITLE
reduce session length in prod

### DIFF
--- a/runtime/dancebox/src/lib.rs
+++ b/runtime/dancebox/src/lib.rs
@@ -436,7 +436,7 @@ impl pallet_initializer::Config for Runtime {
 impl parachain_info::Config for Runtime {}
 
 parameter_types! {
-    pub const Period: u32 = prod_or_fast!(6 * HOURS, 1 * MINUTES);
+    pub const Period: u32 = prod_or_fast!(1 * HOURS, 1 * MINUTES);
     pub const Offset: u32 = 0;
 }
 


### PR DESCRIPTION
Reduce session lengths in dancebox to 1 hour to make sure changes are reflected in less time