### PR TITLE
Run CI jobs in appropriate context

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,7 +309,7 @@ jobs:
     strategy:
       matrix:
         image: ["tanssi", "container-chain-simple-template", "container-chain-evm-template"]
-    if: ${{ (needs.set-tags.outputs.image_exists == 'false') && (github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ (needs.set-tags.outputs.image_exists == 'false') && (github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,7 +181,7 @@ jobs:
 
   typescript-tests-frontier:
     runs-on: ubuntu-latest
-    needs: ["set-tags", build"]
+    needs: ["set-tags", "build"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          ref:  ${{ steps.check-git-ref.outputs.git_ref }}
+          ref: ${{ steps.check-git-ref.outputs.git_ref }}
       - name: Get Sha
         id: get-sha
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,11 @@ on:
     branches:
       - master
       - perm-*
-
+  workflow_dispatch:
+    inputs:
+      commit:
+        description: commit for which we need to run the action
+        required: false
 jobs:
   set-tags:
     runs-on: ubuntu-latest
@@ -24,9 +28,8 @@ jobs:
           if [[ -n "${{ github.event.pull_request.head.sha }}" ]]; then
             echo "git_branch=$(echo ${GITHUB_HEAD_REF})" >> $GITHUB_OUTPUT
             echo "git_ref=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
-          elif [[ -n "${{ github.event.inputs.pull_request }}" ]]; then
-            echo "git_branch=$(echo ${GITHUB_HEAD_REF})" >> $GITHUB_OUTPUT
-            echo "git_ref=refs/pull/${{ github.event.inputs.pull_request }}/head" >> $GITHUB_OUTPUT
+          elif [[ -n "${{ github.event.inputs.commit }}" ]]; then
+            echo "git_ref=${{ github.event.inputs.commit }}" >> $GITHUB_OUTPUT
           else
             echo "git_branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
             echo "git_ref=$GITHUB_REF" >> $GITHUB_OUTPUT
@@ -34,7 +37,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.inputs.sha }}
+          ref:  ${{ steps.check-git-ref.outputs.git_ref }}
       - name: Get Sha
         id: get-sha
         run: |
@@ -49,6 +52,7 @@ jobs:
 
       - name: Display variables
         run: |
+          echo git_ref: ${{ steps.check-git-ref.outputs.git_ref }}
           echo sha: ${{ steps.get-sha.outputs.sha }}
           echo sha8: ${{ steps.get-sha.outputs.sha8 }}
           echo image_exists: ${{ steps.check-docker-image.outputs.image_exists }}
@@ -74,9 +78,12 @@ jobs:
   ####### Building and Testing binaries #######
   cargo-clippy:
     runs-on: self-hosted
+    needs: ["set-tags"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.set-tags.outputs.git_ref }}
 
       - name: Setup Rust toolchain
         run: rustup show
@@ -86,6 +93,7 @@ jobs:
 
   build:
     runs-on: self-hosted
+    needs: ["set-tags"]
     env:
       RUSTFLAGS: "-C opt-level=3 -D warnings"
       TMP_TARGET: "/tmp/target"
@@ -93,6 +101,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.set-tags.outputs.git_ref }}
 
       - name: Setup Rust toolchain
         run: rustup show
@@ -137,12 +147,12 @@ jobs:
 
   typescript-tests:
     runs-on: ubuntu-latest
-    needs: ["build"]
+    needs: ["set-tags", "build"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.inputs.sha }}
+          ref: ${{ needs.set-tags.outputs.git_ref }}
         
       - name: Pnpm
         uses: pnpm/action-setup@v2
@@ -171,12 +181,12 @@ jobs:
 
   typescript-tests-frontier:
     runs-on: ubuntu-latest
-    needs: ["build"]
+    needs: ["set-tags", build"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.inputs.sha }}
+          ref: ${{ needs.set-tags.outputs.git_ref }}
         
       - name: Pnpm
         uses: pnpm/action-setup@v2
@@ -205,12 +215,12 @@ jobs:
 
   typescript-dancebox-specs:
     runs-on: ubuntu-latest
-    needs: ["build"]
+    needs: ["set-tags", "build"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.inputs.sha }}
+          ref: ${{ needs.set-tags.outputs.git_ref }}
         
       - name: Pnpm
         uses: pnpm/action-setup@v2
@@ -244,7 +254,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.inputs.sha }}
+          ref: ${{ needs.set-tags.outputs.git_ref }}
 
       - name: Pnpm
         uses: pnpm/action-setup@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,9 @@ jobs:
           if [[ -n "${{ github.event.pull_request.head.sha }}" ]]; then
             echo "git_branch=$(echo ${GITHUB_HEAD_REF})" >> $GITHUB_OUTPUT
             echo "git_ref=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
-          elif [[ -n "${{ github.event.inputs.commit }}" ]]; then
-            echo "git_ref=${{ github.event.inputs.commit }}" >> $GITHUB_OUTPUT
+          elif [[ -n "${{ github.event.inputs.pull_request }}" ]]; then
+            echo "git_branch=$(echo ${GITHUB_HEAD_REF})" >> $GITHUB_OUTPUT
+            echo "git_ref=refs/pull/${{ github.event.inputs.pull_request }}/head" >> $GITHUB_OUTPUT
           else
             echo "git_branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
             echo "git_ref=$GITHUB_REF" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,7 @@ on:
     branches:
       - master
       - perm-*
-  workflow_dispatch:
-    inputs:
-      commit:
-        description: commit for which we need to run the action
-        required: false
+
 jobs:
   set-tags:
     runs-on: ubuntu-latest
@@ -309,7 +305,7 @@ jobs:
     strategy:
       matrix:
         image: ["tanssi", "container-chain-simple-template", "container-chain-evm-template"]
-    if: ${{ (needs.set-tags.outputs.image_exists == 'false') && (github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch') }}
+    if: ${{ (needs.set-tags.outputs.image_exists == 'false') && (github.event.pull_request.head.repo.full_name == github.repository) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Modularizes CI to use most of the steps on git_ref plus allowing to choose a commit on a workflow dispatch against which one can run