### PR TITLE
Use moonkit repo instead of nimbus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6074,7 +6074,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.9.0"
-source = "git+https://github.com/moondance-labs/nimbus?branch=tanssi-polkadot-v0.9.43#064843615dff3dd4592d219cce27b5364dba1ab8"
+source = "git+https://github.com/moondance-labs/moonkit?branch=tanssi-polkadot-v0.9.43#49c08c1850f957563f03f72681aecf3e16184ce8"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -6104,7 +6104,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.9.0"
-source = "git+https://github.com/moondance-labs/nimbus?branch=tanssi-polkadot-v0.9.43#064843615dff3dd4592d219cce27b5364dba1ab8"
+source = "git+https://github.com/moondance-labs/moonkit?branch=tanssi-polkadot-v0.9.43#49c08c1850f957563f03f72681aecf3e16184ce8"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -6443,7 +6443,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.9.0"
-source = "git+https://github.com/moondance-labs/nimbus?branch=tanssi-polkadot-v0.9.43#064843615dff3dd4592d219cce27b5364dba1ab8"
+source = "git+https://github.com/moondance-labs/moonkit?branch=tanssi-polkadot-v0.9.43#49c08c1850f957563f03f72681aecf3e16184ce8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6074,7 +6074,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.9.0"
-source = "git+https://github.com/moondance-labs/moonkit?branch=tanssi-polkadot-v0.9.43#49c08c1850f957563f03f72681aecf3e16184ce8"
+source = "git+https://github.com/moondance-labs/moonkit?branch=tanssi-polkadot-v0.9.43#2c0edfb948b609f5c6c50c18d858f76ac9acc784"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -6104,7 +6104,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.9.0"
-source = "git+https://github.com/moondance-labs/moonkit?branch=tanssi-polkadot-v0.9.43#49c08c1850f957563f03f72681aecf3e16184ce8"
+source = "git+https://github.com/moondance-labs/moonkit?branch=tanssi-polkadot-v0.9.43#2c0edfb948b609f5c6c50c18d858f76ac9acc784"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -6443,7 +6443,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.9.0"
-source = "git+https://github.com/moondance-labs/moonkit?branch=tanssi-polkadot-v0.9.43#49c08c1850f957563f03f72681aecf3e16184ce8"
+source = "git+https://github.com/moondance-labs/moonkit?branch=tanssi-polkadot-v0.9.43#2c0edfb948b609f5c6c50c18d858f76ac9acc784"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,9 +50,9 @@ tp-core = { path = "primitives/core", default-features = false }
 tp-traits = { path = "primitives/traits", default-features = false }
 
 # Nimbus (wasm)
-nimbus-consensus = { git = "https://github.com/moondance-labs/nimbus", branch = "tanssi-polkadot-v0.9.43" }
-nimbus-primitives = { git = "https://github.com/moondance-labs/nimbus", branch = "tanssi-polkadot-v0.9.43", default-features = false }
-pallet-author-inherent = { git = "https://github.com/moondance-labs/nimbus", branch = "tanssi-polkadot-v0.9.43", default-features = false }
+nimbus-consensus = { git = "https://github.com/moondance-labs/moonkit", branch = "tanssi-polkadot-v0.9.43" }
+nimbus-primitives = { git = "https://github.com/moondance-labs/moonkit", branch = "tanssi-polkadot-v0.9.43", default-features = false }
+pallet-author-inherent = { git = "https://github.com/moondance-labs/moonkit", branch = "tanssi-polkadot-v0.9.43", default-features = false }
 
 # Substrate (wasm)
 frame-benchmarking = { git = "https://github.com/moondance-labs/substrate", branch = "tanssi-polkadot-v0.9.43", default-features = false }


### PR DESCRIPTION
Using this moonkit branch, which is identical to moonbeam-polkadot-v0.9.43 except the git urls: https://github.com/Moonsong-Labs/moonkit/compare/moonbeam-polkadot-v0.9.43...moondance-labs:moonkit:tanssi-polkadot-v0.9.43