### PR TITLE
Allow modularizing releases tanssi-templates

### DIFF
--- a/.github/workflows/publish-docker-runtime-containers.yml
+++ b/.github/workflows/publish-docker-runtime-containers.yml
@@ -1,4 +1,4 @@
-name: Publish Docker runtime
+name: Publish Docker runtime containers
 
 on:
   workflow_dispatch:

--- a/.github/workflows/publish-docker-runtime-containers.yml
+++ b/.github/workflows/publish-docker-runtime-containers.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: runtime tag (ex. runtime-2200) to publish on docker
+        description: runtime tag (ex. runtime-2200-templates) to publish on docker
         required: true
 
 jobs:

--- a/.github/workflows/publish-docker-runtime-tanssi.yml
+++ b/.github/workflows/publish-docker-runtime-tanssi.yml
@@ -1,4 +1,4 @@
-name: Publish Docker runtime
+name: Publish Docker runtime tanssi
 
 on:
   workflow_dispatch:

--- a/.github/workflows/publish-docker-runtime-tanssi.yml
+++ b/.github/workflows/publish-docker-runtime-tanssi.yml
@@ -1,0 +1,32 @@
+name: Publish Docker runtime
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: runtime tag (ex. runtime-2200) to publish on docker
+        required: true
+
+jobs:
+  tag-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Login to DockerHub
+        uses: docker/login-action@v2.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Publish runtime docker image
+        run: |
+            DOCKER_IMAGE=moondancelabs/tanssi
+            DOCKER_TAG="${{ github.event.inputs.tag }}"
+            COMMIT=`git rev-list -n 1 '${{ github.event.inputs.tag }}'`
+            SHA=sha-${COMMIT::8}
+            echo tagging "${DOCKER_IMAGE}:${SHA}"
+            docker pull "${DOCKER_IMAGE}:${SHA}"
+            docker tag "${DOCKER_IMAGE}:${SHA}" "${DOCKER_IMAGE}:${DOCKER_TAG}"
+            docker push "${DOCKER_IMAGE}:${DOCKER_TAG}"

--- a/.github/workflows/publish-docker-runtime.yml
+++ b/.github/workflows/publish-docker-runtime.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   tag-docker:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: ["tanssi", "container-chain-simple-template", "container-chain-evm-template"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -22,7 +25,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Publish runtime docker image
         run: |
-            DOCKER_IMAGE=moondancelabs/tanssi
+            DOCKER_IMAGE=moondancelabs/${{matrix.image}}
             DOCKER_TAG="${{ github.event.inputs.tag }}"
             COMMIT=`git rev-list -n 1 '${{ github.event.inputs.tag }}'`
             SHA=sha-${COMMIT::8}

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -50,18 +50,9 @@ jobs:
       - name: create matrix
         id: prepare
         run: |
-          dancebox='{
-            "runtime_name": "dancebox",
-            "runtime_path" : "./runtime/dancebox/src/lib.rs"
-          }'
-          frontier-template='{
-            "runtime_name": "frontier-template",
-            "runtime_path" : "./container-chains/templates/frontier/runtime/src/lib.rs"
-          }'
-          simple-template='{
-            "runtime_name": "simple-template",
-            "runtime_path" : "./container-chains/templates/simple/runtime/src/lib.rs"
-          }'
+          dancebox='{"runtime_name": "dancebox","runtime_path" : "./runtime/dancebox/src/lib.rs"}'
+          frontier-template='{"runtime_name": "frontier-template","runtime_path" : "./container-chains/templates/frontier/runtime/src/lib.rs"}'
+          simple-template='{"runtime_name": "simple-template","runtime_path" : "./container-chains/templates/simple/runtime/src/lib.rs"}'
 
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
             echo "matrix_tests=[$dancebox]" >> $GITHUB_OUTPUT

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -50,7 +50,10 @@ jobs:
       - name: create matrix
         id: prepare
         run: |
-          dancebox='{"runtime_name": "dancebox","runtime_path" : "./runtime/dancebox/src/lib.rs"}'
+          dancebox='{\
+            "runtime_name": "dancebox",
+            "runtime_path" : "./runtime/dancebox/src/lib.rs"
+          }'
           frontier_template='{"runtime_name": "frontier-template","runtime_path" : "./container-chains/templates/frontier/runtime/src/lib.rs"}'
           simple_template='{"runtime_name": "simple-template","runtime_path" : "./container-chains/templates/simple/runtime/src/lib.rs"}'
 
@@ -112,7 +115,7 @@ jobs:
       - name: Summary
         run: |
           echo '${{ steps.srtool_build.outputs.json }}' | jq . > ${{ matrix.chain.runtime_name }}-srtool-digest.json
-          cat ${{ matrix.chain }}-srtool-digest.json
+          cat ${{ matrix.chain.runtime_name }}-srtool-digest.json
           cp ${{ steps.srtool_build.outputs.wasm_compressed }} ${{ matrix.chain.runtime_name }}-runtime.compact.compressed.wasm
       - name: Archive Artifacts for ${{ matrix.chain }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -51,7 +51,7 @@ jobs:
         id: prepare
         run: |
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
-            echo "matrix_tests=[\"['aaa', 'bbb', 'ccc']\"]" >> $GITHUB_OUTPUT
+            echo "matrix_tests=[\"['aaa', 'bbb', 'ccc']\",\"['ddd', 'eee', 'fff']\"]" >> $GITHUB_OUTPUT
           elif [[ ${{ github.event.inputs.chains }} = "templates-only" ]]; then
             echo "matrix_tests=['simple-template', 'frontier-template']" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - name: Read tests
         run: |
-          echo "${{ fromJson(needs.matrix_prep.outputs.matrix_tests) }}"
+          echo "${{ fromJson(needs.matrix_prep.outputs.matrix_tests)[0] }}"
   build-srtool-runtimes:
     needs: ["setup-scripts", "matrix_prep"]
     runs-on: self-hosted

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -51,7 +51,7 @@ jobs:
         id: prepare
         run: |
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
-            echo "matrix_tests=[\"['aaa', 'bbb', 'ccc']\",\"['ddd', 'eee', 'fff']\"]" >> $GITHUB_OUTPUT
+            echo "matrix_tests=['aaa', 'bbb', 'ccc']" >> $GITHUB_OUTPUT
           else
             echo "matrix_tests=[\"['aaa', 'bbb', 'ccc']\",\"['ddd', 'eee', 'fff']\"]" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -66,8 +66,7 @@ jobs:
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
             echo "matrix_tests=[$dancebox]" >> $GITHUB_OUTPUT
           elif [[ ${{ github.event.inputs.chains }} = "templates-only" ]]; then
-            echo "matrix_tests=[$          simple_template='{
-              , $frontier_template]" >> $GITHUB_OUTPUT
+            echo "matrix_tests=[$simple_template, $frontier_template]" >> $GITHUB_OUTPUT
           else
             echo "matrix_tests=[$dancebox, 'simple-template', 'frontier-template']" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -51,7 +51,7 @@ jobs:
         id: prepare
         run: |
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
-            echo "matrix_tests=[\"['runtime_name': 'dancebox']\"]" >> $GITHUB_OUTPUT
+            echo "matrix_tests=[\"['aaa', 'bbb', 'ccc']\"]" >> $GITHUB_OUTPUT
           elif [[ ${{ github.event.inputs.chains }} = "templates-only" ]]; then
             echo "matrix_tests=['simple-template', 'frontier-template']" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -151,7 +151,7 @@ jobs:
         id: generate-release-body
         working-directory: original-tools
         run: |
-          RUNTIMES=$(echo '${{needs.matrix_prep.outputs.matrix_tests}}' | jq -r '[.[] | .runtime_name]')
+          RUNTIMES=$(echo '${{needs.matrix_prep.outputs.matrix_tests}}' | jq -r '.[] | .runtime_name')
           echo $RUNTIMES
           yarn
           yarn -s run ts-node github/generate-runtimes-body.ts --owner "${{ github.repository_owner }}" --repo "$(basename ${{ github.repository }})" --from "${{ github.event.inputs.from }}" --to "${{ github.event.inputs.to }}" --srtool-report-folder '../build/' --runtimes $RUNTIMES > ../body.md      - name: Get runtime version

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -50,9 +50,9 @@ jobs:
       - name: create matrix
         id: prepare
         run: |
-          dancebox='dancebox'
+          dancebox=dancebox
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
-            echo "matrix_tests=[${dancebox}]" >> $GITHUB_OUTPUT
+            echo "matrix_tests=['$dancebox']" >> $GITHUB_OUTPUT
           elif [[ ${{ github.event.inputs.chains }} = "templates-only" ]]; then
             echo "matrix_tests=['simple-template', 'frontier-template']" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -51,7 +51,7 @@ jobs:
         id: prepare
         run: |
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
-            echo "matrix_tests=[\"{'runtime_name': 'dancebox'}\"]" >> $GITHUB_OUTPUT
+            echo "matrix_tests=[\"['runtime_name': 'dancebox']\"]" >> $GITHUB_OUTPUT
           elif [[ ${{ github.event.inputs.chains }} = "templates-only" ]]; then
             echo "matrix_tests=['simple-template', 'frontier-template']" >> $GITHUB_OUTPUT
           else
@@ -65,7 +65,7 @@ jobs:
     steps:
       - name: Read tests
         run: |
-          echo "${{ fromJson(needs.matrix_prep.outputs.matrix_tests[0].runtime_name) }}"
+          echo "${{ fromJson(needs.matrix_prep.outputs.matrix_tests[0]) }}"
   build-srtool-runtimes:
     needs: ["setup-scripts", "matrix_prep"]
     runs-on: self-hosted

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -57,15 +57,6 @@ jobs:
           else
             echo "matrix_tests=['dancebox', 'simple-template', 'frontier-template']" >> $GITHUB_OUTPUT
           fi
-  debug:
-    name: L2 debug
-    runs-on:
-      - ubuntu-latest
-    needs: matrix_prep
-    steps:
-      - name: Read tests
-        run: |
-          echo "${{ fromJson(needs.matrix_prep.outputs.matrix_tests) }}"
 
   build-srtool-runtimes:
     needs: ["setup-scripts", "matrix_prep"]
@@ -121,7 +112,7 @@ jobs:
 
           
   ####### Prepare the release draft #######
-  publish-draft-release:
+  prepare-draft-release:
     runs-on: ubuntu-latest
     needs: ["setup-scripts", "build-srtool-runtimes"]
     outputs:
@@ -155,13 +146,6 @@ jobs:
         run: |
           yarn
           yarn -s run ts-node github/generate-runtimes-body.ts --owner "${{ github.repository_owner }}" --repo "$(basename ${{ github.repository }})" --from "${{ github.event.inputs.from }}" --to "${{ github.event.inputs.to }}" --srtool-report-folder '../build/' > ../body.md      - name: Get runtime version
-      - name: Get runtime version
-        id: get-runtime-ver
-        run: |
-          runtime_dancebox_ver="$(cat ./runtime/dancebox/src/lib.rs | grep -o 'spec_version: [0-9]*' | tail -1 | grep -o '[0-9]*')"
-          echo "runtime_dancebox_ver=$runtime_dancebox_ver" >> $GITHUB_OUTPUT
-          mv build/dancebox-runtime.compact.compressed.wasm dancebox-runtime-${runtime_dancebox_ver}.wasm
-          mv build/dancebox-srtool-digest.json dancebox-runtime-${runtime_dancebox_ver}-srtool-digest.json
       - name: Create draft release
         id: create-release
         uses: actions/create-release@v1
@@ -172,12 +156,31 @@ jobs:
           release_name: Runtime ${{ github.event.inputs.to }}
           body_path: body.md
           draft: true
+
+          
+  ####### Upload asserts to the release draft #######
+  publish-draft-release:
+    runs-on: ubuntu-latest
+    needs: ["setup-scripts", "build-srtool-runtimes", "prepare-draft-release", "matrix_prep"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.to }}
+          fetch-depth: 0
+      - name: Get runtime version
+        id: get-runtime-ver
+        run: |
+          runtime_dancebox_ver="$(cat ./runtime/dancebox/src/lib.rs | grep -o 'spec_version: [0-9]*' | tail -1 | grep -o '[0-9]*')"
+          echo "runtime_dancebox_ver=$runtime_dancebox_ver" >> $GITHUB_OUTPUT
+          mv build/dancebox-runtime.compact.compressed.wasm dancebox-runtime-${runtime_dancebox_ver}.wasm
+          mv build/dancebox-srtool-digest.json dancebox-runtime-${runtime_dancebox_ver}-srtool-digest.json
       - name: Upload dancebox wasm
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          upload_url: ${{ needs.prepare-draft-release.outputs.asset_upload_url }}
           asset_path: dancebox-runtime-${{ steps.get-runtime-ver.outputs.runtime_dancebox_ver }}.wasm
           asset_name: dancebox-runtime-${{ steps.get-runtime-ver.outputs.runtime_dancebox_ver }}.wasm
           asset_content_type: application/octet-stream
@@ -186,7 +189,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          upload_url:  ${{ needs.prepare-draft-release.outputs.asset_upload_url }}
           asset_path: dancebox-runtime-${{ steps.get-runtime-ver.outputs.runtime_dancebox_ver }}-srtool-digest.json
           asset_name: dancebox-runtime-${{ steps.get-runtime-ver.outputs.runtime_dancebox_ver }}.srtool-digest.json
           asset_content_type: application/json

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           dancebox='dancebox'
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
-            echo "matrix_tests=[$dancebox]" >> $GITHUB_OUTPUT
+            echo "matrix_tests=[${dancebox}]" >> $GITHUB_OUTPUT
           elif [[ ${{ github.event.inputs.chains }} = "templates-only" ]]; then
             echo "matrix_tests=['simple-template', 'frontier-template']" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -90,7 +90,7 @@ jobs:
         if: github.repository == 'moondance-labs/tanssi'
         run: |
           echo ${{ matrix.chain }}
-          echo ${{ fromJson(matrix.chain) }}
+          echo ${{ fromJson(matrix.chain).runtime_name }}
 
           docker pull "${{ matrix.srtool_image }}:${{ matrix.srtool_image_tag }}" && image_exists=true || image_exists=false
 

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -151,7 +151,7 @@ jobs:
         id: generate-release-body
         working-directory: original-tools
         run: |
-          RUNTIMES=$(echo ${{fromJson(needs.matrix_prep.outputs.matrix_tests)}} | jq -r '[.[] | .runtime_name]')
+          RUNTIMES=$(echo ${{needs.matrix_prep.outputs.matrix_tests}} | jq -r '[.[] | .runtime_name]')
           echo $RUNTIMES
           yarn
           yarn -s run ts-node github/generate-runtimes-body.ts --owner "${{ github.repository_owner }}" --repo "$(basename ${{ github.repository }})" --from "${{ github.event.inputs.from }}" --to "${{ github.event.inputs.to }}" --srtool-report-folder '../build/' --runtimes $RUNTIMES > ../body.md      - name: Get runtime version

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -50,7 +50,7 @@ jobs:
       - name: create matrix
         id: prepare
         run: |
-          dancebox=dancebox
+          dancebox=\"{ 'runtime-name': 'dancebox' }\"
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
             echo "matrix_tests=['$dancebox']" >> $GITHUB_OUTPUT
           elif [[ ${{ github.event.inputs.chains }} = "templates-only" ]]; then

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -51,7 +51,7 @@ jobs:
         id: prepare
         run: |
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
-            echo "matrix_tests=['aaa', 'bbb', 'ccc']" >> $GITHUB_OUTPUT
+            echo "matrix_tests=['dancebox']" >> $GITHUB_OUTPUT
           else
             echo "matrix_tests=[\"['aaa', 'bbb', 'ccc']\",\"['ddd', 'eee', 'fff']\"]" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -51,7 +51,7 @@ jobs:
         id: prepare
         run: |
           dancebox='{ \"runtime_name\": \"dancebox\", \"runtime_path\" : \"./runtime/dancebox/src/lib.rs\" }'
-          test={"aaa": "bbb"}
+          test='{"aaa": "bbb"}'
 
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
             echo "matrix_tests=[$test]" >> $GITHUB_OUTPUT

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           dancebox='\"{ 'runtime_name': 'dancebox', 'runtime_path' : './runtime/dancebox/src/lib.rs' }\"'
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
-            echo "matrix_tests=['$dancebox']" >> $GITHUB_OUTPUT
+            echo "matrix_tests=['\"{ 'runtime_name': 'dancebox', 'runtime_path' : './runtime/dancebox/src/lib.rs' }\"']" >> $GITHUB_OUTPUT
           elif [[ ${{ github.event.inputs.chains }} = "templates-only" ]]; then
             echo "matrix_tests=['simple-template', 'frontier-template']" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -54,7 +54,7 @@ jobs:
           test='{\"aaa\": \"bbb\"}'
 
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
-            echo "matrix_tests=[$test]" >> $GITHUB_OUTPUT
+            echo "matrix_tests=[{\"aaa\": \"bbb\"}]" >> $GITHUB_OUTPUT
           elif [[ ${{ github.event.inputs.chains }} = "templates-only" ]]; then
             echo "matrix_tests=['simple-template', 'frontier-template']" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -51,7 +51,7 @@ jobs:
         id: prepare
         run: |
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
-            echo "matrix_tests=[\"{'aaa': 'bbb'}\"]" >> $GITHUB_OUTPUT
+            echo "matrix_tests=[{\"aaa\": \"bbb\"}]" >> $GITHUB_OUTPUT
           elif [[ ${{ github.event.inputs.chains }} = "templates-only" ]]; then
             echo "matrix_tests=['simple-template', 'frontier-template']" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -138,12 +138,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.to }}
-          fetch-depth: 0
-      - name: Download dancebox runtime
-        uses: actions/download-artifact@v3.0.2
-        with:
-          name: dancebox-runtime
-          path: build     
+          fetch-depth: 0 
       - name: Use Node.js 18.x
         uses: actions/setup-node@v3
         with:
@@ -177,34 +172,42 @@ jobs:
   publish-draft-release:
     runs-on: ubuntu-latest
     needs: ["setup-scripts", "build-srtool-runtimes", "prepare-draft-release", "matrix_prep"]
+    strategy:
+      matrix:
+        chain: ${{ fromJson(needs.matrix_prep.outputs.matrix_tests) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.to }}
           fetch-depth: 0
+      - name: Download ${{ matrix.chain }} runtime
+        uses: actions/download-artifact@v3.0.2
+        with:
+          name: ${{ matrix.chain }}-runtime
+          path: build    
       - name: Get runtime version
         id: get-runtime-ver
         run: |
-          runtime_dancebox_ver="$(cat ./runtime/dancebox/src/lib.rs | grep -o 'spec_version: [0-9]*' | tail -1 | grep -o '[0-9]*')"
-          echo "runtime_dancebox_ver=$runtime_dancebox_ver" >> $GITHUB_OUTPUT
-          mv build/dancebox-runtime.compact.compressed.wasm dancebox-runtime-${runtime_dancebox_ver}.wasm
-          mv build/dancebox-srtool-digest.json dancebox-runtime-${runtime_dancebox_ver}-srtool-digest.json
-      - name: Upload dancebox wasm
+          runtime_ver="$(cat ${{ matrix.chain.runtime_path }} | grep -o 'spec_version: [0-9]*' | tail -1 | grep -o '[0-9]*')"
+          echo "runtime_ver=$runtime_ver" >> $GITHUB_OUTPUT
+          mv build/${{ matrix.chain }}-runtime.compact.compressed.wasm ${{ matrix.chain }}-runtime-${runtime_ver}.wasm
+          mv build/${{ matrix.chain }}-srtool-digest.json ${{ matrix.chain }}-runtime-${runtime_ver}-srtool-digest.json
+      - name: Upload ${{ matrix.chain }} wasm
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.prepare-draft-release.outputs.asset_upload_url }}
-          asset_path: dancebox-runtime-${{ steps.get-runtime-ver.outputs.runtime_dancebox_ver }}.wasm
-          asset_name: dancebox-runtime-${{ steps.get-runtime-ver.outputs.runtime_dancebox_ver }}.wasm
+          asset_path: ${{ matrix.chain }}-runtime-${{ steps.get-runtime-ver.outputs.runtime_ver }}.wasm
+          asset_name: ${{ matrix.chain }}-runtime-${{ steps.get-runtime-ver.outputs.runtime_ver }}.wasm
           asset_content_type: application/octet-stream
-      - name: Upload dancebox srtool digest
+      - name: Upload ${{ matrix.chain }} srtool digest
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url:  ${{ needs.prepare-draft-release.outputs.asset_upload_url }}
-          asset_path: dancebox-runtime-${{ steps.get-runtime-ver.outputs.runtime_dancebox_ver }}-srtool-digest.json
-          asset_name: dancebox-runtime-${{ steps.get-runtime-ver.outputs.runtime_dancebox_ver }}.srtool-digest.json
+          asset_path: ${{ matrix.chain }}-runtime-${{ steps.get-runtime-ver.outputs.runtime_ver }}-srtool-digest.json
+          asset_name: ${{ matrix.chain }}-runtime-${{ steps.get-runtime-ver.outputs.runtime_ver }}.srtool-digest.json
           asset_content_type: application/json

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -50,14 +50,24 @@ jobs:
       - name: create matrix
         id: prepare
         run: |
-          dancebox='{"runtime_name": "dancebox","runtime_path" : "./runtime/dancebox/src/lib.rs"}'
-          frontier-template='{"runtime_name": "frontier-template","runtime_path" : "./container-chains/templates/frontier/runtime/src/lib.rs"}'
-          simple-template='{"runtime_name": "simple-template","runtime_path" : "./container-chains/templates/simple/runtime/src/lib.rs"}'
+          dancebox='{
+            "runtime_name": "dancebox",
+            "runtime_path" : "./runtime/dancebox/src/lib.rs"
+          }'
+          frontier_template='{
+            "runtime_name": "frontier-template",
+            "runtime_path" : "./container-chains/templates/frontier/runtime/src/lib.rs"
+          }'
+          simple_template='{
+            "runtime_name": "simple-template",
+            "runtime_path" : "./container-chains/templates/simple/runtime/src/lib.rs"
+          }'
 
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
             echo "matrix_tests=[$dancebox]" >> $GITHUB_OUTPUT
           elif [[ ${{ github.event.inputs.chains }} = "templates-only" ]]; then
-            echo "matrix_tests=[$simple-template, $frontier-template]" >> $GITHUB_OUTPUT
+            echo "matrix_tests=[$          simple_template='{
+              , $frontier_template]" >> $GITHUB_OUTPUT
           else
             echo "matrix_tests=[$dancebox, 'simple-template', 'frontier-template']" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -50,7 +50,7 @@ jobs:
       - name: create matrix
         id: prepare
         run: |
-          dancebox='\"{ 'runtime-name': 'dancebox' }\"'
+          dancebox='\"{ 'runtime_name': 'dancebox', 'runtime_path' : './runtime/dancebox/src/lib.rs' }\"'
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
             echo "matrix_tests=['$dancebox']" >> $GITHUB_OUTPUT
           elif [[ ${{ github.event.inputs.chains }} = "templates-only" ]]; then
@@ -89,7 +89,7 @@ jobs:
       - name: Build & Push purestake/srtool image
         if: github.repository == 'moondance-labs/tanssi'
         run: |
-          echo ${{ matrix.chain }}
+          echo ${{ matrix.chain.runtime_name }}
           docker pull "${{ matrix.srtool_image }}:${{ matrix.srtool_image_tag }}" && image_exists=true || image_exists=false
 
           if [[ $image_exists = "false" ]]; then
@@ -108,16 +108,16 @@ jobs:
           ./original-scripts/build-runtime-srtool.sh
       - name: Summary
         run: |
-          echo '${{ steps.srtool_build.outputs.json }}' | jq . > ${{ matrix.chain }}-srtool-digest.json
-          cat ${{ matrix.chain }}-srtool-digest.json
-          cp ${{ steps.srtool_build.outputs.wasm_compressed }} ${{ matrix.chain }}-runtime.compact.compressed.wasm
-      - name: Archive Artifacts for ${{ matrix.chain }}
+          echo '${{ steps.srtool_build.outputs.json }}' | jq . > ${{ matrix.chain.runtime_name }}-srtool-digest.json
+          cat ${{ matrix.chain.runtime_name }}-srtool-digest.json
+          cp ${{ steps.srtool_build.outputs.wasm_compressed }} ${{ matrix.chain.runtime_name }}-runtime.compact.compressed.wasm
+      - name: Archive Artifacts for ${{ matrix.chain.runtime_name}}
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.chain }}-runtime
           path: |
-            ${{ matrix.chain }}-runtime.compact.compressed.wasm
-            ${{ matrix.chain }}-srtool-digest.json
+            ${{ matrix.chain.runtime_name }}-runtime.compact.compressed.wasm
+            ${{ matrix.chain.runtime_name }}-srtool-digest.json
 
           
   ####### Prepare the release draft #######

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - name: Read tests
         run: |
-          echo "${{ fromJson(needs.matrix_prep.outputs.matrix_tests)[0] }}"
+          echo "${{ fromJson(needs.matrix_prep.outputs.matrix_tests) }}"
   build-srtool-runtimes:
     needs: ["setup-scripts", "matrix_prep"]
     runs-on: self-hosted
@@ -89,7 +89,7 @@ jobs:
       - name: Build & Push purestake/srtool image
         if: github.repository == 'moondance-labs/tanssi'
         run: |
-          echo ${{ matrix.chain.runtime_name }}
+          echo ${{ matrix.chain }}
           docker pull "${{ matrix.srtool_image }}:${{ matrix.srtool_image_tag }}" && image_exists=true || image_exists=false
 
           if [[ $image_exists = "false" ]]; then

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Archive Artifacts for ${{ matrix.chain }}
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.chain }}-runtime
+          name: runtime-info
           path: |
             ${{ matrix.chain.runtime_name }}-runtime.compact.compressed.wasm
             ${{ matrix.chain.runtime_name }}-srtool-digest.json
@@ -145,6 +145,11 @@ jobs:
         with:
           name: original-tools
           path: original-tools 
+      - name: Download runtime-info
+        uses: actions/download-artifact@v3.0.2
+        with:
+          name: runtime-info
+          path: build  
       - name: Generate release body
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -152,7 +157,6 @@ jobs:
         working-directory: original-tools
         run: |
           RUNTIMES=$(echo '${{needs.matrix_prep.outputs.matrix_tests}}' | jq -r '.[] | .runtime_name + " "')
-          echo $RUNTIMES
           yarn
           yarn -s run ts-node github/generate-runtimes-body.ts --owner "${{ github.repository_owner }}" --repo "$(basename ${{ github.repository }})" --from "${{ github.event.inputs.from }}" --to "${{ github.event.inputs.to }}" --srtool-report-folder '../build/' --runtimes $RUNTIMES > ../body.md      - name: Get runtime version
       - name: Create draft release
@@ -183,7 +187,7 @@ jobs:
       - name: Download ${{ matrix.chain }} runtime
         uses: actions/download-artifact@v3.0.2
         with:
-          name: ${{ matrix.chain }}-runtime
+          name: runtime-info
           path: build    
       - name: Get runtime version
         id: get-runtime-ver

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -51,9 +51,9 @@ jobs:
         id: prepare
         run: |
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
-            echo "matrix_tests=[\"['aaa', 'bbb', 'ccc']\",\"['ddd', 'eee', 'fff']\"]" >> $GITHUB_OUTPUT
+            echo "matrix=[\"['aaa', 'bbb', 'dancebox']\"]" >> $GITHUB_OUTPUT
           else
-            echo "matrix_tests=[\"['aaa', 'bbb', 'ccc']\",\"['ddd', 'eee', 'fff']\"]" >> $GITHUB_OUTPUT
+            echo "matrix=[\"['aaa', 'bbb', 'ccc']\",\"['ddd', 'eee', 'fff']\"]" >> $GITHUB_OUTPUT
           fi
   debug:
     name: L2 debug

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -50,9 +50,9 @@ jobs:
       - name: create matrix
         id: prepare
         run: |
-          dancebox=\"{ 'runtime-name': 'dancebox' }\"
+          dancebox='\"{ 'runtime-name': 'dancebox' }\"''
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
-            echo "matrix_tests=['$dancebox']" >> $GITHUB_OUTPUT
+            echo "matrix_tests=[$dancebox]" >> $GITHUB_OUTPUT
           elif [[ ${{ github.event.inputs.chains }} = "templates-only" ]]; then
             echo "matrix_tests=['simple-template', 'frontier-template']" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Build runtime using "${{ matrix.srtool_image }}:${{ matrix.srtool_image_tag }}"
         id: srtool_build
         env:
-          GH_WORKFLOW_MATRIX_CHAIN: ${{ matrix.chain }}
+          GH_WORKFLOW_MATRIX_CHAIN: ${{ matrix.chain.runtime_name }}
           GH_WORKFLOW_MATRIX_SRTOOL_IMAGE: ${{ matrix.srtool_image }}
           GH_WORKFLOW_MATRIX_SRTOOL_IMAGE_TAG: ${{ matrix.srtool_image_tag }}
         run: |

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -52,8 +52,10 @@ jobs:
         run: |
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
             echo "matrix_tests=['dancebox']" >> $GITHUB_OUTPUT
+          elif [[ ${{ github.event.inputs.chains }} = "templates-only" ]]; then
+            echo "matrix_tests=['simple-template', 'frontier-template']" >> $GITHUB_OUTPUT
           else
-            echo "matrix_tests=[\"['aaa', 'bbb', 'ccc']\",\"['ddd', 'eee', 'fff']\"]" >> $GITHUB_OUTPUT
+            echo "matrix_tests=['dancebox', 'simple-template', 'frontier-template']" >> $GITHUB_OUTPUT
           fi
   debug:
     name: L2 debug

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -51,9 +51,10 @@ jobs:
         id: prepare
         run: |
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
-          echo "matrix_tests=[\"['aaa', 'bbb', 'ccc']\",\"['ddd', 'eee', 'fff']\"]" >> $GITHUB_OUTPUT
-          elif
-
+            echo "matrix_tests=[\"['aaa', 'bbb', 'ccc']\",\"['ddd', 'eee', 'fff']\"]" >> $GITHUB_OUTPUT
+          else
+            echo "matrix_tests=[\"['aaa', 'bbb', 'ccc']\",\"['ddd', 'eee', 'fff']\"]" >> $GITHUB_OUTPUT
+          fi
   debug:
     name: L2 debug
     runs-on:

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -50,9 +50,9 @@ jobs:
       - name: create matrix
         id: prepare
         run: |
-          dancebox='\"{ 'runtime_name': 'dancebox', 'runtime_path' : './runtime/dancebox/src/lib.rs' }\"'
+          dancebox="\"{ 'runtime_name': 'dancebox', 'runtime_path' : './runtime/dancebox/src/lib.rs' }\""
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
-            echo "matrix_tests=['\"{ 'runtime_name': 'dancebox', 'runtime_path' : './runtime/dancebox/src/lib.rs' }\"']" >> $GITHUB_OUTPUT
+            echo "matrix_tests=['$dancebox']" >> $GITHUB_OUTPUT
           elif [[ ${{ github.event.inputs.chains }} = "templates-only" ]]; then
             echo "matrix_tests=['simple-template', 'frontier-template']" >> $GITHUB_OUTPUT
           else
@@ -66,8 +66,7 @@ jobs:
     steps:
       - name: Read tests
         run: |
-          echo "${{ fromJson(needs.matrix_prep.outputs.matrix_tests)[0] }}"
-          echo "${{ fromJson(needs.matrix_prep.outputs.matrix_tests)[0].runtime_name }}"
+          echo "${{ fromJson(needs.matrix_prep.outputs.matrix_tests[0].runtime_name) }}"
   build-srtool-runtimes:
     needs: ["setup-scripts", "matrix_prep"]
     runs-on: self-hosted
@@ -91,8 +90,6 @@ jobs:
         if: github.repository == 'moondance-labs/tanssi'
         run: |
           echo ${{ matrix.chain }}
-          echo ${{ fromJson(matrix.chain).runtime_name }}
-
           docker pull "${{ matrix.srtool_image }}:${{ matrix.srtool_image_tag }}" && image_exists=true || image_exists=false
 
           if [[ $image_exists = "false" ]]; then
@@ -103,7 +100,7 @@ jobs:
       - name: Build runtime using "${{ matrix.srtool_image }}:${{ matrix.srtool_image_tag }}"
         id: srtool_build
         env:
-          GH_WORKFLOW_MATRIX_CHAIN: ${{ matrix.chain.runtime_name }}
+          GH_WORKFLOW_MATRIX_CHAIN: ${{ matrix.chain }}
           GH_WORKFLOW_MATRIX_SRTOOL_IMAGE: ${{ matrix.srtool_image }}
           GH_WORKFLOW_MATRIX_SRTOOL_IMAGE_TAG: ${{ matrix.srtool_image_tag }}
         run: |
@@ -112,15 +109,15 @@ jobs:
       - name: Summary
         run: |
           echo '${{ steps.srtool_build.outputs.json }}' | jq . > ${{ matrix.chain.runtime_name }}-srtool-digest.json
-          cat ${{ matrix.chain.runtime_name }}-srtool-digest.json
+          cat ${{ matrix.chain }}-srtool-digest.json
           cp ${{ steps.srtool_build.outputs.wasm_compressed }} ${{ matrix.chain.runtime_name }}-runtime.compact.compressed.wasm
-      - name: Archive Artifacts for ${{ matrix.chain.runtime_name}}
+      - name: Archive Artifacts for ${{ matrix.chain }}
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.chain }}-runtime
           path: |
             ${{ matrix.chain.runtime_name }}-runtime.compact.compressed.wasm
-            ${{ matrix.chain.runtime_name }}-srtool-digest.json
+            ${{ matrix.chain }}-srtool-digest.json
 
           
   ####### Prepare the release draft #######

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -50,7 +50,7 @@ jobs:
       - name: create matrix
         id: prepare
         run: |
-          dancebox='\"{ 'runtime_name': 'dancebox', 'runtime_path' : './runtime/dancebox/src/lib.rs' }\"'
+          dancebox='\"{ \'runtime_name\': \'dancebox\', \'runtime_path\' : \'./runtime/dancebox/src/lib.rs\' }\"'
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
             echo "matrix_tests=['$dancebox']" >> $GITHUB_OUTPUT
           elif [[ ${{ github.event.inputs.chains }} = "templates-only" ]]; then
@@ -90,7 +90,8 @@ jobs:
         if: github.repository == 'moondance-labs/tanssi'
         run: |
           echo ${{ matrix.chain }}
-          echo ${{ matrix.chain['runtime_name'] }}
+          echo ${{ matrix.chain['runtime_name
+          '] }}
 
           docker pull "${{ matrix.srtool_image }}:${{ matrix.srtool_image_tag }}" && image_exists=true || image_exists=false
 

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -50,14 +50,23 @@ jobs:
       - name: create matrix
         id: prepare
         run: |
+          dancebox='dancebox'
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
-            echo "matrix_tests=['dancebox']" >> $GITHUB_OUTPUT
+            echo "matrix_tests=[$dancebox]" >> $GITHUB_OUTPUT
           elif [[ ${{ github.event.inputs.chains }} = "templates-only" ]]; then
             echo "matrix_tests=['simple-template', 'frontier-template']" >> $GITHUB_OUTPUT
           else
             echo "matrix_tests=['dancebox', 'simple-template', 'frontier-template']" >> $GITHUB_OUTPUT
           fi
-
+  debug:
+    name: L2 debug
+    runs-on:
+      - ubuntu-latest
+    needs: matrix_prep
+    steps:
+      - name: Read tests
+        run: |
+          echo "${{ fromJson(needs.matrix_prep.outputs.matrix_tests) }}"
   build-srtool-runtimes:
     needs: ["setup-scripts", "matrix_prep"]
     runs-on: self-hosted

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -90,7 +90,7 @@ jobs:
         if: github.repository == 'moondance-labs/tanssi'
         run: |
           echo ${{ matrix.chain }}
-          echo ${{ fromJson(matrix.chain).runtime_name }}
+          echo ${{ matrix.chain.runtime_path }}
 
           docker pull "${{ matrix.srtool_image }}:${{ matrix.srtool_image_tag }}" && image_exists=true || image_exists=false
 

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -151,7 +151,7 @@ jobs:
         id: generate-release-body
         working-directory: original-tools
         run: |
-          RUNTIMES=$(echo ${{needs.matrix_prep.outputs.matrix_tests}} | jq -r '[.[] | .runtime_name]')
+          RUNTIMES=$(echo ${{fromJson(needs.matrix_prep.outputs.matrix_tests)}} | jq -r '[.[] | .runtime_name]')
           echo $RUNTIMES
           yarn
           yarn -s run ts-node github/generate-runtimes-body.ts --owner "${{ github.repository_owner }}" --repo "$(basename ${{ github.repository }})" --from "${{ github.event.inputs.from }}" --to "${{ github.event.inputs.to }}" --srtool-report-folder '../build/' --runtimes $RUNTIMES > ../body.md      - name: Get runtime version

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -50,7 +50,7 @@ jobs:
       - name: create matrix
         id: prepare
         run: |
-          dancebox='\"{ \'runtime_name\': \'dancebox\', \'runtime_path\' : \'./runtime/dancebox/src/lib.rs\' }\"'
+          dancebox='\"{ 'runtime_name': 'dancebox', 'runtime_path' : './runtime/dancebox/src/lib.rs' }\"'
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
             echo "matrix_tests=['$dancebox']" >> $GITHUB_OUTPUT
           elif [[ ${{ github.event.inputs.chains }} = "templates-only" ]]; then
@@ -90,8 +90,7 @@ jobs:
         if: github.repository == 'moondance-labs/tanssi'
         run: |
           echo ${{ matrix.chain }}
-          echo ${{ matrix.chain['runtime_name
-          '] }}
+          echo ${{ fromJson(matrix.chain) }}
 
           docker pull "${{ matrix.srtool_image }}:${{ matrix.srtool_image_tag }}" && image_exists=true || image_exists=false
 

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -61,15 +61,6 @@ jobs:
           else
             echo "matrix_tests=[$dancebox, $simple_template, $frontier_template]" >> $GITHUB_OUTPUT
           fi
-  debug:
-    name: L2 debug
-    runs-on:
-      - ubuntu-latest
-    needs: matrix_prep
-    steps:
-      - name: Read tests
-        run: |
-          echo "${{ fromJson(needs.matrix_prep.outputs.matrix_tests)[0].runtime_name }}"
   build-srtool-runtimes:
     needs: ["setup-scripts", "matrix_prep"]
     runs-on: self-hosted

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -51,10 +51,10 @@ jobs:
         id: prepare
         run: |
           dancebox='{ \"runtime_name\": \"dancebox\", \"runtime_path\" : \"./runtime/dancebox/src/lib.rs\" }'
-          test='{\"aaa\": \"bbb\"}'
+          test={"aaa": "bbb"}
 
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
-            echo "matrix_tests=[{\"aaa\": \"bbb\"}]" >> $GITHUB_OUTPUT
+            echo "matrix_tests=[$test]" >> $GITHUB_OUTPUT
           elif [[ ${{ github.event.inputs.chains }} = "templates-only" ]]; then
             echo "matrix_tests=['simple-template', 'frontier-template']" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -51,7 +51,7 @@ jobs:
         id: prepare
         run: |
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
-            echo "matrix_tests=[\"['aaa', 'bbb', 'ccc']\",\"['ddd', 'eee', 'fff']\"]" >> $GITHUB_OUTPUT
+            echo "matrix_tests=[\"['aaa', 'bbb', 'ccc']\"]" >> $GITHUB_OUTPUT
           elif [[ ${{ github.event.inputs.chains }} = "templates-only" ]]; then
             echo "matrix_tests=['simple-template', 'frontier-template']" >> $GITHUB_OUTPUT
           else
@@ -65,7 +65,7 @@ jobs:
     steps:
       - name: Read tests
         run: |
-          echo "${{ fromJson(needs.matrix_prep.outputs.matrix_tests[0]) }}"
+          echo "${{ fromJson(needs.matrix_prep.outputs.matrix_tests)[0] }}"
   build-srtool-runtimes:
     needs: ["setup-scripts", "matrix_prep"]
     runs-on: self-hosted

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -151,7 +151,7 @@ jobs:
         id: generate-release-body
         working-directory: original-tools
         run: |
-          RUNTIMES=$(echo '${{needs.matrix_prep.outputs.matrix_tests}}' | jq -r '.[] | .runtime_name')
+          RUNTIMES=$(echo '${{needs.matrix_prep.outputs.matrix_tests}}' | jq -r '.[] | .runtime_name + " "')
           echo $RUNTIMES
           yarn
           yarn -s run ts-node github/generate-runtimes-body.ts --owner "${{ github.repository_owner }}" --repo "$(basename ${{ github.repository }})" --from "${{ github.event.inputs.from }}" --to "${{ github.event.inputs.to }}" --srtool-report-folder '../build/' --runtimes $RUNTIMES > ../body.md      - name: Get runtime version

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -90,6 +90,8 @@ jobs:
         if: github.repository == 'moondance-labs/tanssi'
         run: |
           echo ${{ matrix.chain }}
+          echo ${{ matrix.chain['runtime_name'] }}
+
           docker pull "${{ matrix.srtool_image }}:${{ matrix.srtool_image_tag }}" && image_exists=true || image_exists=false
 
           if [[ $image_exists = "false" ]]; then

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -50,7 +50,7 @@ jobs:
       - name: create matrix
         id: prepare
         run: |
-          dancebox='\"{ 'runtime-name': 'dancebox' }\"''
+          dancebox='\"{ 'runtime-name': 'dancebox' }\"'
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
             echo "matrix_tests=[$dancebox]" >> $GITHUB_OUTPUT
           elif [[ ${{ github.event.inputs.chains }} = "templates-only" ]]; then

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -51,7 +51,7 @@ jobs:
         id: prepare
         run: |
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
-            echo "matrix_tests=[\"['aaa', 'bbb', 'ccc']\"]" >> $GITHUB_OUTPUT
+            echo "matrix_tests=[\"{'aaa': 'bbb'}\"]" >> $GITHUB_OUTPUT
           elif [[ ${{ github.event.inputs.chains }} = "templates-only" ]]; then
             echo "matrix_tests=['simple-template', 'frontier-template']" >> $GITHUB_OUTPUT
           else
@@ -65,7 +65,7 @@ jobs:
     steps:
       - name: Read tests
         run: |
-          echo "${{ fromJson(needs.matrix_prep.outputs.matrix_tests)[0] }}"
+          echo "${{ fromJson(needs.matrix_prep.outputs.matrix_tests)[0].aaa }}"
   build-srtool-runtimes:
     needs: ["setup-scripts", "matrix_prep"]
     runs-on: self-hosted

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -54,7 +54,7 @@ jobs:
           test='{\"aaa\": \"bbb\"}'
 
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
-            echo "matrix_tests=['$test']" >> $GITHUB_OUTPUT
+            echo "matrix_tests=[$test]" >> $GITHUB_OUTPUT
           elif [[ ${{ github.event.inputs.chains }} = "templates-only" ]]; then
             echo "matrix_tests=['simple-template', 'frontier-template']" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -51,7 +51,7 @@ jobs:
         id: prepare
         run: |
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
-            echo "matrix=[\"['aaa', 'bbb', 'dancebox']\"]" >> $GITHUB_OUTPUT
+            echo "matrix=[\"['aaa', 'bbb', 'ccc']\"]" >> $GITHUB_OUTPUT
           else
             echo "matrix=[\"['aaa', 'bbb', 'ccc']\",\"['ddd', 'eee', 'fff']\"]" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -50,11 +50,9 @@ jobs:
       - name: create matrix
         id: prepare
         run: |
-          dancebox='{ \"runtime_name\": \"dancebox\", \"runtime_path\" : \"./runtime/dancebox/src/lib.rs\" }'
-          test='{"aaa": "bbb"}'
-
+          dancebox='{ "runtime_name": "dancebox", "runtime_path" : "./runtime/dancebox/src/lib.rs" }'
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
-            echo "matrix_tests=[$test]" >> $GITHUB_OUTPUT
+            echo "matrix_tests=[$dancebox]" >> $GITHUB_OUTPUT
           elif [[ ${{ github.event.inputs.chains }} = "templates-only" ]]; then
             echo "matrix_tests=['simple-template', 'frontier-template']" >> $GITHUB_OUTPUT
           else
@@ -68,7 +66,7 @@ jobs:
     steps:
       - name: Read tests
         run: |
-          echo "${{ fromJson(needs.matrix_prep.outputs.matrix_tests)[0].aaa }}"
+          echo "${{ fromJson(needs.matrix_prep.outputs.matrix_tests)[0].runtime_name }}"
   build-srtool-runtimes:
     needs: ["setup-scripts", "matrix_prep"]
     runs-on: self-hosted
@@ -91,7 +89,7 @@ jobs:
       - name: Build & Push purestake/srtool image
         if: github.repository == 'moondance-labs/tanssi'
         run: |
-          echo ${{ matrix.chain }}
+          echo ${{ matrix.chain.runtime_name }}
           docker pull "${{ matrix.srtool_image }}:${{ matrix.srtool_image_tag }}" && image_exists=true || image_exists=false
 
           if [[ $image_exists = "false" ]]; then

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -70,7 +70,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        chain: ${{fromJson(needs.matrix_prep.outputs.matrix)}}
+        chain: ${{ fromJson(needs.matrix_prep.outputs.matrix_tests) }}
         srtool_image:
           - purestake/srtool
         srtool_image_tag:

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -50,18 +50,9 @@ jobs:
       - name: create matrix
         id: prepare
         run: |
-          dancebox='{
-            "runtime_name": "dancebox",
-            "runtime_path" : "./runtime/dancebox/src/lib.rs"
-          }'
-          frontier_template='{
-            "runtime_name": "frontier-template",
-            "runtime_path" : "./container-chains/templates/frontier/runtime/src/lib.rs"
-          }'
-          simple_template='{
-            "runtime_name": "simple-template",
-            "runtime_path" : "./container-chains/templates/simple/runtime/src/lib.rs"
-          }'
+          dancebox='{"runtime_name": "dancebox","runtime_path" : "./runtime/dancebox/src/lib.rs"}'
+          frontier_template='{"runtime_name": "frontier-template","runtime_path" : "./container-chains/templates/frontier/runtime/src/lib.rs"}'
+          simple_template='{"runtime_name": "simple-template","runtime_path" : "./container-chains/templates/simple/runtime/src/lib.rs"}'
 
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
             echo "matrix_tests=[$dancebox]" >> $GITHUB_OUTPUT

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -151,7 +151,7 @@ jobs:
         id: generate-release-body
         working-directory: original-tools
         run: |
-          RUNTIMES=$(echo ${{needs.matrix_prep.outputs.matrix_tests}} | jq -r '[.[] | .runtime_name]')
+          RUNTIMES=$(echo '${{needs.matrix_prep.outputs.matrix_tests}}' | jq -r '[.[] | .runtime_name]')
           echo $RUNTIMES
           yarn
           yarn -s run ts-node github/generate-runtimes-body.ts --owner "${{ github.repository_owner }}" --repo "$(basename ${{ github.repository }})" --from "${{ github.event.inputs.from }}" --to "${{ github.event.inputs.to }}" --srtool-report-folder '../build/' --runtimes $RUNTIMES > ../body.md      - name: Get runtime version

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -194,23 +194,23 @@ jobs:
         run: |
           runtime_ver="$(cat ${{ matrix.chain.runtime_path }} | grep -o 'spec_version: [0-9]*' | tail -1 | grep -o '[0-9]*')"
           echo "runtime_ver=$runtime_ver" >> $GITHUB_OUTPUT
-          mv build/${{ matrix.chain }}-runtime.compact.compressed.wasm ${{ matrix.chain }}-runtime-${runtime_ver}.wasm
-          mv build/${{ matrix.chain }}-srtool-digest.json ${{ matrix.chain }}-runtime-${runtime_ver}-srtool-digest.json
+          mv build/${{ matrix.chain.runtime_name }}-runtime.compact.compressed.wasm ${{ matrix.chain.runtime_name }}-runtime-${runtime_ver}.wasm
+          mv build/${{ matrix.chain.runtime_name }}-srtool-digest.json ${{ matrix.chain.runtime_name }}-runtime-${runtime_ver}-srtool-digest.json
       - name: Upload ${{ matrix.chain }} wasm
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.prepare-draft-release.outputs.asset_upload_url }}
-          asset_path: ${{ matrix.chain }}-runtime-${{ steps.get-runtime-ver.outputs.runtime_ver }}.wasm
-          asset_name: ${{ matrix.chain }}-runtime-${{ steps.get-runtime-ver.outputs.runtime_ver }}.wasm
+          asset_path: ${{ matrix.chain.runtime_name }}-runtime-${{ steps.get-runtime-ver.outputs.runtime_ver }}.wasm
+          asset_name: ${{ matrix.chain.runtime_name }}-runtime-${{ steps.get-runtime-ver.outputs.runtime_ver }}.wasm
           asset_content_type: application/octet-stream
-      - name: Upload ${{ matrix.chain }} srtool digest
+      - name: Upload ${{ matrix.chain.runtime_name }} srtool digest
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url:  ${{ needs.prepare-draft-release.outputs.asset_upload_url }}
-          asset_path: ${{ matrix.chain }}-runtime-${{ steps.get-runtime-ver.outputs.runtime_ver }}-srtool-digest.json
-          asset_name: ${{ matrix.chain }}-runtime-${{ steps.get-runtime-ver.outputs.runtime_ver }}.srtool-digest.json
+          asset_path: ${{ matrix.chain.runtime_name }}-runtime-${{ steps.get-runtime-ver.outputs.runtime_ver }}-srtool-digest.json
+          asset_name: ${{ matrix.chain.runtime_name }}-runtime-${{ steps.get-runtime-ver.outputs.runtime_ver }}.srtool-digest.json
           asset_content_type: application/json

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -66,7 +66,8 @@ jobs:
     steps:
       - name: Read tests
         run: |
-          echo "${{ fromJson(needs.matrix_prep.outputs.matrix_tests) }}"
+          echo "${{ fromJson(needs.matrix_prep.outputs.matrix_tests)[0] }}"
+          echo "${{ fromJson(needs.matrix_prep.outputs.matrix_tests)[0].runtime_name }}"
   build-srtool-runtimes:
     needs: ["setup-scripts", "matrix_prep"]
     runs-on: self-hosted
@@ -90,7 +91,7 @@ jobs:
         if: github.repository == 'moondance-labs/tanssi'
         run: |
           echo ${{ matrix.chain }}
-          echo ${{ matrix.chain.runtime_path }}
+          echo ${{ fromJson(matrix.chain).runtime_name }}
 
           docker pull "${{ matrix.srtool_image }}:${{ matrix.srtool_image_tag }}" && image_exists=true || image_exists=false
 

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -50,9 +50,8 @@ jobs:
       - name: create matrix
         id: prepare
         run: |
-          dancebox="\"{ 'runtime_name': 'dancebox', 'runtime_path' : './runtime/dancebox/src/lib.rs' }\""
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
-            echo "matrix_tests=['$dancebox']" >> $GITHUB_OUTPUT
+            echo "matrix_tests=[\"{'runtime_name': 'dancebox'}\"]" >> $GITHUB_OUTPUT
           elif [[ ${{ github.event.inputs.chains }} = "templates-only" ]]; then
             echo "matrix_tests=['simple-template', 'frontier-template']" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -50,8 +50,11 @@ jobs:
       - name: create matrix
         id: prepare
         run: |
+          dancebox='{ \"runtime_name\": \"dancebox\", \"runtime_path\" : \"'./runtime/dancebox/src/lib.rs\" }'
+          test='{\"aaa\": \"bbb\"}'
+
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
-            echo "matrix_tests=[{\"aaa\": \"bbb\"}]" >> $GITHUB_OUTPUT
+            echo "matrix_tests=['$test']" >> $GITHUB_OUTPUT
           elif [[ ${{ github.event.inputs.chains }} = "templates-only" ]]; then
             echo "matrix_tests=['simple-template', 'frontier-template']" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -50,10 +50,7 @@ jobs:
       - name: create matrix
         id: prepare
         run: |
-          dancebox='{\
-            "runtime_name": "dancebox",
-            "runtime_path" : "./runtime/dancebox/src/lib.rs"
-          }'
+          dancebox='{"runtime_name": "dancebox","runtime_path" : "./runtime/dancebox/src/lib.rs"}'
           frontier_template='{"runtime_name": "frontier-template","runtime_path" : "./container-chains/templates/frontier/runtime/src/lib.rs"}'
           simple_template='{"runtime_name": "simple-template","runtime_path" : "./container-chains/templates/simple/runtime/src/lib.rs"}'
 
@@ -129,7 +126,7 @@ jobs:
   ####### Prepare the release draft #######
   prepare-draft-release:
     runs-on: ubuntu-latest
-    needs: ["setup-scripts", "build-srtool-runtimes"]
+    needs: ["setup-scripts", "build-srtool-runtimes", "matrix_prep"]
     outputs:
       release_url: ${{ steps.create-release.outputs.html_url }}
       asset_upload_url: ${{ steps.create-release.outputs.upload_url }}
@@ -154,8 +151,10 @@ jobs:
         id: generate-release-body
         working-directory: original-tools
         run: |
+          RUNTIMES=$(echo ${{needs.matrix_prep.outputs.matrix_tests}} | jq -r '[.[] | .runtime_name]')
+          echo $RUNTIMES
           yarn
-          yarn -s run ts-node github/generate-runtimes-body.ts --owner "${{ github.repository_owner }}" --repo "$(basename ${{ github.repository }})" --from "${{ github.event.inputs.from }}" --to "${{ github.event.inputs.to }}" --srtool-report-folder '../build/' > ../body.md      - name: Get runtime version
+          yarn -s run ts-node github/generate-runtimes-body.ts --owner "${{ github.repository_owner }}" --repo "$(basename ${{ github.repository }})" --from "${{ github.event.inputs.from }}" --to "${{ github.event.inputs.to }}" --srtool-report-folder '../build/' --runtimes $RUNTIMES > ../body.md      - name: Get runtime version
       - name: Create draft release
         id: create-release
         uses: actions/create-release@v1

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           dancebox='\"{ 'runtime-name': 'dancebox' }\"'
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
-            echo "matrix_tests=[$dancebox]" >> $GITHUB_OUTPUT
+            echo "matrix_tests=['$dancebox']" >> $GITHUB_OUTPUT
           elif [[ ${{ github.event.inputs.chains }} = "templates-only" ]]; then
             echo "matrix_tests=['simple-template', 'frontier-template']" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -59,7 +59,7 @@ jobs:
           elif [[ ${{ github.event.inputs.chains }} = "templates-only" ]]; then
             echo "matrix_tests=[$simple_template, $frontier_template]" >> $GITHUB_OUTPUT
           else
-            echo "matrix_tests=[$dancebox, 'simple-template', 'frontier-template']" >> $GITHUB_OUTPUT
+            echo "matrix_tests=[$dancebox, $simple_template, $frontier_template]" >> $GITHUB_OUTPUT
           fi
   debug:
     name: L2 debug

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -50,7 +50,7 @@ jobs:
       - name: create matrix
         id: prepare
         run: |
-          dancebox='{ \"runtime_name\": \"dancebox\", \"runtime_path\" : \"'./runtime/dancebox/src/lib.rs\" }'
+          dancebox='{ \"runtime_name\": \"dancebox\", \"runtime_path\" : \"./runtime/dancebox/src/lib.rs\" }'
           test='{\"aaa\": \"bbb\"}'
 
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -51,9 +51,9 @@ jobs:
         id: prepare
         run: |
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
-            echo "matrix=[\"['aaa', 'bbb', 'ccc']\"]" >> $GITHUB_OUTPUT
+            echo "matrix_tests=[\"['aaa', 'bbb', 'ccc']\",\"['ddd', 'eee', 'fff']\"]" >> $GITHUB_OUTPUT
           else
-            echo "matrix=[\"['aaa', 'bbb', 'ccc']\",\"['ddd', 'eee', 'fff']\"]" >> $GITHUB_OUTPUT
+            echo "matrix_tests=[\"['aaa', 'bbb', 'ccc']\",\"['ddd', 'eee', 'fff']\"]" >> $GITHUB_OUTPUT
           fi
   debug:
     name: L2 debug

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -50,13 +50,25 @@ jobs:
       - name: create matrix
         id: prepare
         run: |
-          dancebox='{ "runtime_name": "dancebox", "runtime_path" : "./runtime/dancebox/src/lib.rs" }'
+          dancebox='{
+            "runtime_name": "dancebox",
+            "runtime_path" : "./runtime/dancebox/src/lib.rs"
+          }'
+          frontier-template='{
+            "runtime_name": "frontier-template",
+            "runtime_path" : "./container-chains/templates/frontier/runtime/src/lib.rs"
+          }'
+          simple-template='{
+            "runtime_name": "simple-template",
+            "runtime_path" : "./container-chains/templates/simple/runtime/src/lib.rs"
+          }'
+
           if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
             echo "matrix_tests=[$dancebox]" >> $GITHUB_OUTPUT
           elif [[ ${{ github.event.inputs.chains }} = "templates-only" ]]; then
-            echo "matrix_tests=['simple-template', 'frontier-template']" >> $GITHUB_OUTPUT
+            echo "matrix_tests=[$simple-template, $frontier-template]" >> $GITHUB_OUTPUT
           else
-            echo "matrix_tests=['dancebox', 'simple-template', 'frontier-template']" >> $GITHUB_OUTPUT
+            echo "matrix_tests=[$dancebox, 'simple-template', 'frontier-template']" >> $GITHUB_OUTPUT
           fi
   debug:
     name: L2 debug
@@ -117,7 +129,7 @@ jobs:
           name: ${{ matrix.chain }}-runtime
           path: |
             ${{ matrix.chain.runtime_name }}-runtime.compact.compressed.wasm
-            ${{ matrix.chain }}-srtool-digest.json
+            ${{ matrix.chain.runtime_name }}-srtool-digest.json
 
           
   ####### Prepare the release draft #######

--- a/scripts/build-runtime-srtool.sh
+++ b/scripts/build-runtime-srtool.sh
@@ -8,10 +8,10 @@
 # Docker command to generate JSON blob of the runtime
 if [[ $GH_WORKFLOW_MATRIX_CHAIN == *"template"* ]]; then
   FOLDER_NAME=$(echo $GH_WORKFLOW_MATRIX_CHAIN |sed 's/-template.*//')
-  PATH_NAME=container-chains/templates/${FOLDER_NAME}/runtime
+  RUNTIME_DIR=container-chains/templates/${FOLDER_NAME}/runtime
   PACKAGE=container-chain-template-${FOLDER_NAME}-runtime
 else
-  PATH_NAME=runtime/${GH_WORKFLOW_MATRIX_CHAIN}
+  RUNTIME_DIR=runtime/${GH_WORKFLOW_MATRIX_CHAIN}
   PACKAGE=${GH_WORKFLOW_MATRIX_CHAIN}-runtime
 fi
 
@@ -20,8 +20,8 @@ CMD="docker run \
   --rm \
   $(~/srtool/uid-gid-mapping.sh 1001 | xargs) \
   -e CARGO_NET_GIT_FETCH_WITH_CLI=true \
-  -e PACKAGE=${GH_WORKFLOW_MATRIX_CHAIN}-runtime \
-  -e RUNTIME_DIR=runtime/${GH_WORKFLOW_MATRIX_CHAIN} \
+  -e PACKAGE=${PACKAGE} \
+  -e RUNTIME_DIR=${RUNTIME_DIR} \
   -v ${PWD}:/build \
   -v /home/${USER}/srtool/.ssh:/home/builder/.ssh \
   -v /home/${USER}/srtool/entrypoint.sh:/srtool/entrypoint.sh \

--- a/scripts/build-runtime-srtool.sh
+++ b/scripts/build-runtime-srtool.sh
@@ -6,6 +6,15 @@
 # $(~/srtool/uid-gid-mapping.sh 1001 | xargs) is used to map the user and group
 
 # Docker command to generate JSON blob of the runtime
+if [[ $GH_WORKFLOW_MATRIX_CHAIN == *"template"* ]]; then
+  FOLDER_NAME=$(echo $GH_WORKFLOW_MATRIX_CHAIN |sed 's/-template.*//')
+  PATH_NAME=container-chains/templates/${FOLDER_NAME}/runtime
+  PACKAGE=container-chain-template-${FOLDER_NAME}-runtime
+else
+  PATH_NAME=runtime/${GH_WORKFLOW_MATRIX_CHAIN}
+  PACKAGE=${GH_WORKFLOW_MATRIX_CHAIN}-runtime
+fi
+
 CMD="docker run \
   -i \
   --rm \

--- a/tools/github/generate-runtimes-body.ts
+++ b/tools/github/generate-runtimes-body.ts
@@ -73,8 +73,13 @@ async function main() {
         describe: "Repository name (Ex: dancebox)",
         required: true,
       },
+      runtimes: {
+        type: "array",
+        describe: "The runtimes for which it needs to be run",
+        required: true
+      }
     })
-    .demandOption(["srtool-report-folder", "from", "to"])
+    .demandOption(["srtool-report-folder", "from", "to", "runtimes"])
     .help().argv;
 
   const octokit = new Octokit({
@@ -84,8 +89,8 @@ async function main() {
   const previousTag = argv.from;
   const newTag = argv.to;
 
-  const runtimes = ["dancebox"].map((runtimeName) =>
-    getRuntimeInfo(argv["srtool-report-folder"], runtimeName)
+  const runtimes = argv.runtimes.map((runtimeName) =>
+    getRuntimeInfo(argv["srtool-report-folder"], runtimeName as string)
   );
 
   const moduleLinks = ["substrate", "polkadot", "cumulus", "frontier"].map((repoName) => ({

--- a/tools/github/generate-runtimes-body.ts
+++ b/tools/github/generate-runtimes-body.ts
@@ -16,16 +16,30 @@ function capitalize(s) {
 }
 
 function getRuntimeInfo(srtoolReportFolder: string, runtimeName: string) {
-  const specVersion = execSync(
-    `cat ../runtime/${runtimeName}/src/lib.rs | grep 'spec_version: [0-9]*' | tail -1`
-  ).toString();
-  return {
-    name: runtimeName,
-    version: /:\s?([0-9A-z\-]*)/.exec(specVersion)[1],
-    srtool: JSON.parse(
-      readFileSync(path.join(srtoolReportFolder, `./${runtimeName}-srtool-digest.json`)).toString()
-    ),
-  };
+  if (runtimeName.includes("-template")) {
+    const specVersion = execSync(
+      `cat ../container-chains/templates/${runtimeName.split("-template")[0]}/runtime/src/lib.rs | grep 'spec_version: [0-9]*' | tail -1`
+    ).toString();
+    return {
+      name: runtimeName,
+      version: /:\s?([0-9A-z\-]*)/.exec(specVersion)[1],
+      srtool: JSON.parse(
+        readFileSync(path.join(srtoolReportFolder, `./${runtimeName}-srtool-digest.json`)).toString()
+      ),
+    };
+  }
+  else {
+    const specVersion = execSync(
+      `cat ../runtime/${runtimeName}/src/lib.rs | grep 'spec_version: [0-9]*' | tail -1`
+    ).toString();
+    return {
+      name: runtimeName,
+      version: /:\s?([0-9A-z\-]*)/.exec(specVersion)[1],
+      srtool: JSON.parse(
+        readFileSync(path.join(srtoolReportFolder, `./${runtimeName}-srtool-digest.json`)).toString()
+      ),
+    };
+  }
 }
 
 // Srtool expects the pallet parachain_system to be at index 1. However just in case we recalculate
@@ -88,8 +102,9 @@ async function main() {
 
   const previousTag = argv.from;
   const newTag = argv.to;
-
-  const runtimes = argv.runtimes.map((runtimeName) =>
+  const injectedRuntimes = argv.runtimes;
+  
+  const runtimes = injectedRuntimes.map((runtimeName) =>
     getRuntimeInfo(argv["srtool-report-folder"], runtimeName as string)
   );
 

--- a/tools/github/print-runtime-release-issue.ts
+++ b/tools/github/print-runtime-release-issue.ts
@@ -34,10 +34,11 @@ async function main() {
 - [ ] Check all proxy types.
 - [ ] Re-run all extrinsics/hooks benchmarks.
 - [ ] Tag master with runtime-${newVersion} and push to github
+- [ ] Tag master with runtime-${newVersion}-templates and push to github
 - [ ] Start the github action Publish Runtime Draft
 with runtime-${previousVersion} => runtime-${newVersion}
   - \`gh workflow run "Publish Runtime Draft" -r 'master' ` +
-    `-f from=runtime-${previousVersion} -f to=runtime-${newVersion}\`
+    `-f from=runtime-${previousVersion} -f to=runtime-${newVersion} -f chains=run-all\`
 - [ ] Review the generated Draft and clean a bit the messages if needed (keep it draft)
 - [ ] Upgrade typescript API: Start the github action "Upgrade typescript API"
 - [ ] Upgrade stagenet-dancebox
@@ -59,10 +60,13 @@ with runtime-${previousVersion} => runtime-${newVersion}
 ${commonTemplate}
 
 ## Post Release
-- [ ] Publish the docker runtime image (trigger the github action "Publish Docker runtime")
+- [ ] Publish the docker runtime image (trigger the github action "Publish Docker runtime tanssi")
   - \`gh workflow run "Publish Runtime Draft" -r 'master' ` +
       `-f from=runtime-${previousVersion} -f to=runtime-${newVersion}\`
-- [ ] Create a PR that increment spec version (like #1051)
+- [ ] Publish the docker runtime image (trigger the github action "Publish Docker runtime containers")
+  - \`gh workflow run "Publish Runtime Draft" -r 'master' ` +
+      `-f from=runtime-${previousVersion}-templates -f to=runtime-${newVersion}-templates\`
+- [ ] Create a PR that increment spec version (like #1051) in both containers and tanssi runtimes
     `;
     console.log(template);
   } else {


### PR DESCRIPTION
This pull request allows us to make releases for tanssi runtimes, templates, or both. The CI job now allows you to choose between releasing:

- `tanssi-only`
- `templates-only`
- `run-all`

The PR modifies the CI job such that it is quite easy to add a new template, since it only involves adding a new element to a json, formatted structure in the job prepare_matrix, e.g.:

`dancebox='{"runtime_name": "dancebox","runtime_path" : "./runtime/dancebox/src/lib.rs"}'
`
I also decoupled the draft release preparation into first pushing the release (non-matrixed) and then uploading the files (matrixed)

The scripts have been modified to support releasing both containers and tanssi runtimes too.

An example of a run only for templates can be seen in: https://github.com/moondance-labs/tanssi/releases/tag/untagged-07ed789acd3b36e2abed

Additionally we push the runtime-changes and tags not only for tanssi, but also for containers

**### How will releases look like from now on?**

Runtimes releases willl contain two tags:
- `runtime-xx.yy`
- `rutime-xx.yy-templates`

We have two different docker jobs for pushing template runtime releases or tanssi runtime releases. Ideally these will be the same (if no bug is encountered), but it might happen that either tanssi or one of the containers contains a bug and we have to do a minor release. In that case:

- If it's a tanssi minor release, we increment the tanssi spec, create the draft release only for tanssi (not the templates) by issuing a new tag `runtime-xx.yz` with the cherry-picked commit ,but without modifying the template tags. Then we just publish the tanssi-runtime release in docker.

- If it's a templates minor release, we increment the templates specs, create the draft release only for templates (not tanssi+) by issuing a new tag `runtime-xx.yz-templates` with the cherry-picked commit ,but without modifying the tanssi tags. Then we just publish the template-runtimes release in docker.

