### PR TITLE
Separate spawning container chain and starting collation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,8 +883,11 @@ dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-parachain-inherent",
  "cumulus-relay-chain-interface",
+ "futures 0.3.28",
  "nimbus-primitives",
  "parity-scale-codec",
+ "polkadot-overseer",
+ "sc-client-api",
  "scale-info",
  "sp-consensus-aura",
  "sp-core",
@@ -894,9 +897,12 @@ dependencies = [
  "sp-state-machine",
  "sp-std",
  "sp-trie",
+ "substrate-test-runtime",
+ "substrate-test-runtime-client",
  "tc-consensus",
  "tc-orchestrator-chain-interface",
  "test-relay-sproof-builder",
+ "tokio",
  "tp-collator-assignment",
  "tp-core",
  "tracing",
@@ -11088,6 +11094,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "sc-network-test"
+version = "0.8.0"
+source = "git+https://github.com/moondance-labs/substrate?branch=tanssi-polkadot-v0.9.43#11f2f27ba5af2d4e8eb1f73ae0056106be5bcfb2"
+dependencies = [
+ "async-trait",
+ "futures 0.3.28",
+ "futures-timer",
+ "libp2p",
+ "log",
+ "parking_lot 0.12.1",
+ "rand 0.8.5",
+ "sc-block-builder",
+ "sc-client-api",
+ "sc-consensus",
+ "sc-network",
+ "sc-network-common",
+ "sc-network-light",
+ "sc-network-sync",
+ "sc-service",
+ "sc-utils",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-consensus-babe",
+ "sp-core",
+ "sp-runtime",
+ "sp-tracing",
+ "substrate-test-runtime",
+ "substrate-test-runtime-client",
+ "tokio",
+]
+
+[[package]]
 name = "sc-network-transactions"
 version = "0.10.0-dev"
 source = "git+https://github.com/moondance-labs/substrate?branch=tanssi-polkadot-v0.9.43#11f2f27ba5af2d4e8eb1f73ae0056106be5bcfb2"
@@ -13088,6 +13126,100 @@ dependencies = [
 ]
 
 [[package]]
+name = "substrate-test-client"
+version = "2.0.1"
+source = "git+https://github.com/moondance-labs/substrate?branch=tanssi-polkadot-v0.9.43#11f2f27ba5af2d4e8eb1f73ae0056106be5bcfb2"
+dependencies = [
+ "array-bytes 4.2.0",
+ "async-trait",
+ "futures 0.3.28",
+ "parity-scale-codec",
+ "sc-client-api",
+ "sc-client-db",
+ "sc-consensus",
+ "sc-executor",
+ "sc-offchain",
+ "sc-service",
+ "serde",
+ "serde_json",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-core",
+ "sp-keyring",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-state-machine",
+]
+
+[[package]]
+name = "substrate-test-runtime"
+version = "2.0.0"
+source = "git+https://github.com/moondance-labs/substrate?branch=tanssi-polkadot-v0.9.43#11f2f27ba5af2d4e8eb1f73ae0056106be5bcfb2"
+dependencies = [
+ "array-bytes 6.1.0",
+ "frame-executive",
+ "frame-support",
+ "frame-system",
+ "frame-system-rpc-runtime-api",
+ "log",
+ "memory-db",
+ "pallet-babe",
+ "pallet-balances",
+ "pallet-beefy-mmr",
+ "pallet-root-testing",
+ "pallet-sudo",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "sc-service",
+ "scale-info",
+ "serde",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-block-builder",
+ "sp-consensus-aura",
+ "sp-consensus-babe",
+ "sp-consensus-beefy",
+ "sp-consensus-grandpa",
+ "sp-core",
+ "sp-debug-derive",
+ "sp-externalities",
+ "sp-inherents",
+ "sp-io",
+ "sp-keyring",
+ "sp-offchain",
+ "sp-runtime",
+ "sp-runtime-interface",
+ "sp-session",
+ "sp-state-machine",
+ "sp-std",
+ "sp-transaction-pool",
+ "sp-trie",
+ "sp-version",
+ "substrate-wasm-builder",
+ "trie-db",
+]
+
+[[package]]
+name = "substrate-test-runtime-client"
+version = "2.0.0"
+source = "git+https://github.com/moondance-labs/substrate?branch=tanssi-polkadot-v0.9.43#11f2f27ba5af2d4e8eb1f73ae0056106be5bcfb2"
+dependencies = [
+ "futures 0.3.28",
+ "parity-scale-codec",
+ "sc-block-builder",
+ "sc-chain-spec",
+ "sc-client-api",
+ "sc-consensus",
+ "sp-api",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-core",
+ "sp-runtime",
+ "substrate-test-client",
+ "substrate-test-runtime",
+]
+
+[[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
 source = "git+https://github.com/moondance-labs/substrate?branch=tanssi-polkadot-v0.9.43#11f2f27ba5af2d4e8eb1f73ae0056106be5bcfb2"
@@ -13274,15 +13406,20 @@ dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-parachain-inherent",
  "futures 0.3.28",
+ "futures-timer",
  "log",
  "nimbus-consensus",
  "nimbus-primitives",
  "parity-scale-codec",
+ "parking_lot 0.12.1",
+ "sc-block-builder",
  "sc-client-api",
  "sc-consensus",
  "sc-consensus-aura",
  "sc-consensus-manual-seal",
  "sc-consensus-slots",
+ "sc-keystore",
+ "sc-network-test",
  "sc-telemetry",
  "sp-api",
  "sp-application-crypto",
@@ -13293,10 +13430,14 @@ dependencies = [
  "sp-consensus-slots",
  "sp-core",
  "sp-inherents",
+ "sp-keyring",
  "sp-keystore",
  "sp-runtime",
  "sp-timestamp",
  "substrate-prometheus-endpoint",
+ "substrate-test-runtime-client",
+ "tempfile",
+ "tokio",
  "tp-consensus",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13187,6 +13187,7 @@ dependencies = [
  "cumulus-client-consensus-aura",
  "cumulus-client-consensus-common",
  "cumulus-client-network",
+ "cumulus-client-pov-recovery",
  "cumulus-client-service",
  "cumulus-primitives-core",
  "cumulus-primitives-parachain-inherent",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,6 +151,7 @@ cumulus-client-collator = { git = "https://github.com/moondance-labs/cumulus", b
 cumulus-client-consensus-aura = { git = "https://github.com/moondance-labs/cumulus", branch = "tanssi-polkadot-v0.9.43", default-features = false }
 cumulus-client-consensus-common = { git = "https://github.com/moondance-labs/cumulus", branch = "tanssi-polkadot-v0.9.43", default-features = false }
 cumulus-client-network = { git = "https://github.com/moondance-labs/cumulus", branch = "tanssi-polkadot-v0.9.43", default-features = false }
+cumulus-client-pov-recovery = { git = "https://github.com/moondance-labs/cumulus", branch = "tanssi-polkadot-v0.9.43", default-features = false }
 cumulus-client-service = { git = "https://github.com/moondance-labs/cumulus", branch = "tanssi-polkadot-v0.9.43", default-features = false }
 cumulus-primitives-parachain-inherent = { git = "https://github.com/moondance-labs/cumulus", branch = "tanssi-polkadot-v0.9.43", default-features = false }
 cumulus-relay-chain-interface = { git = "https://github.com/moondance-labs/cumulus", branch = "tanssi-polkadot-v0.9.43", default-features = false }

--- a/client/consensus/src/lib.rs
+++ b/client/consensus/src/lib.rs
@@ -203,8 +203,8 @@ where
         if let Ok(nimbus_id) = NimbusId::from_slice(&type_public_pair) {
             // If we dont find any parachain that we are assigned to, return none
 
-            if let Ok(Some(para_id)) =
-                runtime_api.check_future_para_id_assignment(*parent_hash, nimbus_id.clone().into())
+            if let Ok(Some(para_id)) = runtime_api
+                .check_para_id_assignment_next_session(*parent_hash, nimbus_id.clone().into())
             {
                 log::debug!("Para id found for assignment {:?}", para_id);
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -88,6 +88,7 @@ cumulus-client-collator = { workspace = true }
 cumulus-client-consensus-aura = { workspace = true }
 cumulus-client-consensus-common = { workspace = true }
 cumulus-client-network = { workspace = true }
+cumulus-client-pov-recovery = { workspace = true }
 cumulus-client-service = { workspace = true }
 cumulus-primitives-core = { workspace = true }
 cumulus-primitives-parachain-inherent = { workspace = true }

--- a/node/src/container_chain_spawner.rs
+++ b/node/src/container_chain_spawner.rs
@@ -207,7 +207,12 @@ impl ContainerChainSpawner {
 
             // Signal that allows to gracefully stop a container chain
             let (signal, on_exit) = exit_future::signal();
-            let collate_on = collate_on.unwrap();
+            let collate_on = collate_on.unwrap_or_else(|| {
+                assert!(!validator, "collate_on should be Some if validator flag is true");
+
+                // When running a full node we don't need to send any collate_on messages, so make this a noop
+                Arc::new(move || Box::pin(std::future::ready(())))
+            });
 
             state
                 .lock()

--- a/node/src/container_chain_spawner.rs
+++ b/node/src/container_chain_spawner.rs
@@ -66,6 +66,7 @@ pub struct ContainerChainStuff {
     /// Async callback that enables collation on the orchestrator chain
     collate_on: Arc<dyn Fn() -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>,
     /// Handle that stops the container chain when dropped
+    #[allow(dead_code)]
     stop_handle: StopContainerChain,
 }
 

--- a/node/src/container_chain_spawner.rs
+++ b/node/src/container_chain_spawner.rs
@@ -312,51 +312,17 @@ impl ContainerChainSpawner {
 
     /// Handle `CcSpawnMsg::UpdateAssignment`
     async fn handle_update_assignment(&self, current: Option<ParaId>, next: Option<ParaId>) {
-        let mut running_chains_before = HashSet::new();
-        let mut running_chains_after = HashSet::new();
-        let mut call_collate_on = None;
-
-        // State mutex cannot be used in the same scope as `.await`, so start a new scope here
-        {
-            let mut state = self.state.lock().expect("poison error");
-
-            if (state.assigned_para_id, state.next_assigned_para_id) == (current, next) {
-                // If nothing changed there is nothing to update
-                return;
-            }
-
-            // Create a set with the container chains that were running before, and the container
-            // chains that should be running after the updated assignment. This is used to calculate
-            // the difference, and stop and start the required container chains.
-            running_chains_before.extend(state.assigned_para_id);
-            running_chains_before.extend(state.next_assigned_para_id);
-            // Ignore orchestrator_para_id because it cannot be stopped or started, it is always running
-            running_chains_before.remove(&self.orchestrator_para_id);
-
-            running_chains_after.extend(current);
-            running_chains_after.extend(next);
-            running_chains_after.remove(&self.orchestrator_para_id);
-
-            if state.assigned_para_id != current {
-                // If the assigned container chain was already running but not collating, we need to call collate_on
-                if let Some(para_id) = current {
-                    // Check if we get assigned to orchestrator chain
-                    if para_id == self.orchestrator_para_id {
-                        call_collate_on = Some(self.collate_on_tanssi.clone());
-                    } else {
-                        // When we get assigned to a different container chain, only need to call collate_on if it was already
-                        // running before
-                        if running_chains_before.contains(&para_id) {
-                            let c = state.spawned_container_chains.get(&para_id).unwrap();
-                            call_collate_on = Some(c.collate_on.clone());
-                        }
-                    }
-                }
-            }
-
-            state.assigned_para_id = current;
-            state.next_assigned_para_id = next;
-        }
+        let HandleUpdateAssignmentResult {
+            call_collate_on,
+            chains_to_stop,
+            chains_to_start,
+        } = handle_update_assignment_state_change(
+            &mut *self.state.lock().expect("poison error"),
+            self.orchestrator_para_id,
+            self.collate_on_tanssi.clone(),
+            current,
+            next,
+        );
 
         // Call collate_on, to start collation on a chain that was already running before
         if let Some(f) = call_collate_on {
@@ -364,16 +330,467 @@ impl ContainerChainSpawner {
         }
 
         // Stop all container chains that are no longer needed
-        for para_id in running_chains_before.difference(&running_chains_after) {
-            self.stop(*para_id);
+        for para_id in chains_to_stop {
+            self.stop(para_id);
         }
 
         // Start all new container chains (usually 1)
-        for para_id in running_chains_after.difference(&running_chains_before) {
+        for para_id in chains_to_start {
             // Edge case: when starting the node it may be assigned to a container chain, so we need to
             // start a container chain already collating.
-            let start_collation = Some(*para_id) == current;
-            self.spawn(*para_id, start_collation).await;
+            let start_collation = Some(para_id) == current;
+            self.spawn(para_id, start_collation).await;
         }
+    }
+}
+
+struct HandleUpdateAssignmentResult {
+    call_collate_on:
+        Option<Arc<dyn Fn() -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>>,
+    chains_to_stop: Vec<ParaId>,
+    chains_to_start: Vec<ParaId>,
+}
+
+// This is a separate function to allow testing
+fn handle_update_assignment_state_change(
+    state: &mut ContainerChainSpawnerState,
+    orchestrator_para_id: ParaId,
+    collate_on_tanssi: Arc<dyn Fn() -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>,
+    current: Option<ParaId>,
+    next: Option<ParaId>,
+) -> HandleUpdateAssignmentResult {
+    if (state.assigned_para_id, state.next_assigned_para_id) == (current, next) {
+        // If nothing changed there is nothing to update
+        return HandleUpdateAssignmentResult {
+            call_collate_on: None,
+            chains_to_stop: Default::default(),
+            chains_to_start: Default::default(),
+        };
+    }
+
+    // Create a set with the container chains that were running before, and the container
+    // chains that should be running after the updated assignment. This is used to calculate
+    // the difference, and stop and start the required container chains.
+    let mut running_chains_before = HashSet::new();
+    let mut running_chains_after = HashSet::new();
+    let mut call_collate_on = None;
+
+    running_chains_before.extend(state.assigned_para_id);
+    running_chains_before.extend(state.next_assigned_para_id);
+    // Ignore orchestrator_para_id because it cannot be stopped or started, it is always running
+    running_chains_before.remove(&orchestrator_para_id);
+
+    running_chains_after.extend(current);
+    running_chains_after.extend(next);
+    running_chains_after.remove(&orchestrator_para_id);
+
+    if state.assigned_para_id != current {
+        // If the assigned container chain was already running but not collating, we need to call collate_on
+        if let Some(para_id) = current {
+            // Check if we get assigned to orchestrator chain
+            if para_id == orchestrator_para_id {
+                call_collate_on = Some(collate_on_tanssi);
+            } else {
+                // When we get assigned to a different container chain, only need to call collate_on if it was already
+                // running before
+                if running_chains_before.contains(&para_id) {
+                    let c = state.spawned_container_chains.get(&para_id).unwrap();
+                    call_collate_on = Some(c.collate_on.clone());
+                }
+            }
+        }
+    }
+
+    state.assigned_para_id = current;
+    state.next_assigned_para_id = next;
+
+    let chains_to_stop = running_chains_before
+        .difference(&running_chains_after)
+        .copied()
+        .collect();
+    let chains_to_start = running_chains_after
+        .difference(&running_chains_before)
+        .copied()
+        .collect();
+
+    HandleUpdateAssignmentResult {
+        call_collate_on,
+        chains_to_stop,
+        chains_to_start,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::executor::block_on;
+
+    use super::*;
+
+    // Copy of ContainerChainSpawner with extra assertions for tests, and mocked spawn function.
+    struct MockContainerChainSpawner {
+        state: Arc<Mutex<ContainerChainSpawnerState>>,
+        orchestrator_para_id: ParaId,
+        collate_on_tanssi: Arc<dyn Fn() -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>,
+        // Keep track of the last CollateOn message, for tests
+        currently_collating_on: Arc<Mutex<Option<ParaId>>>,
+    }
+
+    impl MockContainerChainSpawner {
+        fn new() -> Self {
+            let orchestrator_para_id = 1000.into();
+            // The node always starts as an orchestrator chain collator
+            let currently_collating_on = Arc::new(Mutex::new(Some(orchestrator_para_id)));
+            let currently_collating_on2 = currently_collating_on.clone();
+            let collate_closure = move || async move {
+                let mut lco = currently_collating_on2.lock().unwrap();
+                // TODO: investigate why this assert fails
+                // TODO: found it, see comment in stop_collating_orchestrator
+                //assert_ne!(*lco, Some(orchestrator_para_id), "Received CollateOn message when we were already collating on this chain: {}", orchestrator_para_id);
+                *lco = Some(orchestrator_para_id);
+            };
+            let collate_on_tanssi: Arc<
+                dyn Fn() -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync,
+            > = Arc::new(move || Box::pin((collate_closure.clone())()));
+
+            Self {
+                state: Arc::new(Mutex::new(ContainerChainSpawnerState {
+                    spawned_container_chains: Default::default(),
+                    assigned_para_id: None,
+                    next_assigned_para_id: None,
+                })),
+                orchestrator_para_id,
+                collate_on_tanssi,
+                currently_collating_on,
+            }
+        }
+
+        async fn spawn(&self, container_chain_para_id: ParaId, start_collation: bool) {
+            let (signal, _on_exit) = exit_future::signal();
+            let currently_collating_on2 = self.currently_collating_on.clone();
+            let collate_closure = move || async move {
+                let mut lco = currently_collating_on2.lock().unwrap();
+                assert_ne!(
+                    *lco,
+                    Some(container_chain_para_id),
+                    "Received CollateOn message when we were already collating on this chain: {}",
+                    container_chain_para_id
+                );
+                *lco = Some(container_chain_para_id);
+            };
+            let collate_on: Arc<
+                dyn Fn() -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync,
+            > = Arc::new(move || Box::pin((collate_closure.clone())()));
+
+            let old = self
+                .state
+                .lock()
+                .expect("poison error")
+                .spawned_container_chains
+                .insert(
+                    container_chain_para_id,
+                    ContainerChainState {
+                        collate_on: collate_on.clone(),
+                        stop_handle: StopContainerChain(signal),
+                    },
+                );
+
+            assert!(
+                old.is_none(),
+                "tried to spawn a container chain that was already running: {}",
+                container_chain_para_id
+            );
+
+            if start_collation {
+                collate_on().await;
+            }
+        }
+
+        fn stop(&self, container_chain_para_id: ParaId) {
+            let stop_handle = self
+                .state
+                .lock()
+                .expect("poison error")
+                .spawned_container_chains
+                .remove(&container_chain_para_id);
+
+            match stop_handle {
+                Some(_stop_handle) => {
+                    log::info!("Stopping container chain {}", container_chain_para_id);
+                }
+                None => {
+                    panic!(
+                        "Tried to stop a container chain that is not running: {}",
+                        container_chain_para_id
+                    );
+                }
+            }
+
+            // Update currently_collating_on, if we stopped the chain we are no longer collating there
+            let mut lco = self.currently_collating_on.lock().unwrap();
+            if *lco == Some(container_chain_para_id) {
+                *lco = None;
+            }
+        }
+
+        fn handle_update_assignment(&self, current: Option<ParaId>, next: Option<ParaId>) {
+            let HandleUpdateAssignmentResult {
+                call_collate_on,
+                chains_to_stop,
+                chains_to_start,
+            } = handle_update_assignment_state_change(
+                &mut *self.state.lock().unwrap(),
+                self.orchestrator_para_id,
+                self.collate_on_tanssi.clone(),
+                current,
+                next,
+            );
+
+            // Assert we never start and stop the same container chain
+            for para_id in &chains_to_start {
+                assert!(
+                    !chains_to_stop.contains(para_id),
+                    "Tried to start and stop same container chain: {}",
+                    para_id
+                );
+            }
+            // Assert we never start or stop the orchestrator chain
+            assert!(!chains_to_start.contains(&self.orchestrator_para_id));
+            assert!(!chains_to_stop.contains(&self.orchestrator_para_id));
+
+            // Call collate_on, to start collation on a chain that was already running before
+            if let Some(f) = call_collate_on {
+                block_on(async { f().await });
+            }
+
+            // Stop all container chains that are no longer needed
+            for para_id in chains_to_stop {
+                self.stop(para_id);
+            }
+
+            // Start all new container chains (usually 1)
+            for para_id in chains_to_start {
+                // Edge case: when starting the node it may be assigned to a container chain, so we need to
+                // start a container chain already collating.
+                let start_collation = Some(para_id) == current;
+                block_on(async { self.spawn(para_id, start_collation).await });
+            }
+
+            // Assert that if we are currently assigned to a container chain, we are collating there
+            if let Some(para_id) = current {
+                self.assert_collating_on(Some(para_id));
+            } else {
+                // If we are not assigned anywhere we may be collating on the orchestrator chain,
+                // or we may not be collating anywhere
+                let currently_collating_on = *self.currently_collating_on.lock().unwrap();
+                assert!(
+                    currently_collating_on.is_none()
+                        || currently_collating_on == Some(self.orchestrator_para_id)
+                );
+            }
+        }
+
+        #[track_caller]
+        fn assert_collating_on(&self, para_id: Option<ParaId>) {
+            let currently_collating_on = *self.currently_collating_on.lock().unwrap();
+            assert_eq!(currently_collating_on, para_id);
+        }
+
+        #[track_caller]
+        fn assert_running_chains(&self, para_ids: &[ParaId]) {
+            let mut actually_running: Vec<ParaId> = self
+                .state
+                .lock()
+                .unwrap()
+                .spawned_container_chains
+                .keys()
+                .cloned()
+                .collect();
+            actually_running.sort();
+            let mut should_be_running = para_ids.to_vec();
+            should_be_running.sort();
+            assert_eq!(actually_running, should_be_running);
+        }
+    }
+
+    #[test]
+    fn starts_collating_on_tanssi() {
+        let m = MockContainerChainSpawner::new();
+        m.assert_collating_on(Some(1000.into()));
+        m.assert_running_chains(&[]);
+
+        m.handle_update_assignment(None, None);
+        m.assert_collating_on(Some(1000.into()));
+        m.assert_running_chains(&[]);
+    }
+
+    #[test]
+    fn assigned_to_orchestrator_chain() {
+        let m = MockContainerChainSpawner::new();
+
+        m.handle_update_assignment(Some(1000.into()), Some(1000.into()));
+        m.assert_collating_on(Some(1000.into()));
+        m.assert_running_chains(&[]);
+
+        m.handle_update_assignment(Some(1000.into()), None);
+        m.assert_collating_on(Some(1000.into()));
+        m.assert_running_chains(&[]);
+
+        m.handle_update_assignment(None, None);
+        m.assert_collating_on(Some(1000.into()));
+        m.assert_running_chains(&[]);
+
+        m.handle_update_assignment(None, Some(1000.into()));
+        m.assert_collating_on(Some(1000.into()));
+        m.assert_running_chains(&[]);
+
+        m.handle_update_assignment(Some(1000.into()), Some(1000.into()));
+        m.assert_collating_on(Some(1000.into()));
+        m.assert_running_chains(&[]);
+    }
+
+    #[test]
+    fn assigned_to_container_chain() {
+        let m = MockContainerChainSpawner::new();
+
+        m.handle_update_assignment(Some(2000.into()), Some(2000.into()));
+        m.assert_collating_on(Some(2000.into()));
+        m.assert_running_chains(&[2000.into()]);
+
+        m.handle_update_assignment(Some(2000.into()), None);
+        m.assert_collating_on(Some(2000.into()));
+        m.assert_running_chains(&[2000.into()]);
+
+        m.handle_update_assignment(None, None);
+        m.assert_collating_on(None);
+        m.assert_running_chains(&[]);
+
+        m.handle_update_assignment(None, Some(2000.into()));
+        m.assert_collating_on(None);
+        m.assert_running_chains(&[2000.into()]);
+
+        m.handle_update_assignment(Some(2000.into()), Some(2000.into()));
+        m.assert_collating_on(Some(2000.into()));
+        m.assert_running_chains(&[2000.into()]);
+    }
+
+    #[test]
+    fn spawn_container_chains() {
+        let m = MockContainerChainSpawner::new();
+
+        m.handle_update_assignment(Some(1000.into()), Some(2000.into()));
+        m.assert_collating_on(Some(1000.into()));
+        m.assert_running_chains(&[2000.into()]);
+
+        m.handle_update_assignment(Some(2000.into()), Some(2000.into()));
+        m.assert_collating_on(Some(2000.into()));
+        m.assert_running_chains(&[2000.into()]);
+
+        m.handle_update_assignment(Some(2000.into()), Some(2001.into()));
+        m.assert_collating_on(Some(2000.into()));
+        m.assert_running_chains(&[2000.into(), 2001.into()]);
+
+        m.handle_update_assignment(Some(2001.into()), Some(2001.into()));
+        m.assert_collating_on(Some(2001.into()));
+        m.assert_running_chains(&[2001.into()]);
+
+        m.handle_update_assignment(Some(2001.into()), Some(1000.into()));
+        m.assert_collating_on(Some(2001.into()));
+        m.assert_running_chains(&[2001.into()]);
+
+        m.handle_update_assignment(Some(1000.into()), Some(1000.into()));
+        m.assert_collating_on(Some(1000.into()));
+        m.assert_running_chains(&[]);
+    }
+
+    #[test]
+    fn swap_current_next() {
+        // Going from (2000, 2001) to (2001, 2000) shouldn't start or stop any container chains
+        let m: MockContainerChainSpawner = MockContainerChainSpawner::new();
+
+        m.handle_update_assignment(Some(2000.into()), Some(2001.into()));
+        m.assert_collating_on(Some(2000.into()));
+        m.assert_running_chains(&[2000.into(), 2001.into()]);
+
+        m.handle_update_assignment(Some(2001.into()), Some(2000.into()));
+        m.assert_collating_on(Some(2001.into()));
+        m.assert_running_chains(&[2000.into(), 2001.into()]);
+    }
+
+    #[test]
+    fn stop_collating_orchestrator() {
+        let m: MockContainerChainSpawner = MockContainerChainSpawner::new();
+
+        m.handle_update_assignment(Some(1000.into()), Some(1000.into()));
+        m.assert_collating_on(Some(1000.into()));
+        m.assert_running_chains(&[]);
+
+        m.handle_update_assignment(Some(1000.into()), None);
+        m.assert_collating_on(Some(1000.into()));
+        m.assert_running_chains(&[]);
+
+        m.handle_update_assignment(None, None);
+        m.assert_collating_on(Some(1000.into()));
+        m.assert_running_chains(&[]);
+
+        // TODO: this will send an unneeded CollateOn message, because the ContainerChainSpawner
+        // doesn't remember that the last message has been sent to the orchestrator chain,
+        // which is always running, so it is still collating.
+        m.handle_update_assignment(Some(1000.into()), None);
+        m.assert_collating_on(Some(1000.into()));
+        m.assert_running_chains(&[]);
+    }
+
+    #[test]
+    fn stop_collating_container() {
+        let m: MockContainerChainSpawner = MockContainerChainSpawner::new();
+
+        m.handle_update_assignment(Some(2000.into()), None);
+        m.assert_collating_on(Some(2000.into()));
+        m.assert_running_chains(&[2000.into()]);
+
+        m.handle_update_assignment(None, None);
+        m.assert_collating_on(None);
+        m.assert_running_chains(&[]);
+
+        m.handle_update_assignment(None, Some(2000.into()));
+        m.assert_collating_on(None);
+        m.assert_running_chains(&[2000.into()]);
+
+        // This will send a CollateOn message to the same chain as the last CollateOn,
+        // but this is needed because that chain has been stopped
+        m.handle_update_assignment(Some(2000.into()), Some(2000.into()));
+        m.assert_collating_on(Some(2000.into()));
+        m.assert_running_chains(&[2000.into()]);
+    }
+
+    #[test]
+    fn stop_collating_container_start_immediately() {
+        let m: MockContainerChainSpawner = MockContainerChainSpawner::new();
+
+        m.handle_update_assignment(Some(2000.into()), None);
+        m.assert_collating_on(Some(2000.into()));
+        m.assert_running_chains(&[2000.into()]);
+
+        m.handle_update_assignment(None, None);
+        m.assert_collating_on(None);
+        m.assert_running_chains(&[]);
+
+        // This will start the chain already collating
+        m.handle_update_assignment(Some(2000.into()), Some(2000.into()));
+        m.assert_collating_on(Some(2000.into()));
+        m.assert_running_chains(&[2000.into()]);
+    }
+
+    #[test]
+    fn stop_all_chains() {
+        let m: MockContainerChainSpawner = MockContainerChainSpawner::new();
+
+        m.handle_update_assignment(Some(2000.into()), Some(2001.into()));
+        m.assert_collating_on(Some(2000.into()));
+        m.assert_running_chains(&[2000.into(), 2001.into()]);
+
+        m.handle_update_assignment(None, None);
+        m.assert_collating_on(None);
+        m.assert_running_chains(&[]);
     }
 }

--- a/node/src/container_chain_spawner.rs
+++ b/node/src/container_chain_spawner.rs
@@ -394,7 +394,7 @@ fn handle_update_assignment_state_change(
                 // When we get assigned to a different container chain, only need to call collate_on if it was already
                 // running before
                 if running_chains_before.contains(&para_id) {
-                    let c = state.spawned_container_chains.get(&para_id).unwrap();
+                    let c = state.spawned_container_chains.get(&para_id).expect("container chain was running before so it should exist in spawned_container_chains");
                     call_collate_on = Some(c.collate_on.clone());
                 }
             }

--- a/node/src/container_chain_spawner.rs
+++ b/node/src/container_chain_spawner.rs
@@ -475,7 +475,7 @@ mod tests {
             let currently_collating_on2 = self.currently_collating_on.clone();
             let collate_closure = move || async move {
                 let mut cco = currently_collating_on2.lock().unwrap();
-                // TODO: this is also wrong, see comment in test fuzz2
+                // TODO: this is also wrong, see comment in test keep_collating_on_container
                 /*
                 assert_ne!(
                     *cco,

--- a/node/src/container_chain_spawner.rs
+++ b/node/src/container_chain_spawner.rs
@@ -208,7 +208,10 @@ impl ContainerChainSpawner {
             // Signal that allows to gracefully stop a container chain
             let (signal, on_exit) = exit_future::signal();
             let collate_on = collate_on.unwrap_or_else(|| {
-                assert!(!validator, "collate_on should be Some if validator flag is true");
+                assert!(
+                    !validator,
+                    "collate_on should be Some if validator flag is true"
+                );
 
                 // When running a full node we don't need to send any collate_on messages, so make this a noop
                 Arc::new(move || Box::pin(std::future::ready(())))

--- a/node/src/container_chain_spawner.rs
+++ b/node/src/container_chain_spawner.rs
@@ -64,12 +64,12 @@ pub struct ContainerChainSpawner {
 
 #[derive(Default)]
 pub struct ContainerChainSpawnerState {
-    spawned_container_chains: HashMap<ParaId, ContainerChainStuff>,
+    spawned_container_chains: HashMap<ParaId, ContainerChainState>,
     assigned_para_id: Option<ParaId>,
     next_assigned_para_id: Option<ParaId>,
 }
 
-pub struct ContainerChainStuff {
+pub struct ContainerChainState {
     /// Async callback that enables collation on the orchestrator chain
     collate_on: Arc<dyn Fn() -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>,
     /// Handle that stops the container chain when dropped
@@ -215,7 +215,7 @@ impl ContainerChainSpawner {
                 .spawned_container_chains
                 .insert(
                     container_chain_para_id,
-                    ContainerChainStuff {
+                    ContainerChainState {
                         collate_on: collate_on.clone(),
                         stop_handle: StopContainerChain(signal),
                     },

--- a/node/src/container_chain_spawner.rs
+++ b/node/src/container_chain_spawner.rs
@@ -322,8 +322,12 @@ impl ContainerChainSpawner {
                 return;
             }
 
+            // Create a set with the container chains that were running before, and the container
+            // chains that should be running after the updated assignment. This is used to calculate
+            // the difference, and stop and start the required container chains.
             running_chains_before.extend(state.assigned_para_id);
             running_chains_before.extend(state.next_assigned_para_id);
+            // Ignore orchestrator_para_id because it cannot be stopped or started, it is always running
             running_chains_before.remove(&self.orchestrator_para_id);
 
             running_chains_after.extend(current);

--- a/node/src/container_chain_spawner.rs
+++ b/node/src/container_chain_spawner.rs
@@ -317,7 +317,7 @@ impl ContainerChainSpawner {
             chains_to_stop,
             chains_to_start,
         } = handle_update_assignment_state_change(
-            self.state.lock().expect("poison error"),
+            &mut self.state.lock().expect("poison error"),
             self.orchestrator_para_id,
             self.collate_on_tanssi.clone(),
             current,

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -265,24 +265,26 @@ fn check_assigned_para_id(
     block_hash: H256,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Check current assignment
-    let res = tc_consensus::first_eligible_key::<Block, ParachainClient, NimbusPair>(
-        client_set_aside_for_cidp.as_ref(),
-        &block_hash,
-        sync_keystore.clone(),
-    );
-    let container_chain_para_id = res.map(|x| x.1);
+    let current_container_chain_para_id =
+        tc_consensus::first_eligible_key::<Block, ParachainClient, NimbusPair>(
+            client_set_aside_for_cidp.as_ref(),
+            &block_hash,
+            sync_keystore.clone(),
+        )
+        .map(|(_nimbus_key, para_id)| para_id);
 
     // Check assignment in the next session
-    let res2 = tc_consensus::first_eligible_key_next_session::<Block, ParachainClient, NimbusPair>(
-        client_set_aside_for_cidp.as_ref(),
-        &block_hash,
-        sync_keystore,
-    );
-    let future_container_chain_para_id = res2.map(|x| x.1);
+    let next_container_chain_para_id =
+        tc_consensus::first_eligible_key_next_session::<Block, ParachainClient, NimbusPair>(
+            client_set_aside_for_cidp.as_ref(),
+            &block_hash,
+            sync_keystore,
+        )
+        .map(|(_nimbus_key, para_id)| para_id);
 
     cc_spawn_tx.send(CcSpawnMsg::UpdateAssignment {
-        current: container_chain_para_id,
-        next: future_container_chain_para_id,
+        current: current_container_chain_para_id,
+        next: next_container_chain_para_id,
     })?;
 
     Ok(())

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -15,6 +15,7 @@
 // along with Tanssi.  If not, see <http://www.gnu.org/licenses/>
 
 //! Service and ServiceFactory implementation. Specialized wrapper over substrate service.
+
 use {
     crate::{
         cli::ContainerChainCli,
@@ -26,13 +27,14 @@ use {
         ParachainBlockImport as TParachainBlockImport, ParachainBlockImportMarker,
         ParachainConsensus,
     },
+    cumulus_client_pov_recovery::{PoVRecovery, RecoveryDelayRange},
     cumulus_client_service::{
         build_relay_chain_interface, prepare_node_config, start_collator, start_full_node,
         StartCollatorParams, StartFullNodeParams,
     },
     cumulus_primitives_core::{
         relay_chain::{CollatorPair, Hash as PHash},
-        ParaId,
+        CollectCollationInfo, ParaId,
     },
     cumulus_primitives_parachain_inherent::{
         MockValidationDataInherentDataProvider, MockXcmConfig,
@@ -40,12 +42,15 @@ use {
     cumulus_relay_chain_interface::RelayChainInterface,
     dancebox_runtime::{opaque::Block, RuntimeApi},
     frame_benchmarking_cli::SUBSTRATE_REFERENCE_HARDWARE,
-    futures::StreamExt,
+    futures::{channel::mpsc, StreamExt},
     nimbus_primitives::NimbusPair,
     pallet_registrar_runtime_api::RegistrarApi,
     polkadot_cli::ProvideRuntimeApi,
     polkadot_service::Handle,
-    sc_client_api::{AuxStore, Backend, BlockchainEvents, HeaderBackend, UsageProvider},
+    sc_client_api::{
+        AuxStore, Backend as BackendT, BlockBackend, BlockchainEvents, Finalizer, HeaderBackend,
+        UsageProvider,
+    },
     sc_consensus::{BlockImport, ImportQueue},
     sc_executor::{
         HeapAllocStrategy, NativeElseWasmExecutor, WasmExecutor, DEFAULT_HEAP_ALLOC_STRATEGY,
@@ -59,10 +64,16 @@ use {
     sc_telemetry::{Telemetry, TelemetryHandle, TelemetryWorker, TelemetryWorkerHandle},
     sp_api::StorageProof,
     sp_consensus::SyncOracle,
-    sp_core::{traits::SpawnEssentialNamed, H256},
+    sp_core::{
+        traits::{SpawnEssentialNamed, SpawnNamed},
+        H256,
+    },
     sp_keystore::KeystorePtr,
+    sp_runtime::traits::Block as BlockT,
     sp_state_machine::{Backend as StateBackend, StorageValue},
     std::{
+        future::Future,
+        pin::Pin,
         str::FromStr,
         sync::{Arc, Mutex},
         time::Duration,
@@ -278,7 +289,7 @@ fn check_assigned_para_id(
     if container_chain_para_id != *initial_assigned_para_id {
         if let Some(new_para_id) = container_chain_para_id {
             // Spawn new container chain node
-            cc_spawn_tx.send(CcSpawnMsg::Spawn(new_para_id))?;
+            cc_spawn_tx.send(CcSpawnMsg::CollateOn(new_para_id))?;
         }
 
         if let Some(prev_para_id) = *initial_assigned_para_id {
@@ -673,7 +684,11 @@ pub async fn start_node_impl_container(
     para_id: ParaId,
     orchestrator_para_id: ParaId,
     collator: bool,
-) -> sc_service::error::Result<(TaskManager, Arc<ParachainClient>)> {
+) -> sc_service::error::Result<(
+    TaskManager,
+    Arc<ParachainClient>,
+    Option<Arc<dyn Fn() -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>>,
+)> {
     let parachain_config = prepare_node_config(parachain_config);
     let block_import;
     let mut telemetry;
@@ -772,6 +787,9 @@ pub async fn start_node_impl_container(
     let overseer_handle = relay_chain_interface
         .overseer_handle()
         .map_err(|e| sc_service::Error::Application(Box::new(e)))?;
+    let mut start_collation: Option<
+        Arc<dyn Fn() -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>,
+    > = None;
 
     if collator {
         let parachain_consensus = build_consensus_container(
@@ -808,7 +826,32 @@ pub async fn start_node_impl_container(
             sync_service,
         };
 
-        start_collator(params).await?;
+        // Need to deconstruct it because `StartCollatorParams` does not implement Clone
+        let cumulus_client_collator::StartCollatorParams {
+            para_id,
+            runtime_api,
+            block_status,
+            announce_block,
+            overseer_handle,
+            spawner,
+            key,
+            parachain_consensus,
+        } = partial_start_collator(params)?;
+
+        let collate_closure = move || async move {
+            cumulus_client_collator::start_collator(cumulus_client_collator::StartCollatorParams {
+                para_id,
+                runtime_api,
+                block_status,
+                announce_block,
+                overseer_handle,
+                spawner,
+                key,
+                parachain_consensus,
+            })
+            .await
+        };
+        start_collation = Some(Arc::new(move || Box::pin((collate_closure.clone())())));
     } else {
         let params = StartFullNodeParams {
             client: client.clone(),
@@ -827,7 +870,103 @@ pub async fn start_node_impl_container(
 
     start_network.start_network();
 
-    Ok((task_manager, client))
+    Ok((task_manager, client, start_collation))
+}
+
+// Copy of `cumulus_client_service::start_collator`, that doesn't fully start the collator: it is
+// missing the final call to `cumulus_client_collator::start_collator`.
+// Returns the params of the call to `cumulus_client_collator::start_collator`.
+pub fn partial_start_collator<'a, Block, BS, Client, Backend, RCInterface, Spawner>(
+    StartCollatorParams {
+        block_status,
+        client,
+        announce_block,
+        spawner,
+        para_id,
+        task_manager,
+        relay_chain_interface,
+        parachain_consensus,
+        import_queue,
+        collator_key,
+        relay_chain_slot_duration,
+        recovery_handle,
+        sync_service,
+    }: StartCollatorParams<'a, Block, BS, Client, RCInterface, Spawner>,
+) -> sc_service::error::Result<
+    cumulus_client_collator::StartCollatorParams<Block, Client, BS, Spawner>,
+>
+where
+    Block: BlockT,
+    BS: BlockBackend<Block> + Send + Sync + 'static,
+    Client: Finalizer<Block, Backend>
+        + UsageProvider<Block>
+        + HeaderBackend<Block>
+        + Send
+        + Sync
+        + BlockBackend<Block>
+        + BlockchainEvents<Block>
+        + ProvideRuntimeApi<Block>
+        + 'static,
+    Client::Api: CollectCollationInfo<Block>,
+    for<'b> &'b Client: BlockImport<Block>,
+    Spawner: SpawnNamed + Clone + Send + Sync + 'static,
+    RCInterface: RelayChainInterface + Clone + 'static,
+    Backend: BackendT<Block> + 'static,
+{
+    // Given the sporadic nature of the explicit recovery operation and the
+    // possibility to retry infinite times this value is more than enough.
+    // In practice here we expect no more than one queued messages.
+    const RECOVERY_CHAN_SIZE: usize = 8;
+
+    let (recovery_chan_tx, recovery_chan_rx) = mpsc::channel(RECOVERY_CHAN_SIZE);
+
+    let consensus = cumulus_client_consensus_common::run_parachain_consensus(
+        para_id,
+        client.clone(),
+        relay_chain_interface.clone(),
+        announce_block.clone(),
+        Some(recovery_chan_tx),
+    );
+
+    task_manager
+        .spawn_essential_handle()
+        .spawn_blocking("cumulus-consensus", None, consensus);
+
+    let pov_recovery = PoVRecovery::new(
+        recovery_handle,
+        // We want that collators wait at maximum the relay chain slot duration before starting
+        // to recover blocks. Additionally, we wait at least half the slot time to give the
+        // relay chain the chance to increase availability.
+        RecoveryDelayRange {
+            min: relay_chain_slot_duration / 2,
+            max: relay_chain_slot_duration,
+        },
+        client.clone(),
+        import_queue,
+        relay_chain_interface.clone(),
+        para_id,
+        recovery_chan_rx,
+        sync_service,
+    );
+
+    task_manager
+        .spawn_essential_handle()
+        .spawn("cumulus-pov-recovery", None, pov_recovery.run());
+
+    let overseer_handle = relay_chain_interface
+        .overseer_handle()
+        .map_err(|e| sc_service::Error::Application(Box::new(e)))?;
+
+    Ok(cumulus_client_collator::StartCollatorParams {
+        runtime_api: client,
+        block_status,
+        announce_block,
+        overseer_handle,
+        spawner,
+        para_id,
+        key: collator_key,
+        parachain_consensus,
+    })
 }
 
 /// Build the import queue for the parachain runtime (manual seal).

--- a/primitives/consensus/src/lib.rs
+++ b/primitives/consensus/src/lib.rs
@@ -36,8 +36,9 @@ sp_api::decl_runtime_apis! {
         /// Returns the paraId for which an authority is assigned (if any)
         fn check_para_id_assignment(authority: AuthorityId) -> Option<ParaId>;
 
-        /// Returns the paraId for which an authority is assigned in the next session (if any)
-        fn check_future_para_id_assignment(authority: AuthorityId) -> Option<ParaId>;
+        /// Return the paraId assigned to a given authority on the next session.
+        /// On session boundary this returns the same as `check_para_id_assignment`.
+        fn check_para_id_assignment_next_session(authority: AuthorityId) -> Option<ParaId>;
     }
 }
 

--- a/primitives/consensus/src/lib.rs
+++ b/primitives/consensus/src/lib.rs
@@ -35,6 +35,9 @@ sp_api::decl_runtime_apis! {
 
         /// Returns the paraId for which an authority is assigned (if any)
         fn check_para_id_assignment(authority: AuthorityId) -> Option<ParaId>;
+
+        /// Returns the paraId for which an authority is assigned in the next session (if any)
+        fn check_future_para_id_assignment(authority: AuthorityId) -> Option<ParaId>;
     }
 }
 

--- a/runtime/dancebox/src/lib.rs
+++ b/runtime/dancebox/src/lib.rs
@@ -1082,6 +1082,23 @@ impl_runtime_apis! {
 
             assigned_authorities.para_id_of(&authority, self_para_id)
         }
+
+        /// Return the paraId assigned to a given authority on the next session
+        fn check_future_para_id_assignment(authority: NimbusId) -> Option<ParaId> {
+            let parent_number = System::block_number();
+            let should_end_session = <Runtime as pallet_session::Config>::ShouldEndSession::should_end_session(parent_number + 1);
+
+            let session_index = if should_end_session {
+                Session::current_index() +1
+            }
+            else {
+                Session::current_index()
+            };
+            let assigned_authorities = AuthorityAssignment::collator_container_chain(session_index+1)?;
+            let self_para_id = ParachainInfo::get();
+
+            assigned_authorities.para_id_of(&authority, self_para_id)
+        }
     }
 }
 

--- a/runtime/dancebox/src/lib.rs
+++ b/runtime/dancebox/src/lib.rs
@@ -1083,18 +1083,11 @@ impl_runtime_apis! {
             assigned_authorities.para_id_of(&authority, self_para_id)
         }
 
-        /// Return the paraId assigned to a given authority on the next session
-        fn check_future_para_id_assignment(authority: NimbusId) -> Option<ParaId> {
-            let parent_number = System::block_number();
-            let should_end_session = <Runtime as pallet_session::Config>::ShouldEndSession::should_end_session(parent_number + 1);
-
-            let session_index = if should_end_session {
-                Session::current_index() +1
-            }
-            else {
-                Session::current_index()
-            };
-            let assigned_authorities = AuthorityAssignment::collator_container_chain(session_index+1)?;
+        /// Return the paraId assigned to a given authority on the next session.
+        /// On session boundary this returns the same as `check_para_id_assignment`.
+        fn check_para_id_assignment_next_session(authority: NimbusId) -> Option<ParaId> {
+            let session_index = Session::current_index() + 1;
+            let assigned_authorities = AuthorityAssignment::collator_container_chain(session_index)?;
             let self_para_id = ParachainInfo::get();
 
             assigned_authorities.para_id_of(&authority, self_para_id)

--- a/runtime/dancebox/tests/integration_test.rs
+++ b/runtime/dancebox/tests/integration_test.rs
@@ -1281,6 +1281,185 @@ fn test_consensus_runtime_api_session_changes() {
 }
 
 #[test]
+fn test_consensus_runtime_api_next_session() {
+    ExtBuilder::default()
+        .with_balances(vec![
+            // Alice gets 10k extra tokens for her mapping deposit
+            (AccountId::from(ALICE), 210_000 * UNIT),
+            (AccountId::from(BOB), 100_000 * UNIT),
+            (AccountId::from(CHARLIE), 100_000 * UNIT),
+            (AccountId::from(DAVE), 100_000 * UNIT),
+        ])
+        .with_collators(vec![
+            (AccountId::from(ALICE), 210 * UNIT),
+            (AccountId::from(BOB), 100 * UNIT),
+        ])
+        .with_para_ids(vec![
+            (1001, empty_genesis_data(), vec![]),
+            (1002, empty_genesis_data(), vec![]),
+        ])
+        .with_config(pallet_configuration::HostConfiguration {
+            max_collators: 100,
+            min_orchestrator_collators: 2,
+            max_orchestrator_collators: 2,
+            collators_per_container: 2,
+        })
+        .build()
+        .execute_with(|| {
+            run_to_block(2);
+
+            let alice_id = get_aura_id_from_seed(&AccountId::from(ALICE).to_string());
+            let bob_id = get_aura_id_from_seed(&AccountId::from(BOB).to_string());
+
+            let charlie_id = get_aura_id_from_seed(&AccountId::from(CHARLIE).to_string());
+            let dave_id = get_aura_id_from_seed(&AccountId::from(DAVE).to_string());
+
+            assert_eq!(
+                Runtime::para_id_authorities(100.into()),
+                Some(vec![alice_id.clone(), bob_id.clone()])
+            );
+            assert_eq!(Runtime::para_id_authorities(1001.into()), Some(vec![]));
+            assert_eq!(
+                Runtime::check_para_id_assignment(alice_id.clone()),
+                Some(100.into())
+            );
+            assert_eq!(
+                Runtime::check_para_id_assignment(bob_id.clone()),
+                Some(100.into())
+            );
+            assert_eq!(Runtime::check_para_id_assignment(charlie_id.clone()), None);
+            assert_eq!(Runtime::check_para_id_assignment(dave_id.clone()), None);
+
+            // In the next session the assignment will not change
+            assert_eq!(
+                Runtime::check_para_id_assignment_next_session(alice_id.clone()),
+                Some(100.into())
+            );
+            assert_eq!(
+                Runtime::check_para_id_assignment_next_session(bob_id.clone()),
+                Some(100.into())
+            );
+            assert_eq!(
+                Runtime::check_para_id_assignment_next_session(charlie_id.clone()),
+                None,
+            );
+            assert_eq!(
+                Runtime::check_para_id_assignment_next_session(dave_id.clone()),
+                None,
+            );
+
+            // Set CHARLIE and DAVE keys
+            assert_ok!(Session::set_keys(
+                origin_of(CHARLIE.into()),
+                dancebox_runtime::SessionKeys {
+                    nimbus: charlie_id.clone(),
+                },
+                vec![]
+            ));
+            assert_ok!(Session::set_keys(
+                origin_of(DAVE.into()),
+                dancebox_runtime::SessionKeys {
+                    nimbus: dave_id.clone(),
+                },
+                vec![]
+            ));
+
+            // Set new invulnerables
+            assert_ok!(CollatorSelection::set_invulnerables(
+                root_origin(),
+                vec![ALICE.into(), BOB.into(), CHARLIE.into(), DAVE.into()]
+            ));
+
+            let session_two_edge = dancebox_runtime::Period::get() * 2;
+            // Let's run just 2 blocks before the session 2 change first
+            // Prediction should still be identical, as we are not in the
+            // edge of a session change
+            run_to_block(session_two_edge - 2);
+
+            assert_eq!(
+                Runtime::para_id_authorities(100.into()),
+                Some(vec![alice_id.clone(), bob_id.clone()])
+            );
+            assert_eq!(Runtime::para_id_authorities(1001.into()), Some(vec![]));
+            assert_eq!(
+                Runtime::check_para_id_assignment(alice_id.clone()),
+                Some(100.into())
+            );
+            assert_eq!(
+                Runtime::check_para_id_assignment(bob_id.clone()),
+                Some(100.into())
+            );
+            assert_eq!(Runtime::check_para_id_assignment(charlie_id.clone()), None);
+            assert_eq!(Runtime::check_para_id_assignment(dave_id.clone()), None);
+
+            // But in the next session the assignment will change, so future api returns different value
+            assert_eq!(
+                Runtime::check_para_id_assignment_next_session(alice_id.clone()),
+                Some(100.into())
+            );
+            assert_eq!(
+                Runtime::check_para_id_assignment_next_session(bob_id.clone()),
+                Some(100.into())
+            );
+            assert_eq!(
+                Runtime::check_para_id_assignment_next_session(charlie_id.clone()),
+                Some(1001.into()),
+            );
+            assert_eq!(
+                Runtime::check_para_id_assignment_next_session(dave_id.clone()),
+                Some(1001.into()),
+            );
+
+            // Now we run to session edge -1. Here we should predict already with
+            // authorities of the next block!
+            run_to_block(session_two_edge - 1);
+            assert_eq!(
+                Runtime::para_id_authorities(100.into()),
+                Some(vec![alice_id.clone(), bob_id.clone()])
+            );
+            assert_eq!(
+                Runtime::para_id_authorities(1001.into()),
+                Some(vec![charlie_id.clone(), dave_id.clone()])
+            );
+            assert_eq!(
+                Runtime::check_para_id_assignment(alice_id.clone()),
+                Some(100.into())
+            );
+            assert_eq!(
+                Runtime::check_para_id_assignment(bob_id.clone()),
+                Some(100.into())
+            );
+            assert_eq!(
+                Runtime::check_para_id_assignment(charlie_id.clone()),
+                Some(1001.into())
+            );
+            assert_eq!(
+                Runtime::check_para_id_assignment(dave_id.clone()),
+                Some(1001.into())
+            );
+
+            // check_para_id_assignment_next_session returns the same value as check_para_id_assignment
+            // because we are on a session boundary
+            assert_eq!(
+                Runtime::check_para_id_assignment_next_session(alice_id),
+                Some(100.into())
+            );
+            assert_eq!(
+                Runtime::check_para_id_assignment_next_session(bob_id),
+                Some(100.into())
+            );
+            assert_eq!(
+                Runtime::check_para_id_assignment_next_session(charlie_id),
+                Some(1001.into())
+            );
+            assert_eq!(
+                Runtime::check_para_id_assignment_next_session(dave_id),
+                Some(1001.into())
+            );
+        });
+}
+
+#[test]
 fn test_author_noting_self_para_id_not_noting() {
     ExtBuilder::default()
         .with_balances(vec![

--- a/test/moonwall.config.json
+++ b/test/moonwall.config.json
@@ -78,7 +78,8 @@
       "foundation": {
         "type": "zombie",
         "zombieSpec": {
-          "configPath": "./configs/zombieTanssi.json"
+          "configPath": "./configs/zombieTanssi.json",
+          "skipBlockCheck": ["Container2002"]
         }
       },
       "connections": [
@@ -101,6 +102,11 @@
           "name": "Container2001",
           "type": "polkadotJs",
           "endpoints": ["ws://127.0.0.1:9950"]
+        },
+        {
+          "name": "Container2002",
+          "type": "polkadotJs",
+          "endpoints": ["ws://127.0.0.1:9951"]
         },
         {
           "name": "ethers",


### PR DESCRIPTION
This PR allows starting container chains that will start collating in the future, for example in the next session.

The main feature is the `partial_start_collator` function, which starts the collation subsystem for a container chain but doesn't enable it, leaving that to the caller. This works the same way as the `collate_on_tanssi` feature, which has already been implemented before.

Now we start container chains one session in advance, and start collating later when they we are actually assigned. 

Also changed the way `ContainerChainSpawner` works, instead of having `Start` and `Stop` messages, we now only have a `UpdateAssignment` message. This allows the `ContainerChainSpawner` to keep track of which container chains should be running or should be stopped, and which one should be collating.