### PR TITLE
Change AuthorNoting to include block number, and add runtime api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6510,12 +6510,8 @@ dependencies = [
 name = "pallet-author-noting-runtime-api"
 version = "0.1.0"
 dependencies = [
- "frame-support",
- "pallet-registrar",
  "parity-scale-codec",
- "scale-info",
  "sp-api",
- "tp-container-chain-genesis-data",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2260,6 +2260,7 @@ dependencies = [
  "nimbus-primitives",
  "pallet-author-inherent",
  "pallet-author-noting",
+ "pallet-author-noting-runtime-api",
  "pallet-authority-assignment",
  "pallet-authority-mapping",
  "pallet-balances",
@@ -6503,6 +6504,18 @@ dependencies = [
  "tp-chain-state-snapshot",
  "tp-core",
  "tp-traits",
+]
+
+[[package]]
+name = "pallet-author-noting-runtime-api"
+version = "0.1.0"
+dependencies = [
+ "frame-support",
+ "pallet-registrar",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api",
+ "tp-container-chain-genesis-data",
 ]
 
 [[package]]
@@ -13333,6 +13346,7 @@ dependencies = [
  "log",
  "nimbus-consensus",
  "nimbus-primitives",
+ "pallet-author-noting-runtime-api",
  "pallet-collator-assignment-runtime-api",
  "pallet-configuration",
  "pallet-registrar-runtime-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ repository = "https://github.com/moondance-labs/tanssi"
 [workspace.dependencies]
 # Members
 pallet-author-noting = { path = "pallets/author-noting", default-features = false }
+pallet-author-noting-runtime-api = { path = "pallets/author-noting/rpc/runtime-api", default-features = false }
 pallet-authority-assignment = { path = "pallets/authority-assignment", default-features = false }
 pallet-authority-mapping = { path = "pallets/authority-mapping", default-features = false }
 pallet-collator-assignment = { path = "pallets/collator-assignment", default-features = false }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -23,6 +23,7 @@ tokio = { workspace = true }
 # Local
 ccp-authorities-noting-inherent = { workspace = true, features = [ "std" ] }
 dancebox-runtime = { workspace = true, features = [ "std" ] }
+pallet-author-noting-runtime-api = { workspace = true, features = [ "std" ] }
 pallet-collator-assignment-runtime-api = { workspace = true, features = [ "std" ] }
 pallet-configuration = { workspace = true, features = [ "std" ] }
 pallet-registrar-runtime-api = { workspace = true, features = [ "std" ] }

--- a/pallets/author-noting/rpc/runtime-api/Cargo.toml
+++ b/pallets/author-noting/rpc/runtime-api/Cargo.toml
@@ -9,17 +9,12 @@ version = "0.1.0"
 [package.metadata.docs.rs]
 targets = [ "x86_64-unknown-linux-gnu" ]
 [dependencies]
-frame-support = { workspace = true }
-pallet-registrar = { workspace = true }
 parity-scale-codec = { workspace = true }
-scale-info = { workspace = true }
 sp-api = { workspace = true }
-tp-container-chain-genesis-data = { workspace = true }
 
 [features]
 default = [ "std" ]
 std = [
 	"parity-scale-codec/std",
 	"sp-api/std",
-	"tp-container-chain-genesis-data/std",
 ]

--- a/pallets/author-noting/rpc/runtime-api/Cargo.toml
+++ b/pallets/author-noting/rpc/runtime-api/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "pallet-author-noting-runtime-api"
+authors = { workspace = true }
+description = "Runtime API definition of pallet-author-noting"
+edition = "2021"
+license = "GPL-3.0-only"
+version = "0.1.0"
+
+[package.metadata.docs.rs]
+targets = [ "x86_64-unknown-linux-gnu" ]
+[dependencies]
+frame-support = { workspace = true }
+pallet-registrar = { workspace = true }
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true }
+sp-api = { workspace = true }
+tp-container-chain-genesis-data = { workspace = true }
+
+[features]
+default = [ "std" ]
+std = [
+	"parity-scale-codec/std",
+	"sp-api/std",
+	"tp-container-chain-genesis-data/std",
+]

--- a/pallets/author-noting/rpc/runtime-api/src/lib.rs
+++ b/pallets/author-noting/rpc/runtime-api/src/lib.rs
@@ -1,0 +1,31 @@
+// Copyright (C) Moondance Labs Ltd.
+// This file is part of Tanssi.
+
+// Tanssi is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Tanssi is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Tanssi.  If not, see <http://www.gnu.org/licenses/>
+
+//! Runtime API for Author Noting pallet
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+sp_api::decl_runtime_apis! {
+    pub trait AuthorNotingApi<AccountId, BlockNumber, ParaId>
+    where
+        AccountId: parity_scale_codec::Codec,
+        BlockNumber: parity_scale_codec::Codec,
+        ParaId: parity_scale_codec::Codec,
+    {
+        fn latest_block_number(para_id: ParaId) -> Option<BlockNumber>;
+        fn latest_author(para_id: ParaId) -> Option<AccountId>;
+    }
+}

--- a/pallets/author-noting/src/benchmarks.rs
+++ b/pallets/author-noting/src/benchmarks.rs
@@ -85,8 +85,9 @@ benchmarks! {
 
     set_author {
         let para_id = 1000.into();
+        let block_number = 1;
         let author: T::AccountId = account("account id", 0u32, 0u32);
-    }: _(RawOrigin::Root, para_id, author)
+    }: _(RawOrigin::Root, para_id, block_number, author)
 
     impl_benchmark_test_suite!(
         Pallet,

--- a/pallets/author-noting/src/tests.rs
+++ b/pallets/author-noting/src/tests.rs
@@ -59,7 +59,10 @@ fn test_author_id_insertion() {
             _ => unreachable!(),
         })
         .add(1, || {
-            assert_eq!(AuthorNoting::latest_author(ParaId::from(1001)), Some((1, 13u64)));
+            assert_eq!(
+                AuthorNoting::latest_author(ParaId::from(1001)),
+                Some((1, 13u64))
+            );
         });
 }
 
@@ -159,12 +162,21 @@ fn test_author_id_insertion_many_paras() {
             MockData::mutate(|m| {
                 m.container_chains = vec![1001.into(), 1002.into()];
             });
-            assert_eq!(AuthorNoting::latest_author(ParaId::from(1001)), Some((1, 10u64)));
+            assert_eq!(
+                AuthorNoting::latest_author(ParaId::from(1001)),
+                Some((1, 10u64))
+            );
             assert_eq!(AuthorNoting::latest_author(ParaId::from(1002)), None);
         })
         .add(2, || {
-            assert_eq!(AuthorNoting::latest_author(ParaId::from(1001)), Some((2, 13u64)));
-            assert_eq!(AuthorNoting::latest_author(ParaId::from(1002)), Some((1, 14u64)));
+            assert_eq!(
+                AuthorNoting::latest_author(ParaId::from(1001)),
+                Some((2, 13u64))
+            );
+            assert_eq!(
+                AuthorNoting::latest_author(ParaId::from(1002)),
+                Some((1, 14u64))
+            );
         });
 }
 
@@ -194,7 +206,10 @@ fn test_should_panic_with_invalid_proof_root() {
         // Insert an invalid root, not matching the proof generated
         .with_overriden_state_root(H256::default())
         .add(1, || {
-            assert_eq!(AuthorNoting::latest_author(ParaId::from(1001)), Some((1, 13u64)));
+            assert_eq!(
+                AuthorNoting::latest_author(ParaId::from(1001)),
+                Some((1, 13u64))
+            );
         });
 }
 
@@ -227,7 +242,10 @@ fn test_should_panic_with_invalid_proof_state() {
         // Insert a proof, not matching the root generated
         .with_overriden_state_proof(relay_chain_state)
         .add(1, || {
-            assert_eq!(AuthorNoting::latest_author(ParaId::from(1001)), Some((1, 13u64)));
+            assert_eq!(
+                AuthorNoting::latest_author(ParaId::from(1001)),
+                Some((1, 13u64))
+            );
         });
 }
 
@@ -435,14 +453,20 @@ fn test_set_author() {
             _ => unreachable!(),
         })
         .add(1, || {
-            assert_eq!(AuthorNoting::latest_author(ParaId::from(1001)), Some((1, 13u64)));
+            assert_eq!(
+                AuthorNoting::latest_author(ParaId::from(1001)),
+                Some((1, 13u64))
+            );
             assert_ok!(AuthorNoting::set_author(
                 RuntimeOrigin::root(),
                 1001.into(),
                 1,
                 14u64,
             ));
-            assert_eq!(AuthorNoting::latest_author(ParaId::from(1001)), Some((1, 14u64)));
+            assert_eq!(
+                AuthorNoting::latest_author(ParaId::from(1001)),
+                Some((1, 14u64))
+            );
             System::assert_last_event(
                 Event::LatestAuthorChanged {
                     para_id: 1001.into(),

--- a/pallets/author-noting/src/tests.rs
+++ b/pallets/author-noting/src/tests.rs
@@ -47,7 +47,7 @@ fn test_author_id_insertion() {
                 s.author_id =
                     HeaderAs::NonEncoded(sp_runtime::generic::Header::<u32, BlakeTwo256> {
                         parent_hash: Default::default(),
-                        number: Default::default(),
+                        number: 1,
                         state_root: Default::default(),
                         extrinsics_root: Default::default(),
                         digest: sp_runtime::generic::Digest {
@@ -59,7 +59,7 @@ fn test_author_id_insertion() {
             _ => unreachable!(),
         })
         .add(1, || {
-            assert_eq!(AuthorNoting::latest_author(ParaId::from(1001)), Some(13u64));
+            assert_eq!(AuthorNoting::latest_author(ParaId::from(1001)), Some((1, 13u64)));
         });
 }
 
@@ -93,7 +93,7 @@ fn test_author_id_insertion_real_data() {
             assert_eq!(
                 AuthorNoting::latest_author(ParaId::from(1001)),
                 // Our mock author fetcher will just note the slot
-                Some(140006956u64)
+                Some((3511063, 140006956))
             );
         });
 }
@@ -111,7 +111,7 @@ fn test_author_id_insertion_many_paras() {
                 s.author_id =
                     HeaderAs::NonEncoded(sp_runtime::generic::Header::<u32, BlakeTwo256> {
                         parent_hash: Default::default(),
-                        number: Default::default(),
+                        number: 1,
                         state_root: Default::default(),
                         extrinsics_root: Default::default(),
                         digest: sp_runtime::generic::Digest {
@@ -127,7 +127,7 @@ fn test_author_id_insertion_many_paras() {
                 s.author_id =
                     HeaderAs::NonEncoded(sp_runtime::generic::Header::<u32, BlakeTwo256> {
                         parent_hash: Default::default(),
-                        number: Default::default(),
+                        number: 2,
                         state_root: Default::default(),
                         extrinsics_root: Default::default(),
                         digest: sp_runtime::generic::Digest {
@@ -142,7 +142,7 @@ fn test_author_id_insertion_many_paras() {
                 s.author_id =
                     HeaderAs::NonEncoded(sp_runtime::generic::Header::<u32, BlakeTwo256> {
                         parent_hash: Default::default(),
-                        number: Default::default(),
+                        number: 1,
                         state_root: Default::default(),
                         extrinsics_root: Default::default(),
                         digest: sp_runtime::generic::Digest {
@@ -159,12 +159,12 @@ fn test_author_id_insertion_many_paras() {
             MockData::mutate(|m| {
                 m.container_chains = vec![1001.into(), 1002.into()];
             });
-            assert_eq!(AuthorNoting::latest_author(ParaId::from(1001)), Some(10u64));
+            assert_eq!(AuthorNoting::latest_author(ParaId::from(1001)), Some((1, 10u64)));
             assert_eq!(AuthorNoting::latest_author(ParaId::from(1002)), None);
         })
         .add(2, || {
-            assert_eq!(AuthorNoting::latest_author(ParaId::from(1001)), Some(13u64));
-            assert_eq!(AuthorNoting::latest_author(ParaId::from(1002)), Some(14u64));
+            assert_eq!(AuthorNoting::latest_author(ParaId::from(1001)), Some((2, 13u64)));
+            assert_eq!(AuthorNoting::latest_author(ParaId::from(1002)), Some((1, 14u64)));
         });
 }
 
@@ -180,7 +180,7 @@ fn test_should_panic_with_invalid_proof_root() {
                 s.author_id =
                     HeaderAs::NonEncoded(sp_runtime::generic::Header::<u32, BlakeTwo256> {
                         parent_hash: Default::default(),
-                        number: Default::default(),
+                        number: 1,
                         state_root: Default::default(),
                         extrinsics_root: Default::default(),
                         digest: sp_runtime::generic::Digest {
@@ -194,7 +194,7 @@ fn test_should_panic_with_invalid_proof_root() {
         // Insert an invalid root, not matching the proof generated
         .with_overriden_state_root(H256::default())
         .add(1, || {
-            assert_eq!(AuthorNoting::latest_author(ParaId::from(1001)), Some(13u64));
+            assert_eq!(AuthorNoting::latest_author(ParaId::from(1001)), Some((1, 13u64)));
         });
 }
 
@@ -213,7 +213,7 @@ fn test_should_panic_with_invalid_proof_state() {
                 s.author_id =
                     HeaderAs::NonEncoded(sp_runtime::generic::Header::<u32, BlakeTwo256> {
                         parent_hash: Default::default(),
-                        number: Default::default(),
+                        number: 1,
                         state_root: Default::default(),
                         extrinsics_root: Default::default(),
                         digest: sp_runtime::generic::Digest {
@@ -227,7 +227,7 @@ fn test_should_panic_with_invalid_proof_state() {
         // Insert a proof, not matching the root generated
         .with_overriden_state_proof(relay_chain_state)
         .add(1, || {
-            assert_eq!(AuthorNoting::latest_author(ParaId::from(1001)), Some(13u64));
+            assert_eq!(AuthorNoting::latest_author(ParaId::from(1001)), Some((1, 13u64)));
         });
 }
 
@@ -423,7 +423,7 @@ fn test_set_author() {
                 s.author_id =
                     HeaderAs::NonEncoded(sp_runtime::generic::Header::<u32, BlakeTwo256> {
                         parent_hash: Default::default(),
-                        number: Default::default(),
+                        number: 1,
                         state_root: Default::default(),
                         extrinsics_root: Default::default(),
                         digest: sp_runtime::generic::Digest {
@@ -435,16 +435,18 @@ fn test_set_author() {
             _ => unreachable!(),
         })
         .add(1, || {
-            assert_eq!(AuthorNoting::latest_author(ParaId::from(1001)), Some(13u64));
+            assert_eq!(AuthorNoting::latest_author(ParaId::from(1001)), Some((1, 13u64)));
             assert_ok!(AuthorNoting::set_author(
                 RuntimeOrigin::root(),
                 1001.into(),
-                14u64
+                1,
+                14u64,
             ));
-            assert_eq!(AuthorNoting::latest_author(ParaId::from(1001)), Some(14u64));
+            assert_eq!(AuthorNoting::latest_author(ParaId::from(1001)), Some((1, 14u64)));
             System::assert_last_event(
                 Event::LatestAuthorChanged {
                     para_id: 1001.into(),
+                    block_number: 1,
                     new_author: 14u64,
                 }
                 .into(),
@@ -561,7 +563,8 @@ fn weights_assigned_to_extrinsics_are_correct() {
         assert_eq!(
             crate::Call::<Test>::set_author {
                 para_id: 1.into(),
-                new: 1u64
+                block_number: 1,
+                author: 1u64
             }
             .get_dispatch_info()
             .weight,

--- a/pallets/author-noting/src/tests.rs
+++ b/pallets/author-noting/src/tests.rs
@@ -15,7 +15,7 @@
 // along with Tanssi.  If not, see <http://www.gnu.org/licenses/>
 
 use {
-    crate::{mock::*, Event},
+    crate::{mock::*, ContainerChainBlockInfo, Event},
     cumulus_primitives_core::ParaId,
     frame_support::{
         assert_ok,
@@ -61,7 +61,10 @@ fn test_author_id_insertion() {
         .add(1, || {
             assert_eq!(
                 AuthorNoting::latest_author(ParaId::from(1001)),
-                Some((1, 13u64))
+                Some(ContainerChainBlockInfo {
+                    block_number: 1,
+                    author: 13u64
+                })
             );
         });
 }
@@ -96,7 +99,10 @@ fn test_author_id_insertion_real_data() {
             assert_eq!(
                 AuthorNoting::latest_author(ParaId::from(1001)),
                 // Our mock author fetcher will just note the slot
-                Some((3511063, 140006956))
+                Some(ContainerChainBlockInfo {
+                    block_number: 3511063,
+                    author: 140006956
+                })
             );
         });
 }
@@ -164,18 +170,27 @@ fn test_author_id_insertion_many_paras() {
             });
             assert_eq!(
                 AuthorNoting::latest_author(ParaId::from(1001)),
-                Some((1, 10u64))
+                Some(ContainerChainBlockInfo {
+                    block_number: 1,
+                    author: 10u64
+                })
             );
             assert_eq!(AuthorNoting::latest_author(ParaId::from(1002)), None);
         })
         .add(2, || {
             assert_eq!(
                 AuthorNoting::latest_author(ParaId::from(1001)),
-                Some((2, 13u64))
+                Some(ContainerChainBlockInfo {
+                    block_number: 2,
+                    author: 13u64
+                })
             );
             assert_eq!(
                 AuthorNoting::latest_author(ParaId::from(1002)),
-                Some((1, 14u64))
+                Some(ContainerChainBlockInfo {
+                    block_number: 1,
+                    author: 14u64
+                })
             );
         });
 }
@@ -208,7 +223,10 @@ fn test_should_panic_with_invalid_proof_root() {
         .add(1, || {
             assert_eq!(
                 AuthorNoting::latest_author(ParaId::from(1001)),
-                Some((1, 13u64))
+                Some(ContainerChainBlockInfo {
+                    block_number: 1,
+                    author: 13u64
+                })
             );
         });
 }
@@ -244,7 +262,10 @@ fn test_should_panic_with_invalid_proof_state() {
         .add(1, || {
             assert_eq!(
                 AuthorNoting::latest_author(ParaId::from(1001)),
-                Some((1, 13u64))
+                Some(ContainerChainBlockInfo {
+                    block_number: 1,
+                    author: 13u64
+                })
             );
         });
 }
@@ -455,7 +476,10 @@ fn test_set_author() {
         .add(1, || {
             assert_eq!(
                 AuthorNoting::latest_author(ParaId::from(1001)),
-                Some((1, 13u64))
+                Some(ContainerChainBlockInfo {
+                    block_number: 1,
+                    author: 13u64
+                })
             );
             assert_ok!(AuthorNoting::set_author(
                 RuntimeOrigin::root(),
@@ -465,7 +489,10 @@ fn test_set_author() {
             ));
             assert_eq!(
                 AuthorNoting::latest_author(ParaId::from(1001)),
-                Some((1, 14u64))
+                Some(ContainerChainBlockInfo {
+                    block_number: 1,
+                    author: 14u64
+                })
             );
             System::assert_last_event(
                 Event::LatestAuthorChanged {

--- a/runtime/dancebox/Cargo.toml
+++ b/runtime/dancebox/Cargo.toml
@@ -19,6 +19,7 @@ smallvec = { workspace = true }
 
 # Own
 pallet-author-noting = { workspace = true }
+pallet-author-noting-runtime-api = { workspace = true }
 pallet-authority-assignment = { workspace = true }
 pallet-authority-mapping = { workspace = true }
 pallet-collator-assignment = { workspace = true }

--- a/runtime/dancebox/src/lib.rs
+++ b/runtime/dancebox/src/lib.rs
@@ -1050,11 +1050,11 @@ impl_runtime_apis! {
         ParaId: parity_scale_codec::Codec,
     {
         fn latest_block_number(para_id: ParaId) -> Option<BlockNumber> {
-            AuthorNoting::latest_author(para_id).map(|(block_number, _author)| block_number)
+            AuthorNoting::latest_author(para_id).map(|info| info.block_number)
         }
 
         fn latest_author(para_id: ParaId) -> Option<AccountId> {
-            AuthorNoting::latest_author(para_id).map(|(_block_number, author)| author)
+            AuthorNoting::latest_author(para_id).map(|info| info.author)
         }
     }
 

--- a/runtime/dancebox/src/lib.rs
+++ b/runtime/dancebox/src/lib.rs
@@ -1043,6 +1043,21 @@ impl_runtime_apis! {
         }
     }
 
+    impl pallet_author_noting_runtime_api::AuthorNotingApi<Block, AccountId, BlockNumber, ParaId> for Runtime
+        where
+        AccountId: parity_scale_codec::Codec,
+        BlockNumber: parity_scale_codec::Codec,
+        ParaId: parity_scale_codec::Codec,
+    {
+        fn latest_block_number(para_id: ParaId) -> Option<BlockNumber> {
+            AuthorNoting::latest_author(para_id).map(|(block_number, _author)| block_number)
+        }
+
+        fn latest_author(para_id: ParaId) -> Option<AccountId> {
+            AuthorNoting::latest_author(para_id).map(|(_block_number, author)| author)
+        }
+    }
+
     impl tp_consensus::TanssiAuthorityAssignmentApi<Block, NimbusId> for Runtime {
         /// Return the current authorities assigned to a given paraId
         fn para_id_authorities(para_id: ParaId) -> Option<Vec<NimbusId>> {

--- a/runtime/dancebox/tests/integration_test.rs
+++ b/runtime/dancebox/tests/integration_test.rs
@@ -1532,7 +1532,7 @@ fn test_author_noting_not_self_para() {
             s.para_id = other_para;
             s.author_id = HeaderAs::NonEncoded(sp_runtime::generic::Header::<u32, BlakeTwo256> {
                 parent_hash: Default::default(),
-                number: Default::default(),
+                number: 1,
                 state_root: Default::default(),
                 extrinsics_root: Default::default(),
                 digest: sp_runtime::generic::Digest {
@@ -1545,7 +1545,7 @@ fn test_author_noting_not_self_para() {
 
             assert_eq!(
                 AuthorNoting::latest_author(other_para),
-                Some(AccountId::from(DAVE))
+                Some((1, AccountId::from(DAVE)))
             );
         });
 }

--- a/test/suites/para/test_tanssi_containers.ts
+++ b/test/suites/para/test_tanssi_containers.ts
@@ -168,8 +168,8 @@ describeSuite({
         const author2000 = await paraApi.query.authorNoting.latestAuthor(paraId2000);
         const author2001 = await paraApi.query.authorNoting.latestAuthor(paraId2001);
 
-        expect(containerChainCollators2000.includes(author2000.toJSON()[1])).to.be.true;
-        expect(containerChainCollators2001.includes(author2001.toJSON()[1])).to.be.true;
+        expect(containerChainCollators2000.includes(author2000.toJSON().author)).to.be.true;
+        expect(containerChainCollators2001.includes(author2001.toJSON().author)).to.be.true;
       },
     });
 

--- a/test/suites/para/test_tanssi_containers.ts
+++ b/test/suites/para/test_tanssi_containers.ts
@@ -168,8 +168,8 @@ describeSuite({
         const author2000 = await paraApi.query.authorNoting.latestAuthor(paraId2000);
         const author2001 = await paraApi.query.authorNoting.latestAuthor(paraId2001);
 
-        expect(containerChainCollators2000.includes(author2000.toString())).to.be.true;
-        expect(containerChainCollators2001.includes(author2001.toString())).to.be.true;
+        expect(containerChainCollators2000.includes(author2000.toJSON()[1])).to.be.true;
+        expect(containerChainCollators2001.includes(author2001.toJSON()[1])).to.be.true;
       },
     });
 


### PR DESCRIPTION
Change type of `pallet_author_noting::LatestAuthor` storage item from `AccountId` to `(BlockNumber, AccountId)`. This is because we want to store the container chain block number along with the author.

Add runtime api that allows to query latest author and latest block number for a container chain.