### PR TITLE
Fix race condition in zombienet test

### DIFF
--- a/test/suites/warp-sync/test_warp_sync.ts
+++ b/test/suites/warp-sync/test_warp_sync.ts
@@ -194,6 +194,7 @@ describeSuite({
     it({
       id: "T13",
       title: "Collator1000-03 is producing blocks on Container 2000",
+      timeout: 300000,
       test: async function () {
         const blockStart = (await container2000Api.rpc.chain.getBlock()).block.header.number.toNumber();
         // Wait up to 8 blocks, giving the new collator 4 chances to build a block

--- a/test/suites/warp-sync/test_warp_sync.ts
+++ b/test/suites/warp-sync/test_warp_sync.ts
@@ -213,7 +213,7 @@ describeSuite({
             if (author == getKeyringNimbusIdHex("Collator1000-03")) {
                 break;
             }
-            await context.waitBlock(1, "Tanssi");
+            await context.waitBlock(1, "Container2000");
         }
 
         expect(authors).to.contain(getKeyringNimbusIdHex("Collator1000-03"))


### PR DESCRIPTION
context.waitBlock was waiting for a new block on the wrong chain, meaning that the container chain could still be at block N when we call getBlock(N+1), resulting in error:

     → Unable to retrieve header and parent from supplied hash