### PR TITLE
cancel release and coverage jobs

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -7,8 +7,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - uses: styfle/cancel-workflow-action@0.9.1
+      - name: Cancel release job
+        uses: styfle/cancel-workflow-action@0.9.1
         with:
           workflow_id: ".github/workflows/release.yml"
+          all_but_latest: true
+          access_token: ${{ github.token }}
+
+      - name: Cancel coverage job
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          workflow_id: ".github/workflows/coverage.yml"
           all_but_latest: true
           access_token: ${{ github.token }}

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -7,16 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - name: Cancel release job
-        uses: styfle/cancel-workflow-action@0.9.1
+      - uses: styfle/cancel-workflow-action@0.9.1
         with:
-          workflow_id: ".github/workflows/release.yml"
-          all_but_latest: true
-          access_token: ${{ github.token }}
-
-      - name: Cancel coverage job
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          workflow_id: ".github/workflows/coverage.yml"
+          workflow_id: ".github/workflows/release.yml,.github/workflows/coverage.yml"
           all_but_latest: true
           access_token: ${{ github.token }}


### PR DESCRIPTION
Currently we only cancel on a new PR the release.yml job, but we should also cancel the coverage one