### PR TITLE
Girazoki allow to choose whether publish as latest

### DIFF
--- a/.github/workflows/publish-docker-runtime-containers.yml
+++ b/.github/workflows/publish-docker-runtime-containers.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image: ["tanssi", "container-chain-simple-template", "container-chain-evm-template"]
+        image: ["container-chain-simple-template", "container-chain-evm-template"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/publish-docker-runtime-containers.yml
+++ b/.github/workflows/publish-docker-runtime-containers.yml
@@ -6,6 +6,10 @@ on:
       tag:
         description: runtime tag (ex. runtime-2200-templates) to publish on docker
         required: true
+      latest:
+        description: whether to publish the in docker as latest
+        required: true
+        type: boolean
 
 jobs:
   tag-docker:
@@ -33,3 +37,8 @@ jobs:
             docker pull "${DOCKER_IMAGE}:${SHA}"
             docker tag "${DOCKER_IMAGE}:${SHA}" "${DOCKER_IMAGE}:${DOCKER_TAG}"
             docker push "${DOCKER_IMAGE}:${DOCKER_TAG}"
+            if [[ ${{ github.event.inputs.latest }} ]]; then
+              echo tagging "${DOCKER_IMAGE}:latest"
+              docker tag "${DOCKER_IMAGE}:${SHA}" "${DOCKER_IMAGE}:latest"
+              docker push "${DOCKER_IMAGE}:latest"
+            fi


### PR DESCRIPTION
When having a new runtime for container-chains (not a node) we should allow to push as latest, as the dapp will need this to actually run correctly the proper runtime