### PR TITLE
remove tanssi from the containers job

### DIFF
--- a/.github/workflows/publish-docker-runtime-containers.yml
+++ b/.github/workflows/publish-docker-runtime-containers.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image: ["tanssi", "container-chain-simple-template", "container-chain-evm-template"]
+        image: ["container-chain-simple-template", "container-chain-evm-template"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Removes tanssi from the job which publishes runtimes for containers