### PR TITLE
Remove build from typescript publishing

### DIFF
--- a/.github/workflows/publish-typescript-api.yml
+++ b/.github/workflows/publish-typescript-api.yml
@@ -57,3 +57,4 @@ jobs:
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: typescript-api/package.json
+          access: public

--- a/.github/workflows/publish-typescript-api.yml
+++ b/.github/workflows/publish-typescript-api.yml
@@ -57,4 +57,3 @@ jobs:
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: typescript-api/package.json
-          access: public

--- a/typescript-api/package.json
+++ b/typescript-api/package.json
@@ -27,7 +27,7 @@
         "prebuild": "rimraf build",
         "build": "tsc -b --verbose",
         "postbuild": "pnpm tsx ./scripts/postbuild.ts",
-        "publish": "cd build && npm publish",
+        "publish": "npm publish",
         "deploy": "pnpm run generate && pnpm run build && pnpm run publish",
         "pretty": "prettier --write --ignore-unknown --plugin prettier-plugin-jsdoc 'src/**/*'"
     },


### PR DESCRIPTION
Without this change the typescript-api was not able to be published