### PR TITLE
Fix dancebox rpc for smoke tests

### DIFF
--- a/test/moonwall.config.json
+++ b/test/moonwall.config.json
@@ -172,6 +172,21 @@
             ]
         },
         {
+            "name": "stagenet_dancebox_smoke",
+            "testFileDir": ["suites/smoke-test"],
+            "foundation": {
+                "type": "read_only"
+            },
+            "reporters": ["basic", "html"],
+            "connections": [
+                {
+                    "name": "DBX",
+                    "type": "polkadotJs",
+                    "endpoints": ["wss://fraa-stagebox-rpc.a.stagenet.tanssi.network"]
+                }
+            ]
+        },
+        {
             "name": "chopsticks_stagenet_dancebox_upgrade",
             "testFileDir": ["suites/rt-ugprade-chopsticks"],
             "foundation": {

--- a/test/moonwall.config.json
+++ b/test/moonwall.config.json
@@ -167,7 +167,7 @@
                 {
                     "name": "DBX",
                     "type": "polkadotJs",
-                    "endpoints": ["wss://fraa-stagebox-rpc.a.stagenet.tanssi.network"]
+                    "endpoints": ["wss://fraa-dancebox-rpc.a.dancebox.tanssi.network"]
                 }
             ]
         },


### PR DESCRIPTION
Before this PR:

`pnpm moonwall test dancebox_smoke`

would run on stagenet dancebox.

Now:

`pnpm moonwall test dancebox_smoke`

Will run on dancebox, and

`pnpm moonwall test stagenet_dancebox_smoke`

will run on stagenet dancebox