### PR TITLE
Fix workflow template features

### DIFF
--- a/.github/workflow-templates/cargo-build/action.yml
+++ b/.github/workflow-templates/cargo-build/action.yml
@@ -42,8 +42,8 @@ runs:
       run: |
         env
         params=" --locked --release"
-        if [ -n "${{ github.event.inputs.features }}" ]; then
-          params="$params --features ${{ github.event.inputs.features }}"
+        if [ -n "${{ inputs.features }}" ]; then
+          params="$params --features ${{ inputs.features }}"
         fi
         echo "cargo build $params"
         cargo build $params

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Cargo build
         uses: ./.github/workflow-templates/cargo-build
         with:
-          features: fast-runtime
+          features: "fast-runtime"
       - name: Clean-up possible coverage generated during builds
         run: |
           rm default_*.profraw


### PR DESCRIPTION
The coverage job was not setting the "fast-runtime" feature because the cargo-build template was ignoring that argument.

This is the command that was being run before:

https://github.com/moondance-labs/tanssi/actions/runs/6145058170/job/16671718848

![image](https://github.com/moondance-labs/tanssi/assets/44604217/c3f02f68-af3d-4544-9f90-473880ca0682)

This is now:

![image2](https://github.com/moondance-labs/tanssi/assets/44604217/de964b01-9daf-4d6d-a714-58bf983d192c)
