### PR TITLE
Mock pending registered para ids for chopsticks

### DIFF
--- a/test/configs/dancebox.yml
+++ b/test/configs/dancebox.yml
@@ -14,3 +14,4 @@ import-storage:
 
     Registrar:
         registeredParaIds: []
+        pendingParaIds: []

--- a/test/configs/stagenet-dancebox.yml
+++ b/test/configs/stagenet-dancebox.yml
@@ -15,3 +15,4 @@ import-storage:
 
     Registrar:
         registeredParaIds: []
+        pendingParaIds: []


### PR DESCRIPTION
Otherwise chopsticks upgrade job fails, because chopsticks is unable to produce blocks when the list of registered para ids is not empty