### PR TITLE
Fix collators rotating 1 block too early

### DIFF
--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -227,7 +227,9 @@ pub fn build_check_assigned_para_id(
     spawner: impl SpawnEssentialNamed,
 ) {
     // Subscribe to new blocks in order to react to para id assignment
-    let mut import_notifications = client.import_notification_stream();
+    // This must be the stream of finalized blocks, otherwise the collators may rotate to a
+    // different chain before the block is finalized, and that could lead to a stalled chain
+    let mut import_notifications = client.finality_notification_stream();
 
     let check_assigned_para_id_task = async move {
         while let Some(msg) = import_notifications.next().await {

--- a/test/suites/para/test_tanssi_containers.ts
+++ b/test/suites/para/test_tanssi_containers.ts
@@ -269,6 +269,9 @@ describeSuite({
                 expect(await directoryExists(container2002DbPath)).to.be.false;
                 // The node starts one session before the container chain is in registered list
                 await waitSessions(context, paraApi, 1);
+                // The node detects assignment when the block is finalized, but "waitSessions" ignores finality.
+                // So wait a few blocks more hoping that the current block will be finalized by then.
+                await context.waitBlock(3, "Tanssi");
                 expect(await directoryExists(container2002DbPath)).to.be.true;
                 // Not registered yet, still pending
                 const registered4 = await paraApi.query.registrar.registeredParaIds();


### PR DESCRIPTION
I found a bug while testing #267, if all the tanssi collators rotate at the same time, tanssi chain is stalled because no one produces blocks. This fixes it, by delaying the rotation until the tanssi block is finalized. The old behavior triggered the rotation before sending the block to the relay, so if the session change was in block 25, the chain got stuck at block 23.

Will add tests for this case in #267 