### PR TITLE
pallet-initializer new session is applied immediately 

### DIFF
--- a/pallets/initializer/src/lib.rs
+++ b/pallets/initializer/src/lib.rs
@@ -32,7 +32,6 @@ mod tests;
 pub use pallet::*;
 use {
     frame_support::{pallet_prelude::*, traits::OneSessionHandler},
-    parity_scale_codec::{Decode, Encode},
     scale_info::TypeInfo,
     sp_runtime::{
         traits::{AtLeast32BitUnsigned, Zero},
@@ -44,15 +43,6 @@ use {
 #[frame_support::pallet]
 pub mod pallet {
     use super::*;
-
-    #[derive(Encode, Decode, TypeInfo)]
-    #[scale_info(skip_type_params(T))]
-    pub struct BufferedSessionChange<T: Config> {
-        pub changed: bool,
-        pub validators: Vec<(T::AccountId, T::AuthorityId)>,
-        pub queued: Vec<(T::AccountId, T::AuthorityId)>,
-        pub session_index: T::SessionIndex,
-    }
 
     // The apply_new_session trait. We need to comply with this
     pub trait ApplyNewSession<T: Config> {

--- a/pallets/initializer/src/lib.rs
+++ b/pallets/initializer/src/lib.rs
@@ -33,10 +33,7 @@ pub use pallet::*;
 use {
     frame_support::{pallet_prelude::*, traits::OneSessionHandler},
     scale_info::TypeInfo,
-    sp_runtime::{
-        traits::{AtLeast32BitUnsigned, Zero},
-        RuntimeAppPublic,
-    },
+    sp_runtime::{traits::AtLeast32BitUnsigned, RuntimeAppPublic},
     sp_std::prelude::*,
 };
 
@@ -91,12 +88,7 @@ impl<T: Config> Pallet<T> {
             validators.clone()
         };
 
-        if session_index == T::SessionIndex::zero() {
-            // Genesis session should be immediately enacted.
-            T::SessionHandler::apply_new_session(false, 0u32.into(), validators, queued);
-        } else {
-            T::SessionHandler::apply_new_session(changed, session_index, validators, queued);
-        }
+        T::SessionHandler::apply_new_session(changed, session_index, validators, queued);
     }
 
     /// Should be called when a new session occurs. Buffers the session notification to be applied

--- a/pallets/initializer/src/tests.rs
+++ b/pallets/initializer/src/tests.rs
@@ -47,4 +47,3 @@ fn session_change_before_initialize_is_still_buffered_after() {
         assert_eq!(session_change_validators(), Some((1, Vec::new())));
     });
 }
-

--- a/pallets/initializer/src/tests.rs
+++ b/pallets/initializer/src/tests.rs
@@ -34,7 +34,7 @@ fn session_0_is_instantly_applied() {
 }
 
 #[test]
-fn session_change_before_initialize_is_still_buffered_after() {
+fn session_change_applied() {
     new_test_ext().execute_with(|| {
         Initializer::test_trigger_on_new_session(
             false,

--- a/pallets/initializer/src/tests.rs
+++ b/pallets/initializer/src/tests.rs
@@ -16,7 +16,7 @@
 
 use {
     super::*,
-    crate::mock::{new_test_ext, session_change_validators, Initializer, System, Test},
+    crate::mock::{new_test_ext, session_change_validators, Initializer},
 };
 
 #[test]
@@ -28,9 +28,6 @@ fn session_0_is_instantly_applied() {
             Vec::new().into_iter(),
             Some(Vec::new().into_iter()),
         );
-
-        let v = BufferedSessionChanges::<Test>::get();
-        assert!(v.is_none());
 
         assert_eq!(session_change_validators(), Some((0, Vec::new())));
     });
@@ -46,33 +43,8 @@ fn session_change_before_initialize_is_still_buffered_after() {
             Some(Vec::new().into_iter()),
         );
 
-        let now = System::block_number();
-        Initializer::on_initialize(now);
-
-        // Session change validators are applied after on_finalize
-        assert_eq!(session_change_validators(), None);
-
-        let v = BufferedSessionChanges::<Test>::get();
-        assert!(v.is_some());
-    });
-}
-
-#[test]
-fn session_change_applied_on_finalize() {
-    new_test_ext().execute_with(|| {
-        Initializer::on_initialize(1);
-        Initializer::test_trigger_on_new_session(
-            false,
-            1,
-            Vec::new().into_iter(),
-            Some(Vec::new().into_iter()),
-        );
-
-        Initializer::on_finalize(1);
-
-        // Session change validators are applied after on_finalize
+        // Session change validators are applied
         assert_eq!(session_change_validators(), Some((1, Vec::new())));
-
-        assert!(BufferedSessionChanges::<Test>::get().is_none());
     });
 }
+

--- a/runtime/dancebox/src/lib.rs
+++ b/runtime/dancebox/src/lib.rs
@@ -80,6 +80,7 @@ use {
     },
     sp_std::{marker::PhantomData, prelude::*},
     sp_version::RuntimeVersion,
+    tp_traits::GetSessionContainerChains,
 };
 pub use {
     sp_runtime::{MultiAddress, Perbill, Permill},
@@ -1332,7 +1333,18 @@ impl_runtime_apis! {
     impl pallet_registrar_runtime_api::RegistrarApi<Block, ParaId, MaxLengthTokenSymbol> for Runtime {
         /// Return the registered para ids
         fn registered_paras() -> Vec<ParaId> {
-            Registrar::registered_para_ids().to_vec()
+            // We should return the container-chains for the session in which we are kicking in
+            let parent_number = System::block_number();
+            let should_end_session = <Runtime as pallet_session::Config>::ShouldEndSession::should_end_session(parent_number + 1);
+
+            let session_index = if should_end_session {
+                Session::current_index() +1
+            }
+            else {
+                Session::current_index()
+            };
+
+            Registrar::session_container_chains(session_index).to_vec()
         }
 
         /// Fetch genesis data for this para id

--- a/typescript-api/src/dancebox/interfaces/augment-api-query.ts
+++ b/typescript-api/src/dancebox/interfaces/augment-api-query.ts
@@ -33,7 +33,6 @@ import type {
     PalletBalancesIdAmount,
     PalletBalancesReserveData,
     PalletConfigurationHostConfiguration,
-    PalletInitializerBufferedSessionChange,
     PalletPooledStakingCandidateEligibleCandidate,
     PalletPooledStakingPendingOperationKey,
     PalletPooledStakingPoolsKey,
@@ -260,24 +259,6 @@ declare module "@polkadot/api-base/types/storage" {
                 [u32]
             > &
                 QueryableStorageEntry<ApiType, [u32]>;
-            /** Generic query */
-            [key: string]: QueryableStorageEntry<ApiType>;
-        };
-        initializer: {
-            /**
-             * Buffered session changes along with the block number at which they should be applied.
-             *
-             * Typically this will be empty or one element long. Apart from that this item never hits the storage.
-             *
-             * However this is a `Vec` regardless to handle various edge cases that may occur at runtime upgrade boundaries or
-             * if governance intervenes.
-             */
-            bufferedSessionChanges: AugmentedQuery<
-                ApiType,
-                () => Observable<Option<PalletInitializerBufferedSessionChange>>,
-                []
-            > &
-                QueryableStorageEntry<ApiType, []>;
             /** Generic query */
             [key: string]: QueryableStorageEntry<ApiType>;
         };

--- a/typescript-api/src/dancebox/interfaces/lookup.ts
+++ b/typescript-api/src/dancebox/interfaces/lookup.ts
@@ -2419,19 +2419,12 @@ export default {
         orchestratorChain: "Vec<AccountId32>",
         containerChains: "BTreeMap<u32, Vec<AccountId32>>",
     },
-    /** Lookup294: pallet_initializer::pallet::BufferedSessionChange<T> */
-    PalletInitializerBufferedSessionChange: {
-        changed: "bool",
-        validators: "Vec<(AccountId32,NimbusPrimitivesNimbusCryptoPublic)>",
-        queued: "Vec<(AccountId32,NimbusPrimitivesNimbusCryptoPublic)>",
-        sessionIndex: "u32",
-    },
-    /** Lookup297: pallet_author_noting::pallet::ContainerChainBlockInfo<T> */
+    /** Lookup294: pallet_author_noting::pallet::ContainerChainBlockInfo<T> */
     PalletAuthorNotingContainerChainBlockInfo: {
         blockNumber: "u32",
         author: "AccountId32",
     },
-    /** Lookup298: pallet_author_noting::pallet::Error<T> */
+    /** Lookup295: pallet_author_noting::pallet::Error<T> */
     PalletAuthorNotingError: {
         _enum: [
             "FailedReading",
@@ -2443,31 +2436,31 @@ export default {
             "NonAuraDigest",
         ],
     },
-    /** Lookup299: tp_collator_assignment::AssignedCollators<nimbus_primitives::nimbus_crypto::Public> */
+    /** Lookup296: tp_collator_assignment::AssignedCollators<nimbus_primitives::nimbus_crypto::Public> */
     TpCollatorAssignmentAssignedCollatorsPublic: {
         orchestratorChain: "Vec<NimbusPrimitivesNimbusCryptoPublic>",
         containerChains: "BTreeMap<u32, Vec<NimbusPrimitivesNimbusCryptoPublic>>",
     },
-    /** Lookup305: pallet_invulnerables::pallet::Error<T> */
+    /** Lookup302: pallet_invulnerables::pallet::Error<T> */
     PalletInvulnerablesError: {
         _enum: ["TooManyInvulnerables", "AlreadyInvulnerable", "NotInvulnerable"],
     },
-    /** Lookup310: sp_core::crypto::KeyTypeId */
+    /** Lookup307: sp_core::crypto::KeyTypeId */
     SpCoreCryptoKeyTypeId: "[u8;4]",
-    /** Lookup311: pallet_session::pallet::Error<T> */
+    /** Lookup308: pallet_session::pallet::Error<T> */
     PalletSessionError: {
         _enum: ["InvalidProof", "NoAssociatedValidatorId", "DuplicatedKey", "NoKeys", "NoAccount"],
     },
-    /** Lookup315: pallet_author_inherent::pallet::Error<T> */
+    /** Lookup312: pallet_author_inherent::pallet::Error<T> */
     PalletAuthorInherentError: {
         _enum: ["AuthorAlreadySet", "NoAccountId", "CannotBeAuthor"],
     },
-    /** Lookup317: pallet_pooled_staking::candidate::EligibleCandidate<sp_core::crypto::AccountId32, S> */
+    /** Lookup314: pallet_pooled_staking::candidate::EligibleCandidate<sp_core::crypto::AccountId32, S> */
     PalletPooledStakingCandidateEligibleCandidate: {
         candidate: "AccountId32",
         stake: "u128",
     },
-    /** Lookup320: pallet_pooled_staking::pallet::PoolsKey<sp_core::crypto::AccountId32> */
+    /** Lookup317: pallet_pooled_staking::pallet::PoolsKey<sp_core::crypto::AccountId32> */
     PalletPooledStakingPoolsKey: {
         _enum: {
             CandidateTotalStake: "Null",
@@ -2509,7 +2502,7 @@ export default {
             },
         },
     },
-    /** Lookup322: pallet_pooled_staking::pallet::Error<T> */
+    /** Lookup319: pallet_pooled_staking::pallet::Error<T> */
     PalletPooledStakingError: {
         _enum: {
             InvalidPalletSetting: "Null",
@@ -2528,21 +2521,21 @@ export default {
             SwapResultsInZeroShares: "Null",
         },
     },
-    /** Lookup324: cumulus_pallet_xcmp_queue::InboundChannelDetails */
+    /** Lookup321: cumulus_pallet_xcmp_queue::InboundChannelDetails */
     CumulusPalletXcmpQueueInboundChannelDetails: {
         sender: "u32",
         state: "CumulusPalletXcmpQueueInboundState",
         messageMetadata: "Vec<(u32,PolkadotParachainPrimitivesPrimitivesXcmpMessageFormat)>",
     },
-    /** Lookup325: cumulus_pallet_xcmp_queue::InboundState */
+    /** Lookup322: cumulus_pallet_xcmp_queue::InboundState */
     CumulusPalletXcmpQueueInboundState: {
         _enum: ["Ok", "Suspended"],
     },
-    /** Lookup328: polkadot_parachain_primitives::primitives::XcmpMessageFormat */
+    /** Lookup325: polkadot_parachain_primitives::primitives::XcmpMessageFormat */
     PolkadotParachainPrimitivesPrimitivesXcmpMessageFormat: {
         _enum: ["ConcatenatedVersionedXcm", "ConcatenatedEncodedBlob", "Signals"],
     },
-    /** Lookup331: cumulus_pallet_xcmp_queue::OutboundChannelDetails */
+    /** Lookup328: cumulus_pallet_xcmp_queue::OutboundChannelDetails */
     CumulusPalletXcmpQueueOutboundChannelDetails: {
         recipient: "u32",
         state: "CumulusPalletXcmpQueueOutboundState",
@@ -2550,11 +2543,11 @@ export default {
         firstIndex: "u16",
         lastIndex: "u16",
     },
-    /** Lookup332: cumulus_pallet_xcmp_queue::OutboundState */
+    /** Lookup329: cumulus_pallet_xcmp_queue::OutboundState */
     CumulusPalletXcmpQueueOutboundState: {
         _enum: ["Ok", "Suspended"],
     },
-    /** Lookup334: cumulus_pallet_xcmp_queue::QueueConfigData */
+    /** Lookup331: cumulus_pallet_xcmp_queue::QueueConfigData */
     CumulusPalletXcmpQueueQueueConfigData: {
         suspendThreshold: "u32",
         dropThreshold: "u32",
@@ -2563,27 +2556,27 @@ export default {
         weightRestrictDecay: "SpWeightsWeightV2Weight",
         xcmpMaxIndividualWeight: "SpWeightsWeightV2Weight",
     },
-    /** Lookup336: cumulus_pallet_xcmp_queue::pallet::Error<T> */
+    /** Lookup333: cumulus_pallet_xcmp_queue::pallet::Error<T> */
     CumulusPalletXcmpQueueError: {
         _enum: ["FailedToSend", "BadXcmOrigin", "BadXcm", "BadOverweightIndex", "WeightOverLimit"],
     },
-    /** Lookup337: cumulus_pallet_xcm::pallet::Error<T> */
+    /** Lookup334: cumulus_pallet_xcm::pallet::Error<T> */
     CumulusPalletXcmError: "Null",
-    /** Lookup338: cumulus_pallet_dmp_queue::ConfigData */
+    /** Lookup335: cumulus_pallet_dmp_queue::ConfigData */
     CumulusPalletDmpQueueConfigData: {
         maxIndividual: "SpWeightsWeightV2Weight",
     },
-    /** Lookup339: cumulus_pallet_dmp_queue::PageIndexData */
+    /** Lookup336: cumulus_pallet_dmp_queue::PageIndexData */
     CumulusPalletDmpQueuePageIndexData: {
         beginUsed: "u32",
         endUsed: "u32",
         overweightCount: "u64",
     },
-    /** Lookup342: cumulus_pallet_dmp_queue::pallet::Error<T> */
+    /** Lookup339: cumulus_pallet_dmp_queue::pallet::Error<T> */
     CumulusPalletDmpQueueError: {
         _enum: ["Unknown", "OverLimit"],
     },
-    /** Lookup343: pallet_xcm::pallet::QueryStatus<BlockNumber> */
+    /** Lookup340: pallet_xcm::pallet::QueryStatus<BlockNumber> */
     PalletXcmQueryStatus: {
         _enum: {
             Pending: {
@@ -2602,7 +2595,7 @@ export default {
             },
         },
     },
-    /** Lookup347: staging_xcm::VersionedResponse */
+    /** Lookup344: staging_xcm::VersionedResponse */
     StagingXcmVersionedResponse: {
         _enum: {
             __Unused0: "Null",
@@ -2611,7 +2604,7 @@ export default {
             V3: "StagingXcmV3Response",
         },
     },
-    /** Lookup353: pallet_xcm::pallet::VersionMigrationStage */
+    /** Lookup350: pallet_xcm::pallet::VersionMigrationStage */
     PalletXcmVersionMigrationStage: {
         _enum: {
             MigrateSupportedVersion: "Null",
@@ -2620,7 +2613,7 @@ export default {
             MigrateAndNotifyOldTargets: "Null",
         },
     },
-    /** Lookup355: staging_xcm::VersionedAssetId */
+    /** Lookup352: staging_xcm::VersionedAssetId */
     StagingXcmVersionedAssetId: {
         _enum: {
             __Unused0: "Null",
@@ -2629,14 +2622,14 @@ export default {
             V3: "StagingXcmV3MultiassetAssetId",
         },
     },
-    /** Lookup356: pallet_xcm::pallet::RemoteLockedFungibleRecord<ConsumerIdentifier, MaxConsumers> */
+    /** Lookup353: pallet_xcm::pallet::RemoteLockedFungibleRecord<ConsumerIdentifier, MaxConsumers> */
     PalletXcmRemoteLockedFungibleRecord: {
         amount: "u128",
         owner: "StagingXcmVersionedMultiLocation",
         locker: "StagingXcmVersionedMultiLocation",
         consumers: "Vec<(Null,u128)>",
     },
-    /** Lookup363: pallet_xcm::pallet::Error<T> */
+    /** Lookup360: pallet_xcm::pallet::Error<T> */
     PalletXcmError: {
         _enum: [
             "Unreachable",
@@ -2661,7 +2654,7 @@ export default {
             "InUse",
         ],
     },
-    /** Lookup365: sp_runtime::MultiSignature */
+    /** Lookup362: sp_runtime::MultiSignature */
     SpRuntimeMultiSignature: {
         _enum: {
             Ed25519: "SpCoreEd25519Signature",
@@ -2669,26 +2662,26 @@ export default {
             Ecdsa: "SpCoreEcdsaSignature",
         },
     },
-    /** Lookup366: sp_core::ed25519::Signature */
+    /** Lookup363: sp_core::ed25519::Signature */
     SpCoreEd25519Signature: "[u8;64]",
-    /** Lookup368: sp_core::sr25519::Signature */
+    /** Lookup365: sp_core::sr25519::Signature */
     SpCoreSr25519Signature: "[u8;64]",
-    /** Lookup369: sp_core::ecdsa::Signature */
+    /** Lookup366: sp_core::ecdsa::Signature */
     SpCoreEcdsaSignature: "[u8;65]",
-    /** Lookup372: frame_system::extensions::check_non_zero_sender::CheckNonZeroSender<T> */
+    /** Lookup369: frame_system::extensions::check_non_zero_sender::CheckNonZeroSender<T> */
     FrameSystemExtensionsCheckNonZeroSender: "Null",
-    /** Lookup373: frame_system::extensions::check_spec_version::CheckSpecVersion<T> */
+    /** Lookup370: frame_system::extensions::check_spec_version::CheckSpecVersion<T> */
     FrameSystemExtensionsCheckSpecVersion: "Null",
-    /** Lookup374: frame_system::extensions::check_tx_version::CheckTxVersion<T> */
+    /** Lookup371: frame_system::extensions::check_tx_version::CheckTxVersion<T> */
     FrameSystemExtensionsCheckTxVersion: "Null",
-    /** Lookup375: frame_system::extensions::check_genesis::CheckGenesis<T> */
+    /** Lookup372: frame_system::extensions::check_genesis::CheckGenesis<T> */
     FrameSystemExtensionsCheckGenesis: "Null",
-    /** Lookup378: frame_system::extensions::check_nonce::CheckNonce<T> */
+    /** Lookup375: frame_system::extensions::check_nonce::CheckNonce<T> */
     FrameSystemExtensionsCheckNonce: "Compact<u32>",
-    /** Lookup379: frame_system::extensions::check_weight::CheckWeight<T> */
+    /** Lookup376: frame_system::extensions::check_weight::CheckWeight<T> */
     FrameSystemExtensionsCheckWeight: "Null",
-    /** Lookup380: pallet_transaction_payment::ChargeTransactionPayment<T> */
+    /** Lookup377: pallet_transaction_payment::ChargeTransactionPayment<T> */
     PalletTransactionPaymentChargeTransactionPayment: "Compact<u128>",
-    /** Lookup381: dancebox_runtime::Runtime */
+    /** Lookup378: dancebox_runtime::Runtime */
     DanceboxRuntimeRuntime: "Null",
 };

--- a/typescript-api/src/dancebox/interfaces/registry.ts
+++ b/typescript-api/src/dancebox/interfaces/registry.ts
@@ -82,7 +82,6 @@ import type {
     PalletConfigurationCall,
     PalletConfigurationError,
     PalletConfigurationHostConfiguration,
-    PalletInitializerBufferedSessionChange,
     PalletInvulnerablesCall,
     PalletInvulnerablesError,
     PalletInvulnerablesEvent,
@@ -296,7 +295,6 @@ declare module "@polkadot/types/types/registry" {
         PalletConfigurationCall: PalletConfigurationCall;
         PalletConfigurationError: PalletConfigurationError;
         PalletConfigurationHostConfiguration: PalletConfigurationHostConfiguration;
-        PalletInitializerBufferedSessionChange: PalletInitializerBufferedSessionChange;
         PalletInvulnerablesCall: PalletInvulnerablesCall;
         PalletInvulnerablesError: PalletInvulnerablesError;
         PalletInvulnerablesEvent: PalletInvulnerablesEvent;

--- a/typescript-api/src/dancebox/interfaces/types-lookup.ts
+++ b/typescript-api/src/dancebox/interfaces/types-lookup.ts
@@ -3316,21 +3316,13 @@ declare module "@polkadot/types/lookup" {
         readonly containerChains: BTreeMap<u32, Vec<AccountId32>>;
     }
 
-    /** @name PalletInitializerBufferedSessionChange (294) */
-    interface PalletInitializerBufferedSessionChange extends Struct {
-        readonly changed: bool;
-        readonly validators: Vec<ITuple<[AccountId32, NimbusPrimitivesNimbusCryptoPublic]>>;
-        readonly queued: Vec<ITuple<[AccountId32, NimbusPrimitivesNimbusCryptoPublic]>>;
-        readonly sessionIndex: u32;
-    }
-
-    /** @name PalletAuthorNotingContainerChainBlockInfo (297) */
+    /** @name PalletAuthorNotingContainerChainBlockInfo (294) */
     interface PalletAuthorNotingContainerChainBlockInfo extends Struct {
         readonly blockNumber: u32;
         readonly author: AccountId32;
     }
 
-    /** @name PalletAuthorNotingError (298) */
+    /** @name PalletAuthorNotingError (295) */
     interface PalletAuthorNotingError extends Enum {
         readonly isFailedReading: boolean;
         readonly isFailedDecodingHeader: boolean;
@@ -3349,13 +3341,13 @@ declare module "@polkadot/types/lookup" {
             | "NonAuraDigest";
     }
 
-    /** @name TpCollatorAssignmentAssignedCollatorsPublic (299) */
+    /** @name TpCollatorAssignmentAssignedCollatorsPublic (296) */
     interface TpCollatorAssignmentAssignedCollatorsPublic extends Struct {
         readonly orchestratorChain: Vec<NimbusPrimitivesNimbusCryptoPublic>;
         readonly containerChains: BTreeMap<u32, Vec<NimbusPrimitivesNimbusCryptoPublic>>;
     }
 
-    /** @name PalletInvulnerablesError (305) */
+    /** @name PalletInvulnerablesError (302) */
     interface PalletInvulnerablesError extends Enum {
         readonly isTooManyInvulnerables: boolean;
         readonly isAlreadyInvulnerable: boolean;
@@ -3363,10 +3355,10 @@ declare module "@polkadot/types/lookup" {
         readonly type: "TooManyInvulnerables" | "AlreadyInvulnerable" | "NotInvulnerable";
     }
 
-    /** @name SpCoreCryptoKeyTypeId (310) */
+    /** @name SpCoreCryptoKeyTypeId (307) */
     interface SpCoreCryptoKeyTypeId extends U8aFixed {}
 
-    /** @name PalletSessionError (311) */
+    /** @name PalletSessionError (308) */
     interface PalletSessionError extends Enum {
         readonly isInvalidProof: boolean;
         readonly isNoAssociatedValidatorId: boolean;
@@ -3376,7 +3368,7 @@ declare module "@polkadot/types/lookup" {
         readonly type: "InvalidProof" | "NoAssociatedValidatorId" | "DuplicatedKey" | "NoKeys" | "NoAccount";
     }
 
-    /** @name PalletAuthorInherentError (315) */
+    /** @name PalletAuthorInherentError (312) */
     interface PalletAuthorInherentError extends Enum {
         readonly isAuthorAlreadySet: boolean;
         readonly isNoAccountId: boolean;
@@ -3384,13 +3376,13 @@ declare module "@polkadot/types/lookup" {
         readonly type: "AuthorAlreadySet" | "NoAccountId" | "CannotBeAuthor";
     }
 
-    /** @name PalletPooledStakingCandidateEligibleCandidate (317) */
+    /** @name PalletPooledStakingCandidateEligibleCandidate (314) */
     interface PalletPooledStakingCandidateEligibleCandidate extends Struct {
         readonly candidate: AccountId32;
         readonly stake: u128;
     }
 
-    /** @name PalletPooledStakingPoolsKey (320) */
+    /** @name PalletPooledStakingPoolsKey (317) */
     interface PalletPooledStakingPoolsKey extends Enum {
         readonly isCandidateTotalStake: boolean;
         readonly isJoiningShares: boolean;
@@ -3460,7 +3452,7 @@ declare module "@polkadot/types/lookup" {
             | "LeavingSharesHeldStake";
     }
 
-    /** @name PalletPooledStakingError (322) */
+    /** @name PalletPooledStakingError (319) */
     interface PalletPooledStakingError extends Enum {
         readonly isInvalidPalletSetting: boolean;
         readonly isDisabledFeature: boolean;
@@ -3494,21 +3486,21 @@ declare module "@polkadot/types/lookup" {
             | "SwapResultsInZeroShares";
     }
 
-    /** @name CumulusPalletXcmpQueueInboundChannelDetails (324) */
+    /** @name CumulusPalletXcmpQueueInboundChannelDetails (321) */
     interface CumulusPalletXcmpQueueInboundChannelDetails extends Struct {
         readonly sender: u32;
         readonly state: CumulusPalletXcmpQueueInboundState;
         readonly messageMetadata: Vec<ITuple<[u32, PolkadotParachainPrimitivesPrimitivesXcmpMessageFormat]>>;
     }
 
-    /** @name CumulusPalletXcmpQueueInboundState (325) */
+    /** @name CumulusPalletXcmpQueueInboundState (322) */
     interface CumulusPalletXcmpQueueInboundState extends Enum {
         readonly isOk: boolean;
         readonly isSuspended: boolean;
         readonly type: "Ok" | "Suspended";
     }
 
-    /** @name PolkadotParachainPrimitivesPrimitivesXcmpMessageFormat (328) */
+    /** @name PolkadotParachainPrimitivesPrimitivesXcmpMessageFormat (325) */
     interface PolkadotParachainPrimitivesPrimitivesXcmpMessageFormat extends Enum {
         readonly isConcatenatedVersionedXcm: boolean;
         readonly isConcatenatedEncodedBlob: boolean;
@@ -3516,7 +3508,7 @@ declare module "@polkadot/types/lookup" {
         readonly type: "ConcatenatedVersionedXcm" | "ConcatenatedEncodedBlob" | "Signals";
     }
 
-    /** @name CumulusPalletXcmpQueueOutboundChannelDetails (331) */
+    /** @name CumulusPalletXcmpQueueOutboundChannelDetails (328) */
     interface CumulusPalletXcmpQueueOutboundChannelDetails extends Struct {
         readonly recipient: u32;
         readonly state: CumulusPalletXcmpQueueOutboundState;
@@ -3525,14 +3517,14 @@ declare module "@polkadot/types/lookup" {
         readonly lastIndex: u16;
     }
 
-    /** @name CumulusPalletXcmpQueueOutboundState (332) */
+    /** @name CumulusPalletXcmpQueueOutboundState (329) */
     interface CumulusPalletXcmpQueueOutboundState extends Enum {
         readonly isOk: boolean;
         readonly isSuspended: boolean;
         readonly type: "Ok" | "Suspended";
     }
 
-    /** @name CumulusPalletXcmpQueueQueueConfigData (334) */
+    /** @name CumulusPalletXcmpQueueQueueConfigData (331) */
     interface CumulusPalletXcmpQueueQueueConfigData extends Struct {
         readonly suspendThreshold: u32;
         readonly dropThreshold: u32;
@@ -3542,7 +3534,7 @@ declare module "@polkadot/types/lookup" {
         readonly xcmpMaxIndividualWeight: SpWeightsWeightV2Weight;
     }
 
-    /** @name CumulusPalletXcmpQueueError (336) */
+    /** @name CumulusPalletXcmpQueueError (333) */
     interface CumulusPalletXcmpQueueError extends Enum {
         readonly isFailedToSend: boolean;
         readonly isBadXcmOrigin: boolean;
@@ -3552,29 +3544,29 @@ declare module "@polkadot/types/lookup" {
         readonly type: "FailedToSend" | "BadXcmOrigin" | "BadXcm" | "BadOverweightIndex" | "WeightOverLimit";
     }
 
-    /** @name CumulusPalletXcmError (337) */
+    /** @name CumulusPalletXcmError (334) */
     type CumulusPalletXcmError = Null;
 
-    /** @name CumulusPalletDmpQueueConfigData (338) */
+    /** @name CumulusPalletDmpQueueConfigData (335) */
     interface CumulusPalletDmpQueueConfigData extends Struct {
         readonly maxIndividual: SpWeightsWeightV2Weight;
     }
 
-    /** @name CumulusPalletDmpQueuePageIndexData (339) */
+    /** @name CumulusPalletDmpQueuePageIndexData (336) */
     interface CumulusPalletDmpQueuePageIndexData extends Struct {
         readonly beginUsed: u32;
         readonly endUsed: u32;
         readonly overweightCount: u64;
     }
 
-    /** @name CumulusPalletDmpQueueError (342) */
+    /** @name CumulusPalletDmpQueueError (339) */
     interface CumulusPalletDmpQueueError extends Enum {
         readonly isUnknown: boolean;
         readonly isOverLimit: boolean;
         readonly type: "Unknown" | "OverLimit";
     }
 
-    /** @name PalletXcmQueryStatus (343) */
+    /** @name PalletXcmQueryStatus (340) */
     interface PalletXcmQueryStatus extends Enum {
         readonly isPending: boolean;
         readonly asPending: {
@@ -3596,7 +3588,7 @@ declare module "@polkadot/types/lookup" {
         readonly type: "Pending" | "VersionNotifier" | "Ready";
     }
 
-    /** @name StagingXcmVersionedResponse (347) */
+    /** @name StagingXcmVersionedResponse (344) */
     interface StagingXcmVersionedResponse extends Enum {
         readonly isV2: boolean;
         readonly asV2: StagingXcmV2Response;
@@ -3605,7 +3597,7 @@ declare module "@polkadot/types/lookup" {
         readonly type: "V2" | "V3";
     }
 
-    /** @name PalletXcmVersionMigrationStage (353) */
+    /** @name PalletXcmVersionMigrationStage (350) */
     interface PalletXcmVersionMigrationStage extends Enum {
         readonly isMigrateSupportedVersion: boolean;
         readonly isMigrateVersionNotifiers: boolean;
@@ -3619,14 +3611,14 @@ declare module "@polkadot/types/lookup" {
             | "MigrateAndNotifyOldTargets";
     }
 
-    /** @name StagingXcmVersionedAssetId (355) */
+    /** @name StagingXcmVersionedAssetId (352) */
     interface StagingXcmVersionedAssetId extends Enum {
         readonly isV3: boolean;
         readonly asV3: StagingXcmV3MultiassetAssetId;
         readonly type: "V3";
     }
 
-    /** @name PalletXcmRemoteLockedFungibleRecord (356) */
+    /** @name PalletXcmRemoteLockedFungibleRecord (353) */
     interface PalletXcmRemoteLockedFungibleRecord extends Struct {
         readonly amount: u128;
         readonly owner: StagingXcmVersionedMultiLocation;
@@ -3634,7 +3626,7 @@ declare module "@polkadot/types/lookup" {
         readonly consumers: Vec<ITuple<[Null, u128]>>;
     }
 
-    /** @name PalletXcmError (363) */
+    /** @name PalletXcmError (360) */
     interface PalletXcmError extends Enum {
         readonly isUnreachable: boolean;
         readonly isSendFailure: boolean;
@@ -3679,7 +3671,7 @@ declare module "@polkadot/types/lookup" {
             | "InUse";
     }
 
-    /** @name SpRuntimeMultiSignature (365) */
+    /** @name SpRuntimeMultiSignature (362) */
     interface SpRuntimeMultiSignature extends Enum {
         readonly isEd25519: boolean;
         readonly asEd25519: SpCoreEd25519Signature;
@@ -3690,36 +3682,36 @@ declare module "@polkadot/types/lookup" {
         readonly type: "Ed25519" | "Sr25519" | "Ecdsa";
     }
 
-    /** @name SpCoreEd25519Signature (366) */
+    /** @name SpCoreEd25519Signature (363) */
     interface SpCoreEd25519Signature extends U8aFixed {}
 
-    /** @name SpCoreSr25519Signature (368) */
+    /** @name SpCoreSr25519Signature (365) */
     interface SpCoreSr25519Signature extends U8aFixed {}
 
-    /** @name SpCoreEcdsaSignature (369) */
+    /** @name SpCoreEcdsaSignature (366) */
     interface SpCoreEcdsaSignature extends U8aFixed {}
 
-    /** @name FrameSystemExtensionsCheckNonZeroSender (372) */
+    /** @name FrameSystemExtensionsCheckNonZeroSender (369) */
     type FrameSystemExtensionsCheckNonZeroSender = Null;
 
-    /** @name FrameSystemExtensionsCheckSpecVersion (373) */
+    /** @name FrameSystemExtensionsCheckSpecVersion (370) */
     type FrameSystemExtensionsCheckSpecVersion = Null;
 
-    /** @name FrameSystemExtensionsCheckTxVersion (374) */
+    /** @name FrameSystemExtensionsCheckTxVersion (371) */
     type FrameSystemExtensionsCheckTxVersion = Null;
 
-    /** @name FrameSystemExtensionsCheckGenesis (375) */
+    /** @name FrameSystemExtensionsCheckGenesis (372) */
     type FrameSystemExtensionsCheckGenesis = Null;
 
-    /** @name FrameSystemExtensionsCheckNonce (378) */
+    /** @name FrameSystemExtensionsCheckNonce (375) */
     interface FrameSystemExtensionsCheckNonce extends Compact<u32> {}
 
-    /** @name FrameSystemExtensionsCheckWeight (379) */
+    /** @name FrameSystemExtensionsCheckWeight (376) */
     type FrameSystemExtensionsCheckWeight = Null;
 
-    /** @name PalletTransactionPaymentChargeTransactionPayment (380) */
+    /** @name PalletTransactionPaymentChargeTransactionPayment (377) */
     interface PalletTransactionPaymentChargeTransactionPayment extends Compact<u128> {}
 
-    /** @name DanceboxRuntimeRuntime (381) */
+    /** @name DanceboxRuntimeRuntime (378) */
     type DanceboxRuntimeRuntime = Null;
 } // declare module


### PR DESCRIPTION
Delaying the application of a new session until `on_finalize` was producing unwanted behavior. This changes it to be applied immediately on `apply_new_session`, and removes `BufferedSessionChange` as it was only used to temporarily save the session change until `on_finalize`