### PR TITLE
Disable beefy in zombienet

### DIFF
--- a/test/configs/zombieDanceboxUpgrade.json
+++ b/test/configs/zombieDanceboxUpgrade.json
@@ -6,7 +6,7 @@
     "relaychain": {
         "chain": "rococo-local",
         "default_command": "tmp/polkadot",
-        "default_args": ["--no-hardware-benchmarks", "-lparachain=debug", "--database=paritydb"],
+        "default_args": ["--no-hardware-benchmarks", "-lparachain=debug", "--database=paritydb", "--no-beefy"],
         "nodes": [
             {
                 "name": "alice",

--- a/test/configs/zombieTanssi.json
+++ b/test/configs/zombieTanssi.json
@@ -6,7 +6,7 @@
     "relaychain": {
         "chain": "rococo-local",
         "default_command": "tmp/polkadot",
-        "default_args": ["--no-hardware-benchmarks", "-lparachain=debug", "--database=paritydb"],
+        "default_args": ["--no-hardware-benchmarks", "-lparachain=debug", "--database=paritydb", "--no-beefy"],
         "nodes": [
             {
                 "name": "alice",

--- a/test/configs/zombieTanssiMetrics.json
+++ b/test/configs/zombieTanssiMetrics.json
@@ -6,7 +6,7 @@
     "relaychain": {
         "chain": "rococo-local",
         "default_command": "tmp/polkadot",
-        "default_args": ["--no-hardware-benchmarks", "-lparachain=debug", "--database=paritydb"],
+        "default_args": ["--no-hardware-benchmarks", "-lparachain=debug", "--database=paritydb", "--no-beefy"],
         "nodes": [
             {
                 "name": "alice",

--- a/test/configs/zombieTanssiWarpSync.json
+++ b/test/configs/zombieTanssiWarpSync.json
@@ -6,7 +6,7 @@
     "relaychain": {
         "chain": "rococo-local",
         "default_command": "tmp/polkadot",
-        "default_args": ["--no-hardware-benchmarks", "-lparachain=debug", "--database=paritydb"],
+        "default_args": ["--no-hardware-benchmarks", "-lparachain=debug", "--database=paritydb", "--no-beefy"],
         "nodes": [
             {
                 "name": "alice",


### PR DESCRIPTION
Because it logs many errors like:

Got message from unregistered peer
BadJustification("Duplicate consensus engine ID")