### PR TITLE
rework prediction with the paraId in which you are assigned

### DIFF
--- a/client/consensus/src/lib.rs
+++ b/client/consensus/src/lib.rs
@@ -81,7 +81,7 @@ pub(crate) fn slot_author<P: Pair>(
 pub fn authorities<B, C, P>(
     client: &C,
     parent_hash: &B::Hash,
-    keystore: KeystorePtr,
+    para_id: ParaId,
 ) -> Option<Vec<AuthorityId<P>>>
 where
     P: Pair + Send + Sync,
@@ -94,8 +94,6 @@ where
 {
     let runtime_api = client.runtime_api();
 
-    let (_first_eligibile_key, para_id) =
-        first_eligible_key::<B, C, P>(client, parent_hash, keystore.clone())?;
     let authorities = runtime_api
         .para_id_authorities(*parent_hash, para_id)
         .ok()?;

--- a/client/consensus/src/tests.rs
+++ b/client/consensus/src/tests.rs
@@ -705,9 +705,6 @@ async fn authorities_runtime_api_tests() {
     let net = AuraTestNet::new(4);
     let net = Arc::new(Mutex::new(net));
 
-    let keystore_path = tempfile::tempdir().expect("Creates keystore path");
-    let keystore = LocalKeystore::open(keystore_path.path(), None).expect("Creates keystore.");
-
     let mut net = net.lock();
     let peer = net.peer(3);
     let client = peer.client().as_client();

--- a/client/consensus/src/tests.rs
+++ b/client/consensus/src/tests.rs
@@ -708,45 +708,18 @@ async fn authorities_runtime_api_tests() {
     let keystore_path = tempfile::tempdir().expect("Creates keystore path");
     let keystore = LocalKeystore::open(keystore_path.path(), None).expect("Creates keystore.");
 
-    let keystoreptr: sp_keystore::KeystorePtr = keystore.into();
     let mut net = net.lock();
     let peer = net.peer(3);
     let client = peer.client().as_client();
     let environ = DummyFactory(client.clone());
 
     let default_hash = Default::default();
+
     let authorities = crate::authorities::<_, _, nimbus_primitives::NimbusPair>(
         &environ,
         &default_hash,
-        keystoreptr.clone(),
-    );
-    assert!(authorities.is_none());
-
-    keystoreptr
-        .sr25519_generate_new(NIMBUS_KEY_ID, Some(&Keyring::Bob.to_seed()))
-        .expect("Key should be created");
-
-    // Bob according top the runtime-api is not eligible
-    let authorities_after_bob = crate::authorities::<_, _, nimbus_primitives::NimbusPair>(
-        &environ,
-        &default_hash,
-        keystoreptr.clone(),
-    );
-    assert!(authorities_after_bob.is_none());
-
-    // Alice according top the runtime-api is eligible
-    keystoreptr
-        .sr25519_generate_new(NIMBUS_KEY_ID, Some(&Keyring::Alice.to_seed()))
-        .expect("Key should be created");
-
-    let authorities_after_alice = crate::authorities::<_, _, nimbus_primitives::NimbusPair>(
-        &environ,
-        &default_hash,
-        keystoreptr.clone(),
+        1000u32.into(),
     );
 
-    assert_eq!(
-        authorities_after_alice,
-        Some(vec![Keyring::Alice.public().into()])
-    );
+    assert_eq!(authorities, Some(vec![Keyring::Alice.public().into()]));
 }

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -1071,7 +1071,6 @@ fn build_consensus_container(
 
     let relay_chain_interace_for_orch = relay_chain_interface.clone();
     let orchestrator_client_for_cidp = orchestrator_client;
-    let keystore_for_cidp = keystore.clone();
 
     let params = tc_consensus::BuildOrchestratorAuraConsensusParams {
         proposer_factory,
@@ -1215,7 +1214,6 @@ fn build_consensus_orchestrator(
     );
 
     let client_set_aside_for_cidp = client.clone();
-    let keystore_for_cidp = keystore.clone();
     let client_set_aside_for_orch = client.clone();
 
     let params = BuildOrchestratorAuraConsensusParams {

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -1129,7 +1129,6 @@ fn build_consensus_container(
         get_authorities_from_orchestrator: move |_block_hash, (relay_parent, _validation_data)| {
             let relay_chain_interace_for_orch = relay_chain_interace_for_orch.clone();
             let orchestrator_client_for_cidp = orchestrator_client_for_cidp.clone();
-            let keystore_for_cidp = keystore_for_cidp.clone();
 
             async move {
                 let latest_header =
@@ -1272,7 +1271,6 @@ fn build_consensus_orchestrator(
         get_authorities_from_orchestrator:
             move |block_hash: H256, (_relay_parent, _validation_data)| {
                 let client_set_aside_for_orch = client_set_aside_for_orch.clone();
-                let keystore_for_cidp = keystore_for_cidp.clone();
 
                 async move {
                     let authorities = tc_consensus::authorities::<Block, ParachainClient, NimbusPair>(

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -1149,7 +1149,7 @@ fn build_consensus_container(
                 let authorities = tc_consensus::authorities::<Block, ParachainClient, NimbusPair>(
                     orchestrator_client_for_cidp.as_ref(),
                     &latest_header.hash(),
-                    keystore_for_cidp,
+                    para_id,
                 );
 
                 let aux_data = authorities.ok_or_else(|| {
@@ -1278,7 +1278,7 @@ fn build_consensus_orchestrator(
                     let authorities = tc_consensus::authorities::<Block, ParachainClient, NimbusPair>(
                         client_set_aside_for_orch.as_ref(),
                         &block_hash,
-                        keystore_for_cidp,
+                        para_id,
                     );
 
                     let aux_data = authorities.ok_or_else(|| {


### PR DESCRIPTION
Fixes panics spotted by @tmpolaczyk on zombie tests due to an invalid prediction that could cause collator to reduce reputation

Before: author prediction was based on where you are assigned with respect to the runtime-api, but not on whether the collation process is already up for such paraId. This caused the node to believe it was eligible, but in reality, it was still proposing in the old assignation.

After: author prediction is based on the para id of the collation process. This provides a smoother prediction in which authors will not try to propose until the collation process is ready for it