### PR TITLE
Give priority to invulnerables as orchestrator collators

### DIFF
--- a/pallets/collator-assignment/src/lib.rs
+++ b/pallets/collator-assignment/src/lib.rs
@@ -316,7 +316,7 @@ pub mod pallet {
             // Fill orchestrator chain collators up to min_num_orchestrator_chain
             // Give priority to invulnerables
             let num_missing_orchestrator_collators =
-                min_num_orchestrator_chain - new_assigned.orchestrator_chain.len();
+                min_num_orchestrator_chain.saturating_sub(new_assigned.orchestrator_chain.len());
             let invulnerables_for_orchestrator = T::RemoveInvulnerables::remove_invulnerables(
                 &mut new_collators,
                 num_missing_orchestrator_collators,

--- a/pallets/collator-assignment/src/lib.rs
+++ b/pallets/collator-assignment/src/lib.rs
@@ -55,8 +55,7 @@ use {
     sp_std::{fmt::Debug, prelude::*, vec},
     tp_collator_assignment::AssignedCollators,
     tp_traits::{
-        GetContainerChainAuthor, GetHostConfiguration, GetSessionContainerChains, ParaId,
-        ShouldRotateAllCollators, Slot,
+        GetContainerChainAuthor, GetHostConfiguration, GetSessionContainerChains, ParaId, Slot, RemoveInvulnerables, ShouldRotateAllCollators
     },
 };
 
@@ -95,6 +94,7 @@ pub mod pallet {
         type ContainerChains: GetSessionContainerChains<Self::SessionIndex>;
         type ShouldRotateAllCollators: ShouldRotateAllCollators<Self::SessionIndex>;
         type GetRandomnessForNextBlock: GetRandomnessForNextBlock<BlockNumberFor<Self>>;
+        type RemoveInvulnerables: RemoveInvulnerables<Self::AccountId>;
         /// The weight information of this pallet.
         type WeightInfo: WeightInfo;
     }
@@ -313,6 +313,13 @@ pub mod pallet {
             }
 
             // Fill orchestrator chain collators up to min_num_orchestrator_chain
+            // Give priority to invulnerables
+            let num_missing_orchestrator_collators = min_num_orchestrator_chain - new_assigned.orchestrator_chain.len();
+            let invulnerables_for_orchestrator = T::RemoveInvulnerables::remove_invulnerables(&mut new_collators, num_missing_orchestrator_collators);
+            new_assigned
+                .fill_orchestrator_chain_collators(min_num_orchestrator_chain, &mut invulnerables_for_orchestrator.into_iter());
+            // If there are no enough invulnerables, or if the invulnerables are currently assigned to other chains,
+            // fill orchestrator chain with regular collators
             let mut new_collators = new_collators.into_iter();
             new_assigned
                 .fill_orchestrator_chain_collators(min_num_orchestrator_chain, &mut new_collators);

--- a/pallets/collator-assignment/src/lib.rs
+++ b/pallets/collator-assignment/src/lib.rs
@@ -55,7 +55,8 @@ use {
     sp_std::{fmt::Debug, prelude::*, vec},
     tp_collator_assignment::AssignedCollators,
     tp_traits::{
-        GetContainerChainAuthor, GetHostConfiguration, GetSessionContainerChains, ParaId, Slot, RemoveInvulnerables, ShouldRotateAllCollators
+        GetContainerChainAuthor, GetHostConfiguration, GetSessionContainerChains, ParaId,
+        RemoveInvulnerables, ShouldRotateAllCollators, Slot,
     },
 };
 
@@ -314,10 +315,16 @@ pub mod pallet {
 
             // Fill orchestrator chain collators up to min_num_orchestrator_chain
             // Give priority to invulnerables
-            let num_missing_orchestrator_collators = min_num_orchestrator_chain - new_assigned.orchestrator_chain.len();
-            let invulnerables_for_orchestrator = T::RemoveInvulnerables::remove_invulnerables(&mut new_collators, num_missing_orchestrator_collators);
-            new_assigned
-                .fill_orchestrator_chain_collators(min_num_orchestrator_chain, &mut invulnerables_for_orchestrator.into_iter());
+            let num_missing_orchestrator_collators =
+                min_num_orchestrator_chain - new_assigned.orchestrator_chain.len();
+            let invulnerables_for_orchestrator = T::RemoveInvulnerables::remove_invulnerables(
+                &mut new_collators,
+                num_missing_orchestrator_collators,
+            );
+            new_assigned.fill_orchestrator_chain_collators(
+                min_num_orchestrator_chain,
+                &mut invulnerables_for_orchestrator.into_iter(),
+            );
             // If there are no enough invulnerables, or if the invulnerables are currently assigned to other chains,
             // fill orchestrator chain with regular collators
             let mut new_collators = new_collators.into_iter();

--- a/pallets/collator-assignment/src/mock.rs
+++ b/pallets/collator-assignment/src/mock.rs
@@ -230,11 +230,13 @@ pub struct RemoveAccountIdsAbove100;
 impl RemoveInvulnerables<u64> for RemoveAccountIdsAbove100 {
     fn remove_invulnerables(collators: &mut Vec<u64>, num_invulnerables: usize) -> Vec<u64> {
         let mut invulnerables = vec![];
-        collators.retain(|x| if invulnerables.len() < num_invulnerables && x >= 100 {
-            invulnerables.push(*x);
-            false
-        } else {
-            true
+        collators.retain(|x| {
+            if invulnerables.len() < num_invulnerables && *x >= 100 {
+                invulnerables.push(*x);
+                false
+            } else {
+                true
+            }
         });
 
         invulnerables

--- a/primitives/traits/src/lib.rs
+++ b/primitives/traits/src/lib.rs
@@ -66,5 +66,8 @@ pub trait ShouldRotateAllCollators<SessionIndex> {
 /// Helper trait for pallet_collator_assignment to be able to give priority to invulnerables
 pub trait RemoveInvulnerables<AccountId> {
     /// Remove the first n invulnerables from the list of collators. The order should be respected.
-    fn remove_invulnerables(collators: &mut Vec<AccountId>, num_invulnerables: usize) -> Vec<AccountId>;
+    fn remove_invulnerables(
+        collators: &mut Vec<AccountId>,
+        num_invulnerables: usize,
+    ) -> Vec<AccountId>;
 }

--- a/primitives/traits/src/lib.rs
+++ b/primitives/traits/src/lib.rs
@@ -62,3 +62,9 @@ pub trait GetSessionIndex<SessionIndex> {
 pub trait ShouldRotateAllCollators<SessionIndex> {
     fn should_rotate_all_collators(session_index: SessionIndex) -> bool;
 }
+
+/// Helper trait for pallet_collator_assignment to be able to give priority to invulnerables
+pub trait RemoveInvulnerables<AccountId> {
+    /// Remove the first n invulnerables from the list of collators. The order should be respected.
+    fn remove_invulnerables(collators: &mut Vec<AccountId>, num_invulnerables: usize) -> Vec<AccountId>;
+}

--- a/runtime/dancebox/src/lib.rs
+++ b/runtime/dancebox/src/lib.rs
@@ -29,6 +29,7 @@ use sp_version::NativeVersion;
 
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
+use tp_traits::RemoveInvulnerables;
 
 pub mod migrations;
 pub mod weights;
@@ -650,6 +651,25 @@ impl GetRandomnessForNextBlock<u32> for BabeGetRandomnessForNextBlock {
     }
 }
 
+pub struct RemoveInvulnerablesImpl;
+
+impl RemoveInvulnerables<AccountId> for RemoveInvulnerablesImpl {
+    fn remove_invulnerables(collators: &mut Vec<AccountId>, num_invulnerables: usize) -> Vec<AccountId> {
+        // TODO: check if this works on session changes
+        let all_invulnerables = pallet_invulnerables::Invulnerables::<Runtime>::get();
+        let mut invulnerables = vec![];
+        // TODO: use binary_search when invulnerables are sorted
+        collators.retain(|x| if invulnerables.len() < num_invulnerables && all_invulnerables.contains(x) {
+            invulnerables.push(x.clone());
+            false
+        } else {
+            true
+        });
+
+        invulnerables
+    }
+}
+
 impl pallet_collator_assignment::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type HostConfiguration = Configuration;
@@ -658,6 +678,7 @@ impl pallet_collator_assignment::Config for Runtime {
     type ShouldRotateAllCollators =
         RotateCollatorsEveryNSessions<ConfigurationCollatorRotationSessionPeriod>;
     type GetRandomnessForNextBlock = BabeGetRandomnessForNextBlock;
+    type RemoveInvulnerables = RemoveInvulnerablesImpl;
     type WeightInfo = pallet_collator_assignment::weights::SubstrateWeight<Runtime>;
 }
 

--- a/runtime/dancebox/src/lib.rs
+++ b/runtime/dancebox/src/lib.rs
@@ -654,16 +654,21 @@ impl GetRandomnessForNextBlock<u32> for BabeGetRandomnessForNextBlock {
 pub struct RemoveInvulnerablesImpl;
 
 impl RemoveInvulnerables<AccountId> for RemoveInvulnerablesImpl {
-    fn remove_invulnerables(collators: &mut Vec<AccountId>, num_invulnerables: usize) -> Vec<AccountId> {
+    fn remove_invulnerables(
+        collators: &mut Vec<AccountId>,
+        num_invulnerables: usize,
+    ) -> Vec<AccountId> {
         // TODO: check if this works on session changes
         let all_invulnerables = pallet_invulnerables::Invulnerables::<Runtime>::get();
         let mut invulnerables = vec![];
         // TODO: use binary_search when invulnerables are sorted
-        collators.retain(|x| if invulnerables.len() < num_invulnerables && all_invulnerables.contains(x) {
-            invulnerables.push(x.clone());
-            false
-        } else {
-            true
+        collators.retain(|x| {
+            if invulnerables.len() < num_invulnerables && all_invulnerables.contains(x) {
+                invulnerables.push(x.clone());
+                false
+            } else {
+                true
+            }
         });
 
         invulnerables

--- a/runtime/dancebox/src/lib.rs
+++ b/runtime/dancebox/src/lib.rs
@@ -658,8 +658,14 @@ impl RemoveInvulnerables<AccountId> for RemoveInvulnerablesImpl {
         collators: &mut Vec<AccountId>,
         num_invulnerables: usize,
     ) -> Vec<AccountId> {
+        if num_invulnerables == 0 {
+            return vec![];
+        }
         // TODO: check if this works on session changes
         let all_invulnerables = pallet_invulnerables::Invulnerables::<Runtime>::get();
+        if all_invulnerables.is_empty() {
+            return vec![];
+        }
         let mut invulnerables = vec![];
         // TODO: use binary_search when invulnerables are sorted
         collators.retain(|x| {

--- a/runtime/dancebox/tests/common/mod.rs
+++ b/runtime/dancebox/tests/common/mod.rs
@@ -122,6 +122,46 @@ pub fn set_parachain_inherent_data() {
     .dispatch(inherent_origin()));
 }
 
+pub fn set_parachain_inherent_data_random_seed(random_seed: [u8; 32]) {
+    use cumulus_primitives_core::relay_chain::well_known_keys;
+    use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
+
+    let (relay_parent_storage_root, relay_chain_state) = {
+        let mut sproof = RelayStateSproofBuilder::default();
+        sproof.additional_key_values.push((
+            well_known_keys::CURRENT_BLOCK_RANDOMNESS.to_vec(),
+            Some(random_seed).encode(),
+        ));
+
+        sproof.into_state_root_and_proof()
+    };
+    let vfp = PersistedValidationData {
+        // TODO: this is previous relay_parent_number + 1, but not sure where can I get that value
+        relay_parent_number: 2u32,
+        relay_parent_storage_root,
+        ..Default::default()
+    };
+    let parachain_inherent_data = ParachainInherentData {
+        validation_data: vfp,
+        relay_chain_state: relay_chain_state,
+        downward_messages: Default::default(),
+        horizontal_messages: Default::default(),
+    };
+    // Delete existing flag to avoid error
+    // 'ValidationData must be updated only once in a block'
+    // TODO: this is a hack
+    frame_support::storage::unhashed::kill(&frame_support::storage::storage_prefix(
+        b"ParachainSystem",
+        b"ValidationData",
+    ));
+    assert_ok!(RuntimeCall::ParachainSystem(
+        cumulus_pallet_parachain_system::Call::<Runtime>::set_validation_data {
+            data: parachain_inherent_data
+        }
+    )
+    .dispatch(inherent_origin()));
+}
+
 #[derive(Default)]
 pub struct ExtBuilder {
     // endowed accounts with balances


### PR DESCRIPTION
When rotating collators, the orchestrator chain will be filled with `min_orchestrator_collators` invulnerables. If there are not enough invulnerables, the rest is filled with regular collators. The rest (up to `max_orchestrator_collators`) is also filled with regular collators (regular means anything, can be invulnerable or not invulnerable).