### PR TITLE
Allow to set zero as rotation period in pallet-configuration

### DIFF
--- a/pallets/configuration/src/lib.rs
+++ b/pallets/configuration/src/lib.rs
@@ -69,6 +69,7 @@ pub struct HostConfiguration {
     pub min_orchestrator_collators: u32,
     pub max_orchestrator_collators: u32,
     pub collators_per_container: u32,
+    // If this value is 0 means that there is no rotation
     pub full_rotation_period: u32,
 }
 
@@ -94,8 +95,6 @@ pub enum InconsistentError {
     MinOrchestratorCollatorsTooLow,
     /// `max_collators` must be at least 1
     MaxCollatorsTooLow,
-    /// `full_rotation_period` must be at least 1
-    FullRotationPeriodTooLow,
 }
 
 impl HostConfiguration {
@@ -113,9 +112,6 @@ impl HostConfiguration {
         }
         if self.max_orchestrator_collators < self.min_orchestrator_collators {
             return Err(InconsistentError::MaxCollatorsLowerThanMinCollators);
-        }
-        if self.full_rotation_period < 1 {
-            return Err(InconsistentError::FullRotationPeriodTooLow);
         }
         Ok(())
     }

--- a/pallets/configuration/src/tests.rs
+++ b/pallets/configuration/src/tests.rs
@@ -98,6 +98,53 @@ fn config_set_value() {
 }
 
 #[test]
+fn config_set_full_rotation_period_to_zero_works() {
+    new_test_ext_with_genesis(HostConfiguration {
+        max_collators: 100,
+        min_orchestrator_collators: 2,
+        max_orchestrator_collators: 5,
+        collators_per_container: 2,
+        full_rotation_period: 24,
+    })
+    .execute_with(|| {
+        run_to_block(1);
+        assert_eq!(Configuration::config().full_rotation_period, 24);
+        assert_ok!(
+            Configuration::set_full_rotation_period(RuntimeOrigin::root(), 0),
+            ()
+        );
+
+        assert_eq!(
+            PendingConfigs::<Test>::get(),
+            vec![(
+                2,
+                HostConfiguration {
+                    max_collators: 100,
+                    min_orchestrator_collators: 2,
+                    max_orchestrator_collators: 5,
+                    collators_per_container: 2,
+                    full_rotation_period: 0,
+                }
+            )]
+        );
+
+        // The session delay is set to 2, and one session is 5 blocks,
+        // so the change should not happen until block 11
+        assert_eq!(Configuration::config().full_rotation_period, 24);
+        run_to_block(2);
+        assert_eq!(Configuration::config().full_rotation_period, 24);
+        // First block of session 1
+        run_to_block(6);
+        assert_eq!(Configuration::config().full_rotation_period, 24);
+        run_to_block(10);
+        assert_eq!(Configuration::config().full_rotation_period, 24);
+        // First block of session 2
+        run_to_block(11);
+        assert_eq!(Configuration::config().full_rotation_period, 0);
+    });
+}
+
+#[test]
 fn config_set_many_values_same_block() {
     new_test_ext_with_genesis(HostConfiguration {
         max_collators: 100,


### PR DESCRIPTION
Removes the check inside `pallet-configuration` that prevented setting zero as a value of `full_rotation_period` field within `HostConfiguration`.