### PR TITLE
Increment ports of "odd" parachains to avoid port conflicts

### DIFF
--- a/node/src/container_chain_monitor.rs
+++ b/node/src/container_chain_monitor.rs
@@ -38,7 +38,7 @@ pub struct SpawnedContainersMonitor {
     /// stopping time and reference count.
     list: VecDeque<SpawnedContainer>,
     /// Count the number of times a container chain has been started
-    count: usize,
+    pub count: usize,
 }
 
 pub struct SpawnedContainer {

--- a/node/src/container_chain_spawner.rs
+++ b/node/src/container_chain_spawner.rs
@@ -189,6 +189,48 @@ impl ContainerChainSpawner {
                 container_chain_para_id
             );
 
+            let odd_parachain = {
+                let state = state.lock().expect("poison error");
+                let monitor_id = state.spawned_containers_monitor.count;
+
+                monitor_id % 2 == 1
+            };
+
+            if odd_parachain {
+                log::info!("This is an odd parachain, incrementing all the ports by 1");
+                // Increment all the ports by 1 to avoid conflicts with the other running container chain
+                container_chain_cli
+                    .base
+                    .base
+                    .prometheus_params
+                    .prometheus_port = Some(
+                    container_chain_cli
+                        .base
+                        .base
+                        .prometheus_params
+                        .prometheus_port
+                        .unwrap_or(9617)
+                        .saturating_add(1),
+                );
+                container_chain_cli.base.base.network_params.port = Some(
+                    container_chain_cli
+                        .base
+                        .base
+                        .network_params
+                        .port
+                        .unwrap_or(30335)
+                        .saturating_add(1),
+                );
+                container_chain_cli.base.base.rpc_port = Some(
+                    container_chain_cli
+                        .base
+                        .base
+                        .rpc_port
+                        .unwrap_or(9946)
+                        .saturating_add(1),
+                );
+            }
+
             // Update CLI params
             container_chain_cli.base.para_id = Some(container_chain_para_id.into());
 


### PR DESCRIPTION
The user can specify p2p, rpc, and prometheus ports using the CLI, and since there can be 2 container chains running at the same time, the port used may be the one specified by the user, or that +1