### PR TITLE
Always restart container chain before starting collation

### DIFF
--- a/node/src/container_chain_monitor.rs
+++ b/node/src/container_chain_monitor.rs
@@ -38,7 +38,7 @@ pub struct SpawnedContainersMonitor {
     /// stopping time and reference count.
     list: VecDeque<SpawnedContainer>,
     /// Count the number of times a container chain has been started
-    count: usize,
+    pub count: usize,
 }
 
 pub struct SpawnedContainer {

--- a/node/src/container_chain_monitor.rs
+++ b/node/src/container_chain_monitor.rs
@@ -38,7 +38,7 @@ pub struct SpawnedContainersMonitor {
     /// stopping time and reference count.
     list: VecDeque<SpawnedContainer>,
     /// Count the number of times a container chain has been started
-    pub count: usize,
+    count: usize,
 }
 
 pub struct SpawnedContainer {

--- a/node/src/container_chain_spawner.rs
+++ b/node/src/container_chain_spawner.rs
@@ -189,6 +189,48 @@ impl ContainerChainSpawner {
                 container_chain_para_id
             );
 
+            let odd_parachain = {
+                let state = state.lock().expect("poison error");
+                let monitor_id = state.spawned_containers_monitor.count;
+
+                monitor_id % 2 == 1
+            };
+
+            if odd_parachain {
+                log::info!("This is an odd parachain, incrementing all the ports by 1");
+                // Increment all the ports by 1 to avoid conflicts with the other running container chain
+                container_chain_cli
+                    .base
+                    .base
+                    .prometheus_params
+                    .prometheus_port = Some(
+                    container_chain_cli
+                        .base
+                        .base
+                        .prometheus_params
+                        .prometheus_port
+                        .unwrap_or(9617)
+                        .saturating_add(1),
+                );
+                container_chain_cli.base.base.network_params.port = Some(
+                    container_chain_cli
+                        .base
+                        .base
+                        .network_params
+                        .port
+                        .unwrap_or(30335)
+                        .saturating_add(1),
+                );
+                container_chain_cli.base.base.rpc_port = Some(
+                    container_chain_cli
+                        .base
+                        .base
+                        .rpc_port
+                        .unwrap_or(9946)
+                        .saturating_add(1),
+                );
+            }
+
             // Update CLI params
             container_chain_cli.base.para_id = Some(container_chain_para_id.into());
 

--- a/node/src/container_chain_spawner.rs
+++ b/node/src/container_chain_spawner.rs
@@ -800,6 +800,7 @@ mod tests {
                 call_collate_on,
                 chains_to_stop,
                 chains_to_start,
+                need_to_restart_current,
             } = handle_update_assignment_state_change(
                 &mut *self.state.lock().unwrap(),
                 self.orchestrator_para_id,
@@ -810,11 +811,22 @@ mod tests {
 
             // Assert we never start and stop the same container chain
             for para_id in &chains_to_start {
-                assert!(
-                    !chains_to_stop.contains(para_id),
-                    "Tried to start and stop same container chain: {}",
-                    para_id
-                );
+                if !need_to_restart_current {
+                    assert!(
+                        !chains_to_stop.contains(para_id),
+                        "Tried to start and stop same container chain: {}",
+                        para_id
+                    );
+                } else {
+                    // Will try to start and stop container chain with id "current", so ignore that
+                    if Some(*para_id) != current {
+                        assert!(
+                            !chains_to_stop.contains(para_id),
+                            "Tried to start and stop same container chain: {}",
+                            para_id
+                        );
+                    }
+                }
             }
             // Assert we never start or stop the orchestrator chain
             assert!(!chains_to_start.contains(&self.orchestrator_para_id));


### PR DESCRIPTION
Container chains can start in "sync mode", which uses random ports, or in "collation mode" which uses the ports provided by the user through CLI. To ensure that the container chain that is currently collating uses the correct ports, we restart it right when it is time to start collation.