### PR TITLE
Use -C target-cpu=native for coverage build

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Variables
         shell: bash
         run: |
-          echo "RUSTFLAGS=-C opt-level=3 -D warnings -C instrument-coverage -C linker=clang -C link-arg=-fuse-ld=$(pwd)/mold/bin/mold" >> $GITHUB_ENV
+          echo "RUSTFLAGS=-C opt-level=3 -C target-cpu=native -D warnings -C instrument-coverage -C linker=clang -C link-arg=-fuse-ld=$(pwd)/mold/bin/mold" >> $GITHUB_ENV
       - name: Setup grcov
         run: |
           wget https://github.com/mozilla/grcov/releases/download/v${{ env.GRCOV_VERSION }}/grcov-x86_64-unknown-linux-gnu.tar.bz2


### PR DESCRIPTION
May reduce the time it takes to run coverage test, if it doesn't don't merge.

We shouldn't use that flag for production because it makes binaries that crash with SIGILL when run in older cpus.

Before: 28m 48s  https://github.com/moondance-labs/tanssi/actions/runs/6744865982/job/18335585820
Before: 22m 06s https://github.com/moondance-labs/tanssi/actions/runs/6784748424/job/18441662553

After: 24m 25s  https://github.com/moondance-labs/tanssi/actions/runs/6772967052/job/18406723934
After: 22m 25s  https://github.com/moondance-labs/tanssi/actions/runs/6772967052/job/18442846938

So it looks like there isn't a big difference, I guess because the tests use the wasm runtime, and this flag does not make sense there, so closing.