### PR TITLE
Prefund pallet accounts in genesis to ensure they are always alive

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -293,6 +293,11 @@ fn testnet_genesis(
     mock_container_chains: &[ParaId],
     configuration: pallet_configuration::GenesisConfig<dancebox_runtime::Runtime>,
 ) -> dancebox_runtime::RuntimeGenesisConfig {
+    let accounts_with_ed = vec![
+        dancebox_runtime::StakingAccount::get(),
+        dancebox_runtime::ParachainBondAccount::get(),
+        dancebox_runtime::PendingRewardsAccount::get(),
+    ];
     dancebox_runtime::RuntimeGenesisConfig {
         system: dancebox_runtime::SystemConfig {
             code: dancebox_runtime::WASM_BINARY
@@ -305,6 +310,12 @@ fn testnet_genesis(
                 .iter()
                 .cloned()
                 .map(|k| (k, 1 << 60))
+                .chain(
+                    accounts_with_ed
+                        .iter()
+                        .cloned()
+                        .map(|k| (k, dancebox_runtime::EXISTENTIAL_DEPOSIT)),
+                )
                 .collect(),
         },
         parachain_info: dancebox_runtime::ParachainInfoConfig {

--- a/test/suites/dev-tanssi/staking/test_staking_rewards_balanced.ts
+++ b/test/suites/dev-tanssi/staking/test_staking_rewards_balanced.ts
@@ -134,8 +134,8 @@ describeSuite({
                 const events = await polkadotJs.query.system.events();
                 const reward = await fetchRewardAuthorOrchestrator(events);
 
-                // 20% plus 1 from rounding
-                const collatorPercentage = (20n * reward.balance.toBigInt()) / 100n + 1n;
+                // 20% collator percentage
+                const collatorPercentage = (20n * reward.balance.toBigInt()) / 100n;
 
                 // Rounding
                 const delegatorRewards = reward.balance.toBigInt() - collatorPercentage;

--- a/test/suites/dev-tanssi/staking/test_staking_rewards_non_balanced.ts
+++ b/test/suites/dev-tanssi/staking/test_staking_rewards_non_balanced.ts
@@ -134,8 +134,8 @@ describeSuite({
                 const events = await polkadotJs.query.system.events();
                 const reward = await fetchRewardAuthorOrchestrator(events);
 
-                // 20% plus 1 from rounding
-                const collatorPercentage = (20n * reward.balance.toBigInt()) / 100n + 1n;
+                // 20% collator percentage
+                const collatorPercentage = (20n * reward.balance.toBigInt()) / 100n;
 
                 // Rounding
                 const delegatorRewards = reward.balance.toBigInt() - collatorPercentage;


### PR DESCRIPTION
This is needed for the StakingAccount, not sure if the other ones need it as well