### PR TITLE
Disable coverage gathering during cargo build

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -60,11 +60,12 @@ jobs:
           echo "RUSTFLAGS=-C opt-level=3 -D warnings -C instrument-coverage -C linker=clang -C link-arg=-fuse-ld=$(pwd)/mold/bin/mold" >> $GITHUB_ENV
           # Disable coverage when building
           echo "LLVM_PROFILE_FILE=/dev/null" >> $GITHUB_ENV
-          # TODO: For testing, clean up .cargo, remove this line before merging:
-          #find $HOME/.cargo -type f -name \*.profraw -delete
+          # TODO: For testing, clean up .cargo, remove this lines before merging:
           find $HOME/.cargo -type f -name \*.profraw -print0 | \
-            tee >(xargs -0 du -ch | grep total$) | \
-            xargs -0 rm
+              tee >(xargs -0 echo | wc -w | xargs echo -n >&2; echo " files" >&2) | \
+              du --files0-from=- -ch | \
+              grep total$
+          find $HOME/.cargo -type f -name \*.profraw -delete
       - name: Setup grcov
         run: |
           wget https://github.com/mozilla/grcov/releases/download/v${{ env.GRCOV_VERSION }}/grcov-x86_64-unknown-linux-gnu.tar.bz2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -60,12 +60,6 @@ jobs:
           echo "RUSTFLAGS=-C opt-level=3 -D warnings -C instrument-coverage -C linker=clang -C link-arg=-fuse-ld=$(pwd)/mold/bin/mold" >> $GITHUB_ENV
           # Disable coverage when building
           echo "LLVM_PROFILE_FILE=/dev/null" >> $GITHUB_ENV
-          # TODO: For testing, clean up .cargo, remove this lines before merging:
-          find $HOME/.cargo -type f -name \*.profraw -print0 | \
-              tee >(xargs -0 echo | wc -w | xargs echo -n >&2; echo " files" >&2) | \
-              du --files0-from=- -ch | \
-              grep total$
-          find $HOME/.cargo -type f -name \*.profraw -delete
       - name: Setup grcov
         run: |
           wget https://github.com/mozilla/grcov/releases/download/v${{ env.GRCOV_VERSION }}/grcov-x86_64-unknown-linux-gnu.tar.bz2
@@ -75,13 +69,10 @@ jobs:
         uses: ./.github/workflow-templates/cargo-build
         with:
           features: "fast-runtime"
-      - name: Clean-up possible coverage generated during builds
+      - name: Enable coverage gathering
         run: |
-          echo "This should be empty:"
-          find . -type f -name \*.profraw -exec ls -l {}  \;
-          echo "nice"
           # Enable coverage when running tests
-          echo "LLVM_PROFILE_FILE=/tmp/proffiles/default_%m_%p.profraw" >> $GITHUB_ENV
+          echo "LLVM_PROFILE_FILE=$(pwd)/proffiles/default_%m_%p.profraw" >> $GITHUB_ENV
       - name: Upload runtimes
         uses: actions/upload-artifact@v3.1.2
         with:
@@ -113,13 +104,6 @@ jobs:
       - name: Retrieve coverage
         id: coverage
         run: |
-          echo "Check junk in .cargo folder"
-          find $HOME/.cargo -type f -name \*.profraw -exec ls -l {} \;
-          echo "^ should be empty"
-          find . -type f -name \*.profraw -exec ls -l {}  \;
-          echo "^ should also be empty"
-
-          mv /tmp/proffiles proffiles
           du -sh proffiles
 
           echo "Executing grcov"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -80,7 +80,6 @@ jobs:
           echo "This should be empty:"
           find . -type f -name \*.profraw -exec ls -l {}  \;
           echo "nice"
-          rm default_*.profraw
           # Enable coverage when running tests
           echo "LLVM_PROFILE_FILE=/tmp/proffiles/default_%m_%p.profraw" >> $GITHUB_ENV
       - name: Upload runtimes

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -58,6 +58,10 @@ jobs:
         shell: bash
         run: |
           echo "RUSTFLAGS=-C opt-level=3 -D warnings -C instrument-coverage -C linker=clang -C link-arg=-fuse-ld=$(pwd)/mold/bin/mold" >> $GITHUB_ENV
+          # Disable coverage when building
+          echo "LLVM_PROFILE_FILE=/dev/null" >> $GITHUB_ENV
+          # TODO: For testing, clean up .cargo, remove this line before merging:
+          find $HOME/.cargo -type f -name \*.profraw -delete
       - name: Setup grcov
         run: |
           wget https://github.com/mozilla/grcov/releases/download/v${{ env.GRCOV_VERSION }}/grcov-x86_64-unknown-linux-gnu.tar.bz2
@@ -69,7 +73,12 @@ jobs:
           features: "fast-runtime"
       - name: Clean-up possible coverage generated during builds
         run: |
+          echo "This should be empty:"
+          find . -type f -name \*.profraw -exec ls -l {}  \;
+          echo "nice"
           rm default_*.profraw
+          # Enable coverage when running tests
+          echo "LLVM_PROFILE_FILE=/tmp/proffiles/default_%m_%p.profraw" >> $GITHUB_ENV
       - name: Upload runtimes
         uses: actions/upload-artifact@v3.1.2
         with:
@@ -103,13 +112,9 @@ jobs:
         run: |
           echo "Check junk in .cargo folder"
           find $HOME/.cargo -type f -name \*.profraw -exec ls -l {} \;
-          mkdir -p /tmp/proffiles
-
-          echo "Those are the important files:"
+          echo "^ should be empty"
           find . -type f -name \*.profraw -exec ls -l {}  \;
-
-          echo "Copying profraw files to /tmp/proffiles"
-          find . -name \*.profraw -exec mv {} /tmp/proffiles/ \;
+          echo "^ should also be empty"
 
           mv /tmp/proffiles proffiles
           du -sh proffiles

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -61,7 +61,10 @@ jobs:
           # Disable coverage when building
           echo "LLVM_PROFILE_FILE=/dev/null" >> $GITHUB_ENV
           # TODO: For testing, clean up .cargo, remove this line before merging:
-          find $HOME/.cargo -type f -name \*.profraw -delete
+          #find $HOME/.cargo -type f -name \*.profraw -delete
+          find $HOME/.cargo -type f -name \*.profraw -print0 | \
+            tee >(xargs -0 du -ch | grep total$) | \
+            xargs -0 rm
       - name: Setup grcov
         run: |
           wget https://github.com/mozilla/grcov/releases/download/v${{ env.GRCOV_VERSION }}/grcov-x86_64-unknown-linux-gnu.tar.bz2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -101,8 +101,11 @@ jobs:
       - name: Retrieve coverage
         id: coverage
         run: |
+          echo "Check junk in .cargo folder"
+          find $HOME/.cargo -type f -name \*.profraw -exec ls -l {} \;
           mkdir -p /tmp/proffiles
 
+          echo "Those are the important files:"
           find . -type f -name \*.profraw -exec ls -l {}  \;
 
           echo "Copying profraw files to /tmp/proffiles"


### PR DESCRIPTION
Prevents the creation of junk `.profraw` files in the `~/.cargo` folder. Now coverage is enabled after cargo build, and `.profraw` files are written directly to the `proffiles` folder.