### PR TITLE
Ignore invalid bootnodes when starting container chain

### DIFF
--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -316,20 +316,13 @@ impl ContainerChainCli {
         genesis_data: ContainerChainGenesisData<MaxLengthTokenSymbol>,
         chain_type: sc_chain_spec::ChainType,
         relay_chain: String,
-        boot_nodes: Vec<String>,
+        boot_nodes: Vec<MultiaddrWithPeerId>,
     ) -> Result<crate::chain_spec::RawChainSpec, String> {
         let name = String::from_utf8(genesis_data.name).map_err(|_e| "Invalid name".to_string())?;
         let id: String =
             String::from_utf8(genesis_data.id).map_err(|_e| "Invalid id".to_string())?;
         let storage_raw: BTreeMap<_, _> =
             genesis_data.storage.into_iter().map(|x| x.into()).collect();
-        let boot_nodes: Vec<MultiaddrWithPeerId> = boot_nodes
-            .into_iter()
-            .map(|x| {
-                x.parse::<MultiaddrWithPeerId>()
-                    .map_err(|e| format!("{}", e))
-            })
-            .collect::<Result<_, _>>()?;
         let telemetry_endpoints = None;
         let protocol_id = Some(format!("container-chain-{}", para_id));
         let fork_id = genesis_data
@@ -370,7 +363,7 @@ impl ContainerChainCli {
         genesis_data: ContainerChainGenesisData<MaxLengthTokenSymbol>,
         chain_type: sc_chain_spec::ChainType,
         relay_chain: String,
-        boot_nodes: Vec<String>,
+        boot_nodes: Vec<MultiaddrWithPeerId>,
     ) -> Result<(), String> {
         let chain_spec = Self::chain_spec_from_genesis_data(
             para_id,

--- a/node/src/container_chain_spawner.rs
+++ b/node/src/container_chain_spawner.rs
@@ -181,30 +181,8 @@ impl ContainerChainSpawner {
                     container_chain_para_id
                 );
             }
-            let boot_nodes: Vec<MultiaddrWithPeerId> = boot_nodes_raw
-                .into_iter()
-                .filter_map(|x| {
-                    let x = String::from_utf8(x)
-                        .map_err(|e| {
-                            log::debug!(
-                                "Invalid boot node in container chain {}: {}",
-                                container_chain_para_id,
-                                e
-                            );
-                        })
-                        .ok()?;
-
-                    x.parse::<MultiaddrWithPeerId>()
-                        .map_err(|e| {
-                            log::debug!(
-                                "Invalid boot node in container chain {}: {}",
-                                container_chain_para_id,
-                                e
-                            )
-                        })
-                        .ok()
-                })
-                .collect();
+            let boot_nodes =
+                parse_boot_nodes_ignore_invalid(boot_nodes_raw, container_chain_para_id);
             if boot_nodes.is_empty() {
                 log::warn!(
                     "No valid boot nodes for container chain {}",
@@ -728,6 +706,37 @@ fn delete_container_chain_db(db_path: &Path) {
     }
 }
 
+/// Parse a list of boot nodes in `Vec<u8>` format. Invalid boot nodes are filtered out.
+fn parse_boot_nodes_ignore_invalid(
+    boot_nodes_raw: Vec<Vec<u8>>,
+    container_chain_para_id: ParaId,
+) -> Vec<MultiaddrWithPeerId> {
+    boot_nodes_raw
+        .into_iter()
+        .filter_map(|x| {
+            let x = String::from_utf8(x)
+                .map_err(|e| {
+                    log::debug!(
+                        "Invalid boot node in container chain {}: {}",
+                        container_chain_para_id,
+                        e
+                    );
+                })
+                .ok()?;
+
+            x.parse::<MultiaddrWithPeerId>()
+                .map_err(|e| {
+                    log::debug!(
+                        "Invalid boot node in container chain {}: {}",
+                        container_chain_para_id,
+                        e
+                    )
+                })
+                .ok()
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use futures::executor::block_on;
@@ -1140,5 +1149,26 @@ mod tests {
         m.handle_update_assignment(Some(2000.into()), Some(2000.into()));
         m.assert_collating_on(Some(2000.into()));
         m.assert_running_chains(&[2000.into()]);
+    }
+
+    #[test]
+    fn invalid_boot_nodes_are_ignored() {
+        let para_id = 100.into();
+        let bootnode1 =
+            b"/ip4/127.0.0.1/tcp/33049/ws/p2p/12D3KooWHVMhQDHBpj9vQmssgyfspYecgV6e3hH1dQVDUkUbCYC9"
+                .to_vec();
+        assert_eq!(
+            parse_boot_nodes_ignore_invalid(vec![b"A".to_vec()], para_id),
+            vec![]
+        );
+        assert_eq!(
+            parse_boot_nodes_ignore_invalid(vec![b"\xff".to_vec()], para_id),
+            vec![]
+        );
+        // Valid boot nodes are not ignored
+        assert_eq!(
+            parse_boot_nodes_ignore_invalid(vec![bootnode1], para_id).len(),
+            1
+        );
     }
 }


### PR DESCRIPTION
Fix a panic when bootnodes are invalid. A container chain with zero valid boot nodes will still start, even though it probably won't find any peers and therefore the collator will not produce any blocks.

Can be tested using the `set_boot_nodes` extrinsic in `zombie_tanssi`, test cases:

0xff (invalid utf8)
A (invalid multiaddr)