### PR TITLE
Force container chains to use paritydb

### DIFF
--- a/node/src/container_chain_spawner.rs
+++ b/node/src/container_chain_spawner.rs
@@ -37,7 +37,7 @@ use {
     pallet_author_noting_runtime_api::AuthorNotingApi,
     pallet_registrar_runtime_api::RegistrarApi,
     polkadot_primitives::CollatorPair,
-    sc_cli::SyncMode,
+    sc_cli::{Database, SyncMode},
     sc_network::config::MultiaddrWithPeerId,
     sc_service::SpawnTaskHandle,
     sp_api::{ApiExt, ProvideRuntimeApi},
@@ -220,6 +220,12 @@ impl ContainerChainSpawner {
 
             // Update CLI params
             container_chain_cli.base.para_id = Some(container_chain_para_id.into());
+            container_chain_cli
+                .base
+                .base
+                .import_params
+                .database_params
+                .database = Some(Database::ParityDb);
 
             let create_container_chain_cli_config = || {
                 let mut container_chain_cli_config = sc_cli::SubstrateCli::create_configuration(
@@ -697,7 +703,7 @@ fn open_and_maybe_delete_db(
 }
 
 // TODO: this leaves some empty folders behind, because it is called with db_path:
-//     Collator2002-01/data/containers/chains/simple_container_2002/db/full-container-2002
+//     Collator2002-01/data/containers/chains/simple_container_2002/paritydb/full-container-2002
 // but we want to delete everything under
 //     Collator2002-01/data/containers/chains/simple_container_2002
 fn delete_container_chain_db(db_path: &Path) {

--- a/test/suites/keep-db/test_restart_keep_db.ts
+++ b/test/suites/keep-db/test_restart_keep_db.ts
@@ -217,10 +217,10 @@ describeSuite({
                 // Check db has not been deleted
                 const dbPath01 =
                     getTmpZombiePath() +
-                    `/Collator2000-01/data/containers/chains/simple_container_2000/db/full-container-2000`;
+                    `/Collator2000-01/data/containers/chains/simple_container_2000/paritydb/full-container-2000`;
                 const dbPath02 =
                     getTmpZombiePath() +
-                    `/Collator2000-02/data/containers/chains/simple_container_2000/db/full-container-2000`;
+                    `/Collator2000-02/data/containers/chains/simple_container_2000/paritydb/full-container-2000`;
 
                 expect(await directoryExists(dbPath01)).to.be.true;
                 expect(await directoryExists(dbPath02)).to.be.true;
@@ -255,10 +255,10 @@ describeSuite({
                 // Collator2000-01 db path exists because it was started with `--keep-db`, Collator2000-02 has deleted it
                 const dbPath01 =
                     getTmpZombiePath() +
-                    `/Collator2000-01/data/containers/chains/simple_container_2000/db/full-container-2000`;
+                    `/Collator2000-01/data/containers/chains/simple_container_2000/paritydb/full-container-2000`;
                 const dbPath02 =
                     getTmpZombiePath() +
-                    `/Collator2000-02/data/containers/chains/simple_container_2000/db/full-container-2000`;
+                    `/Collator2000-02/data/containers/chains/simple_container_2000/paritydb/full-container-2000`;
 
                 expect(await directoryExists(dbPath01)).to.be.true;
                 expect(await directoryExists(dbPath02)).to.be.false;

--- a/test/suites/rotation-para/test_rotation.ts
+++ b/test/suites/rotation-para/test_rotation.ts
@@ -73,8 +73,8 @@ describeSuite({
             console.log(collatorName);
 
             containerDbPaths = [
-                "/data/containers/chains/simple_container_2000/db/full-container-2000",
-                "/data/containers/chains/frontier_container_2001/db/full-container-2001",
+                "/data/containers/chains/simple_container_2000/paritydb/full-container-2000",
+                "/data/containers/chains/frontier_container_2001/paritydb/full-container-2001",
             ];
         }, 120000);
 
@@ -292,10 +292,10 @@ describeSuite({
                 const oldC2001 = collatorName[assignment3.containerChains[2001][0]];
                 const oldContainer2000DbPath =
                     getTmpZombiePath() +
-                    `/${oldC2000}/data/containers/chains/simple_container_2000/db/full-container-2000`;
+                    `/${oldC2000}/data/containers/chains/simple_container_2000/paritydb/full-container-2000`;
                 const oldContainer2001DbPath =
                     getTmpZombiePath() +
-                    `/${oldC2001}/data/containers/chains/frontier_container_2001/db/full-container-2001`;
+                    `/${oldC2001}/data/containers/chains/frontier_container_2001/paritydb/full-container-2001`;
                 expect(await directoryExists(oldContainer2000DbPath)).to.be.true;
                 expect(await directoryExists(oldContainer2001DbPath)).to.be.true;
 
@@ -311,10 +311,10 @@ describeSuite({
                 // and unassignedCollators should not have any db path
                 const container2000DbPath =
                     getTmpZombiePath() +
-                    `/${c2000}/data/containers/chains/simple_container_2000/db/full-container-2000`;
+                    `/${c2000}/data/containers/chains/simple_container_2000/paritydb/full-container-2000`;
                 const container2001DbPath =
                     getTmpZombiePath() +
-                    `/${c2001}/data/containers/chains/frontier_container_2001/db/full-container-2001`;
+                    `/${c2001}/data/containers/chains/frontier_container_2001/paritydb/full-container-2001`;
                 expect(await directoryExists(container2000DbPath)).to.be.true;
                 expect(await directoryExists(container2001DbPath)).to.be.true;
 
@@ -342,10 +342,10 @@ describeSuite({
                 const c2001 = collatorName[assignment5.containerChains[2001][0]];
                 const oldContainer2000DbPath =
                     getTmpZombiePath() +
-                    `/${oldC2000}/data/containers/chains/simple_container_2000/db/full-container-2000`;
+                    `/${oldC2000}/data/containers/chains/simple_container_2000/paritydb/full-container-2000`;
                 const oldContainer2001DbPath =
                     getTmpZombiePath() +
-                    `/${oldC2001}/data/containers/chains/frontier_container_2001/db/full-container-2001`;
+                    `/${oldC2001}/data/containers/chains/frontier_container_2001/paritydb/full-container-2001`;
                 // Edge case: collators may be assigned to the same chain, in that case the directory will still exist
                 if (oldC2000 != c2000) {
                     expect(await directoryExists(oldContainer2000DbPath)).to.be.false;
@@ -361,10 +361,10 @@ describeSuite({
                 // and unassignedCollators should not have any db path
                 const container2000DbPath =
                     getTmpZombiePath() +
-                    `/${c2000}/data/containers/chains/simple_container_2000/db/full-container-2000`;
+                    `/${c2000}/data/containers/chains/simple_container_2000/paritydb/full-container-2000`;
                 const container2001DbPath =
                     getTmpZombiePath() +
-                    `/${c2001}/data/containers/chains/frontier_container_2001/db/full-container-2001`;
+                    `/${c2001}/data/containers/chains/frontier_container_2001/paritydb/full-container-2001`;
                 expect(await directoryExists(container2000DbPath)).to.be.true;
                 expect(await directoryExists(container2001DbPath)).to.be.true;
                 await ensureContainerDbPathsDontExist(unassignedCollators, containerDbPaths);

--- a/test/suites/warp-sync/test_warp_sync.ts
+++ b/test/suites/warp-sync/test_warp_sync.ts
@@ -151,10 +151,10 @@ describeSuite({
                 // Collator2000-02 should have a container 2000 db, and Collator1000-03 should not
                 const collator100003DbPath =
                     getTmpZombiePath() +
-                    "/Collator1000-03/data/containers/chains/simple_container_2000/db/full-container-2000";
+                    "/Collator1000-03/data/containers/chains/simple_container_2000/paritydb/full-container-2000";
                 const container200002DbPath =
                     getTmpZombiePath() +
-                    "/Collator2000-02/data/containers/chains/simple_container_2000/db/full-container-2000";
+                    "/Collator2000-02/data/containers/chains/simple_container_2000/paritydb/full-container-2000";
                 expect(await directoryExists(container200002DbPath)).to.be.true;
                 expect(await directoryExists(collator100003DbPath)).to.be.false;
 


### PR DESCRIPTION
The current default is rocksdb, but warp sync seems to be broken with rocksdb. So from now on, container chains can only use paritydb. Unblocks #361