### PR TITLE
Missing dev_flashbox flags

### DIFF
--- a/test/moonwall.config.json
+++ b/test/moonwall.config.json
@@ -387,7 +387,11 @@
                             "--alice",
                             "--force-authoring",
                             "--rpc-cors=all", 
-                            "--tmp"
+                            "--tmp",
+                            "--no-hardware-benchmarks",
+                            "--no-prometheus",
+                            "--no-telemetry",
+                            "--reserved-only"
                         ],
                         "disableDefaultEthProviders": true,
                         "newRpcBehaviour": true


### PR DESCRIPTION
Fixes the unexpected behavior when running Moonwall test suite `dev_flashbox`, addressed by `--reserved-only`