### PR TITLE
Change default para id for templates

### DIFF
--- a/container-chains/templates/frontier/node/src/command.rs
+++ b/container-chains/templates/frontier/node/src/command.rs
@@ -92,7 +92,7 @@ impl SubstrateCli for Cli {
     }
 
     fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
-        load_spec(id, self.para_id.unwrap_or(1000).into())
+        load_spec(id, self.para_id.unwrap_or(2000).into())
     }
 }
 

--- a/container-chains/templates/simple/node/src/command.rs
+++ b/container-chains/templates/simple/node/src/command.rs
@@ -89,7 +89,7 @@ impl SubstrateCli for Cli {
     }
 
     fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
-        load_spec(id, self.para_id.unwrap_or(1000).into())
+        load_spec(id, self.para_id.unwrap_or(2000).into())
     }
 }
 

--- a/test/moonwall.config.json
+++ b/test/moonwall.config.json
@@ -60,7 +60,7 @@
                     {
                         "name": "frontier-template",
                         "binPath": "../target/release/container-chain-template-frontier-node",
-                        "options": ["--dev", "--sealing=manual", "--para-id=2000"],
+                        "options": ["--dev", "--sealing=manual"],
                         "newRpcBehaviour": true
                     }
                 ]
@@ -78,7 +78,7 @@
                     {
                         "name": "simple-template",
                         "binPath": "../target/release/container-chain-template-simple-node",
-                        "options": ["--dev", "--sealing=manual", "--para-id=2000"],
+                        "options": ["--dev", "--sealing=manual"],
                         "newRpcBehaviour": true,
                         "disableDefaultEthProviders": true
                     }

--- a/test/suites/dev-frontier-template/test-balance/test-balance-existential.ts
+++ b/test/suites/dev-frontier-template/test-balance/test-balance-existential.ts
@@ -2,7 +2,7 @@ import { TransactionTypes, beforeEach, describeSuite, expect } from "@moonwall/c
 import { ALITH_ADDRESS, BALTATHAR_ADDRESS, MIN_GAS_PRICE, createRawTransfer } from "@moonwall/util";
 import { PrivateKeyAccount } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
-//
+
 describeSuite({
     id: "DF0101",
     title: "Existential Deposit disabled",

--- a/test/suites/dev-frontier-template/test-balance/test-balance-existential.ts
+++ b/test/suites/dev-frontier-template/test-balance/test-balance-existential.ts
@@ -2,7 +2,7 @@ import { TransactionTypes, beforeEach, describeSuite, expect } from "@moonwall/c
 import { ALITH_ADDRESS, BALTATHAR_ADDRESS, MIN_GAS_PRICE, createRawTransfer } from "@moonwall/util";
 import { PrivateKeyAccount } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
-
+//
 describeSuite({
     id: "DF0101",
     title: "Existential Deposit disabled",


### PR DESCRIPTION
Prior to this change, the local execution of templates nodes was failing as there was a mismatch with the default `para-id` for the `orchestrator-chain` (1000) and the default `para-id` for `container-chains` (also 1000 and now changed to 2000 as we have in moonwall).