### PR TITLE
Avoid error log "ZeroCollators" when running cargo test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7633,6 +7633,8 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "tp-traits",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -268,8 +268,8 @@ similar-asserts = "1.1.0"
 tempfile = "3.1.0"
 thiserror = { version = "1.0.40" }
 tokio = { version = "1.32.0", default-features = false }
-tracing = { version = "0.1.37", default-features = false } # keep in sync with sp-tracing
-tracing-subscriber = { version = "0.2.25", default-features = false } # keep in sync with sp-tracing
+tracing = { version = "0.1.37", default-features = false }
+tracing-subscriber = { version = "0.2.25", default-features = false }
 url = "2.2.2"
 
 [patch.crates-io]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -268,7 +268,8 @@ similar-asserts = "1.1.0"
 tempfile = "3.1.0"
 thiserror = { version = "1.0.40" }
 tokio = { version = "1.32.0", default-features = false }
-tracing = { version = "0.1.37", default-features = false }
+tracing = { version = "0.1.37", default-features = false } # keep in sync with sp-tracing
+tracing-subscriber = { version = "0.2.25", default-features = false } # keep in sync with sp-tracing
 url = "2.2.2"
 
 [patch.crates-io]

--- a/pallets/collator-assignment/Cargo.toml
+++ b/pallets/collator-assignment/Cargo.toml
@@ -26,6 +26,8 @@ tp-traits = { workspace = true }
 
 [dev-dependencies]
 sp-io = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [features]
 default = [ "std" ]

--- a/pallets/collator-assignment/Cargo.toml
+++ b/pallets/collator-assignment/Cargo.toml
@@ -48,6 +48,7 @@ std = [
 	"sp-runtime/std",
 	"sp-std/std",
 	"tp-traits/std",
+	"tracing/std",
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",

--- a/pallets/collator-assignment/src/mock.rs
+++ b/pallets/collator-assignment/src/mock.rs
@@ -16,8 +16,8 @@
 
 use {
     crate::{
-        self as pallet_collator_assignment, GetRandomnessForNextBlock,
-        RotateCollatorsEveryNSessions,
+        self as pallet_collator_assignment, pallet::CollatorContainerChain,
+        GetRandomnessForNextBlock, RotateCollatorsEveryNSessions,
     },
     frame_support::{
         parameter_types,
@@ -30,7 +30,9 @@ use {
         traits::{BlakeTwo256, IdentityLookup},
         BuildStorage,
     },
+    sp_std::collections::btree_map::BTreeMap,
     tp_traits::{ParaId, RemoveInvulnerables, RemoveParaIdsWithNoCredits},
+    tracing_subscriber::{layer::SubscriberExt, FmtSubscriber},
 };
 
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -225,10 +227,20 @@ impl pallet_collator_assignment::Config for Test {
 
 // Build genesis storage according to the mock runtime.
 pub fn new_test_ext() -> sp_io::TestExternalities {
-    system::GenesisConfig::<Test>::default()
+    let mut ext: sp_io::TestExternalities = system::GenesisConfig::<Test>::default()
         .build_storage()
         .unwrap()
-        .into()
+        .into();
+
+    ext.execute_with(|| {
+        MockData::mutate(|mocks| {
+            // Initialize collators with 1 collator to avoid error `ZeroCollators` in session 0
+            mocks.collators = vec![100];
+            mocks.min_orchestrator_chain_collators = 1;
+        })
+    });
+
+    ext
 }
 
 pub trait GetCollators<AccountId, SessionIndex> {
@@ -289,4 +301,38 @@ impl RemoveParaIdsWithNoCredits for RemoveParaIdsAbove5000 {
             assert!(*para_id > ParaId::from(5000), "{}", para_id);
         }
     }
+}
+
+/// Returns a map of collator to assigned para id
+pub fn assigned_collators() -> BTreeMap<u64, u32> {
+    let assigned_collators = CollatorContainerChain::<Test>::get();
+
+    let mut h = BTreeMap::new();
+
+    for (para_id, collators) in assigned_collators.container_chains.iter() {
+        for collator in collators.iter() {
+            h.insert(*collator, u32::from(*para_id));
+        }
+    }
+
+    for collator in assigned_collators.orchestrator_chain {
+        h.insert(collator, 1000);
+    }
+
+    h
+}
+
+/// Returns the default assignment for session 0 used in tests. Collator 100 is assigned to the orchestrator chain.
+pub fn initial_collators() -> BTreeMap<u64, u32> {
+    BTreeMap::from_iter(vec![(100, 1000)])
+}
+
+/// Executes code without printing any logs. Can be used in tests where we expect logs to be printed, to avoid clogging
+/// up stderr. Only affects the current thread, if `f` spawns any threads or if logs come from another thread, they will
+/// not be silenced.
+pub fn silence_logs<F: FnOnce() -> R, R>(f: F) -> R {
+    let no_logging_layer = tracing_subscriber::filter::LevelFilter::OFF;
+    let no_logging_subscriber = FmtSubscriber::builder().finish().with(no_logging_layer);
+
+    tracing::subscriber::with_default(no_logging_subscriber, f)
 }


### PR DESCRIPTION
In #385 I added a log for error cases that should never happen, but I didn't consider that they happen in tests. This results in `cargo test` currently printing this error multiple times:

```
ERROR pallet_collator_assignment::pallet: Error in collator assignment, will keep previous assignment. ZeroCollators
```

So this PR changes the default collator assignment in tests to avoid that error, and also includes a helper function to silence logs inside a test to avoid this problem in the future.