### PR TITLE
Add lsof to docker image

### DIFF
--- a/docker/tanssi.Dockerfile
+++ b/docker/tanssi.Dockerfile
@@ -4,7 +4,7 @@
 
 FROM docker.io/library/ubuntu:20.04 AS builder
 
-RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificates
+RUN apt-get update && apt-get install -y ca-certificates lsof && update-ca-certificates
 
 FROM debian:bookworm-slim
 LABEL maintainer "gorka@moondancelabs.com"


### PR DESCRIPTION
Allows to more easily troubleshoot issues related to open files in the future.