### PR TITLE
Implement on demand block production

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -545,6 +545,61 @@ jobs:
                   name: logs
                   path: logs
 
+    zombienet-tests-parathreads:
+      runs-on: ubuntu-latest
+      needs: ["set-tags", "build"]
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v3
+          with:
+            ref: ${{ needs.set-tags.outputs.git_ref }}
+
+        - name: Pnpm
+          uses: pnpm/action-setup@v2
+          with:
+            version: 8
+
+        - name: Setup Node
+          uses: actions/setup-node@v3
+          with:
+            node-version: 20.x
+            cache: "pnpm"
+
+        - name: "Download binaries"
+          uses: actions/download-artifact@v3.0.2
+          with:
+            name: binaries
+            path: target/release
+
+        - name: "Run zombie test"
+          run: |
+            chmod uog+x target/release/tanssi-node
+            chmod uog+x target/release/container-chain-template-simple-node
+            chmod uog+x target/release/container-chain-template-frontier-node
+            
+            cd test
+            pnpm install
+            
+            ## Run tests
+            
+            pnpm moonwall test zombie_tanssi_parathreads
+
+        - name: "Gather zombie logs"
+          if: failure()
+          run: |
+            ls -ltr /tmp
+            latest_zombie_dir=$(find /tmp -type d -iname "*zombie*" -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d" ")
+            logs_dir="logs"
+            mkdir -p "$logs_dir"
+            find "$latest_zombie_dir" -type f -name "*.log" -exec cp {} "$logs_dir" \;
+
+        - name: "Upload zombie logs"
+          if: failure()
+          uses: actions/upload-artifact@v3.1.2
+          with:
+            name: logs-parathreads
+            path: logs
+
     zombienet-tests-rotation:
         runs-on: self-hosted
         needs: ["set-tags", "build"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14683,6 +14683,7 @@ dependencies = [
  "log",
  "nimbus-consensus",
  "nimbus-primitives",
+ "pallet-registrar-runtime-api",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "polkadot-node-primitives",

--- a/client/consensus/Cargo.toml
+++ b/client/consensus/Cargo.toml
@@ -30,6 +30,7 @@ substrate-prometheus-endpoint = { workspace = true }
 
 # Own
 tp-consensus = { workspace = true, features = [ "std" ] }
+pallet-registrar-runtime-api = { workspace = true, features = [ "std" ] }
 
 # Cumulus dependencies
 cumulus-client-collator = { workspace = true }

--- a/client/consensus/Cargo.toml
+++ b/client/consensus/Cargo.toml
@@ -29,8 +29,8 @@ sp-timestamp = { workspace = true }
 substrate-prometheus-endpoint = { workspace = true }
 
 # Own
-tp-consensus = { workspace = true, features = [ "std" ] }
 pallet-registrar-runtime-api = { workspace = true, features = [ "std" ] }
+tp-consensus = { workspace = true, features = [ "std" ] }
 
 # Cumulus dependencies
 cumulus-client-collator = { workspace = true }

--- a/client/consensus/src/collators.rs
+++ b/client/consensus/src/collators.rs
@@ -332,17 +332,14 @@ where
         if let Ok(chain_head_slot) = find_pre_digest::<B, P::Signature>(chain_head) {
             let slot_diff = slot.saturating_sub(chain_head_slot);
 
-            if slot_diff >= start {
-                false
-            } else {
-                // TODO: this ignores force authoring
-                true
-            }
+            // TODO: this ignores force authoring
+            slot_diff < start
         } else {
             // In case of error always propose
             false
         }
     } else {
+        // Not a parathread: always propose
         false
     }
 }

--- a/client/consensus/src/collators.rs
+++ b/client/consensus/src/collators.rs
@@ -328,12 +328,14 @@ where
         // Always produce on slot 0 (for tests)
         return false;
     }
-    if let Some((start, _end)) = aux_data.next_slot_range_inclusive {
+    if let Some(min_slot_freq) = aux_data.min_slot_freq {
         if let Ok(chain_head_slot) = find_pre_digest::<B, P::Signature>(chain_head) {
             let slot_diff = slot.saturating_sub(chain_head_slot);
 
-            // TODO: this ignores force authoring
-            slot_diff < start
+            // TODO: this doesn't take into account force authoring.
+            // So a node with `force_authoring = true` will not propose a block for a parathread until the
+            // `min_slot_freq` has elapsed.
+            slot_diff < min_slot_freq
         } else {
             // In case of error always propose
             false

--- a/client/consensus/src/collators/basic.rs
+++ b/client/consensus/src/collators/basic.rs
@@ -45,8 +45,8 @@ use sp_keystore::KeystorePtr;
 use sp_runtime::traits::{Block as BlockT, Header as HeaderT, Member};
 use std::{convert::TryFrom, sync::Arc, time::Duration};
 
-use crate::collators as collator_util;
-use crate::{consensus_orchestrator::RetrieveAuthoritiesFromOrchestrator, AuthorityId};
+use crate::consensus_orchestrator::RetrieveAuthoritiesFromOrchestrator;
+use crate::{collators as collator_util, OrchestratorAuraWorkerAuxData};
 
 /// Parameters for [`run`].
 pub struct Params<BI, CIDP, Client, RClient, SO, Proposer, CS, GOH> {
@@ -93,13 +93,13 @@ where
     SO: SyncOracle + Send + Sync + Clone + 'static,
     Proposer: ProposerInterface<Block> + Send + Sync + 'static,
     CS: CollatorServiceInterface<Block> + Send + Sync + 'static,
-    P: Pair,
+    P: Pair + Sync + Send + 'static,
     P::Public: AppPublic + Member + Codec,
     P::Signature: TryFrom<Vec<u8>> + Member + Codec,
     GOH: RetrieveAuthoritiesFromOrchestrator<
             Block,
             (PHash, PersistedValidationData),
-            Vec<AuthorityId<P>>,
+            OrchestratorAuraWorkerAuxData<P>,
         >
         + 'static
         + Sync
@@ -201,8 +201,9 @@ where
                 Ok(h) => h,
             };
 
-            let mut claim = match collator_util::tanssi_claim_slot::<P>(
+            let mut claim = match collator_util::tanssi_claim_slot::<P, Block>(
                 authorities,
+                &parent_header,
                 inherent_providers.slot(),
                 params.force_authoring,
                 &params.keystore,

--- a/client/consensus/src/collators/basic.rs
+++ b/client/consensus/src/collators/basic.rs
@@ -51,7 +51,7 @@ use crate::{collators as collator_util, OrchestratorAuraWorkerAuxData};
 /// Parameters for [`run`].
 pub struct Params<BI, CIDP, Client, RClient, SO, Proposer, CS, GOH> {
     pub create_inherent_data_providers: CIDP,
-    pub get_authorities_from_orchestrator: GOH,
+    pub get_orchestrator_aux_data: GOH,
     pub block_import: BI,
     pub para_client: Arc<Client>,
     pub relay_client: RClient,
@@ -178,7 +178,7 @@ where
 
             // Retrieve authorities that are able to produce the block
             let authorities = match params
-                .get_authorities_from_orchestrator
+                .get_orchestrator_aux_data
                 .retrieve_authorities_from_orchestrator(
                     parent_hash,
                     (relay_parent_header.hash(), validation_data.clone()),

--- a/client/consensus/src/consensus_orchestrator.rs
+++ b/client/consensus/src/consensus_orchestrator.rs
@@ -21,6 +21,9 @@
 //! the ParachainConsensus trait to access the orchestrator-dicated authorities, and further
 //! it implements the TanssiWorker to TanssiOnSlot trait. This trait is
 use {
+    crate::AuthorityId,
+    crate::Pair,
+    crate::Slot,
     sc_consensus_slots::{SimpleSlotWorker, SlotInfo, SlotResult},
     sp_consensus::Proposer,
     sp_runtime::traits::Block as BlockT,
@@ -58,6 +61,14 @@ where
     ) -> Result<A, Box<dyn std::error::Error + Send + Sync>> {
         (*self)(parent, extra_args).await
     }
+}
+
+pub struct OrchestratorAuraWorkerAuxData<P>
+where
+    P: Pair + Send + Sync + 'static,
+{
+    pub authorities: Vec<AuthorityId<P>>,
+    pub next_slot_range_inclusive: Option<(Slot, Slot)>,
 }
 
 #[async_trait::async_trait]

--- a/client/consensus/src/consensus_orchestrator.rs
+++ b/client/consensus/src/consensus_orchestrator.rs
@@ -68,7 +68,7 @@ where
     P: Pair + Send + Sync + 'static,
 {
     pub authorities: Vec<AuthorityId<P>>,
-    pub next_slot_range_inclusive: Option<(Slot, Slot)>,
+    pub min_slot_freq: Option<Slot>,
 }
 
 #[async_trait::async_trait]

--- a/client/consensus/src/lib.rs
+++ b/client/consensus/src/lib.rs
@@ -28,6 +28,7 @@ mod manual_seal;
 #[cfg(test)]
 mod tests;
 
+pub use crate::consensus_orchestrator::OrchestratorAuraWorkerAuxData;
 pub use sc_consensus_aura::CompatibilityMode;
 
 pub use {
@@ -36,7 +37,9 @@ pub use {
         get_aura_id_from_seed, ContainerManualSealAuraConsensusDataProvider,
         OrchestratorManualSealAuraConsensusDataProvider,
     },
+    pallet_registrar_runtime_api::OnDemandBlockProductionApi,
     parity_scale_codec::{Decode, Encode},
+    sc_consensus_aura::find_pre_digest,
     sc_consensus_aura::{slot_duration, AuraVerifier, BuildAuraWorkerParams, SlotProportion},
     sc_consensus_slots::InherentDataProviderExt,
     sp_api::{Core, ProvideRuntimeApi},
@@ -94,6 +97,35 @@ where
 
     let authorities = runtime_api
         .para_id_authorities(*parent_hash, para_id)
+        .ok()?;
+    log::info!(
+        "Authorities found for para {:?} are {:?}",
+        para_id,
+        authorities
+    );
+    authorities
+}
+
+/// Return the set of authorities assigned to the paraId where
+/// the first eligible key from the keystore is collating
+pub fn slot_range<B, C, P>(
+    client: &C,
+    parent_hash: &B::Hash,
+    para_id: ParaId,
+) -> Option<(Slot, Slot)>
+where
+    P: Pair + Send + Sync + 'static,
+    P::Public: AppPublic + Hash + Member + Encode + Decode,
+    P::Signature: TryFrom<Vec<u8>> + Hash + Member + Encode + Decode,
+    B: BlockT,
+    C: ProvideRuntimeApi<B>,
+    C::Api: OnDemandBlockProductionApi<B, ParaId, Slot>,
+    AuthorityId<P>: From<<NimbusPair as sp_application_crypto::Pair>::Public>,
+{
+    let runtime_api = client.runtime_api();
+
+    let authorities = runtime_api
+        .next_slot_range_inclusive(*parent_hash, para_id)
         .ok()?;
     log::info!(
         "Authorities found for para {:?} are {:?}",

--- a/client/consensus/src/lib.rs
+++ b/client/consensus/src/lib.rs
@@ -108,11 +108,7 @@ where
 
 /// Return the set of authorities assigned to the paraId where
 /// the first eligible key from the keystore is collating
-pub fn slot_range<B, C, P>(
-    client: &C,
-    parent_hash: &B::Hash,
-    para_id: ParaId,
-) -> Option<(Slot, Slot)>
+pub fn min_slot_freq<B, C, P>(client: &C, parent_hash: &B::Hash, para_id: ParaId) -> Option<Slot>
 where
     P: Pair + Send + Sync + 'static,
     P::Public: AppPublic + Hash + Member + Encode + Decode,
@@ -124,15 +120,13 @@ where
 {
     let runtime_api = client.runtime_api();
 
-    let authorities = runtime_api
-        .next_slot_range_inclusive(*parent_hash, para_id)
-        .ok()?;
-    log::info!(
-        "Authorities found for para {:?} are {:?}",
+    let min_slot_freq = runtime_api.min_slot_freq(*parent_hash, para_id).ok()?;
+    log::debug!(
+        "min_slot_freq for para {:?} is {:?}",
         para_id,
-        authorities
+        min_slot_freq
     );
-    authorities
+    min_slot_freq
 }
 
 use nimbus_primitives::{NimbusId, NimbusPair, NIMBUS_KEY_ID};

--- a/client/consensus/src/tests.rs
+++ b/client/consensus/src/tests.rs
@@ -19,11 +19,14 @@
 // https://github.com/paritytech/substrate/blob/master/client/consensus/aura/src/lib.rs#L832
 // Most of the items hereby added are intended to make it work with our current consensus mechanism
 use {
-    crate::collators::{tanssi_claim_slot, Collator, Params as CollatorParams},
+    crate::{
+        collators::{tanssi_claim_slot, Collator, Params as CollatorParams},
+        OrchestratorAuraWorkerAuxData,
+    },
     async_trait::async_trait,
     cumulus_client_collator::service::CollatorService,
     cumulus_client_consensus_proposer::Proposer as ConsensusProposer,
-    cumulus_primitives_core::{relay_chain::BlockId, CollationInfo, CollectCollationInfo},
+    cumulus_primitives_core::{relay_chain::BlockId, CollationInfo, CollectCollationInfo, ParaId},
     cumulus_relay_chain_interface::{
         CommittedCandidateReceipt, OverseerHandle, RelayChainInterface, RelayChainResult,
         StorageValue,
@@ -33,7 +36,7 @@ use {
     nimbus_primitives::{
         CompatibleDigestItem, NimbusId, NimbusPair, NIMBUS_ENGINE_ID, NIMBUS_KEY_ID,
     },
-    parity_scale_codec::alloc::collections::{BTreeMap, BTreeSet},
+    parity_scale_codec::Encode,
     parking_lot::Mutex,
     polkadot_core_primitives::{Header as PHeader, InboundDownwardMessage, InboundHrmpMessage},
     polkadot_parachain_primitives::primitives::HeadData,
@@ -44,9 +47,11 @@ use {
     sc_client_api::HeaderBackend,
     sc_consensus::{BoxJustificationImport, ForkChoiceStrategy},
     sc_keystore::LocalKeystore,
-    sc_network_test::{Block as TestBlock, *},
+    sc_network_test::{Block as TestBlock, Header as TestHeader, *},
+    sp_api::{ApiRef, ProvideRuntimeApi},
     sp_consensus::{EnableProofRecording, Environment, Proposal, Proposer},
-    sp_consensus_aura::{inherents::InherentDataProvider, SlotDuration},
+    sp_consensus_aura::{inherents::InherentDataProvider, SlotDuration, AURA_ENGINE_ID},
+    sp_consensus_slots::Slot,
     sp_core::{
         crypto::{ByteArray, Pair},
         traits::SpawnNamed,
@@ -59,7 +64,12 @@ use {
         Digest, DigestItem,
     },
     sp_timestamp::Timestamp,
-    std::{pin::Pin, sync::Arc, time::Duration},
+    std::{
+        collections::{BTreeMap, BTreeSet},
+        pin::Pin,
+        sync::Arc,
+        time::Duration,
+    },
     substrate_test_runtime_client::TestClient,
 };
 
@@ -73,7 +83,6 @@ struct DummyFactory(Arc<TestClient>);
 // We are going to create API because we need this to test runtime apis
 // We use the client normally, but for testing certain runtime-api calls,
 // we basically mock the runtime-api calls
-use sp_api::{ApiRef, ProvideRuntimeApi};
 impl ProvideRuntimeApi<Block> for DummyFactory {
     type Api = MockApi;
 
@@ -81,8 +90,6 @@ impl ProvideRuntimeApi<Block> for DummyFactory {
         MockApi.into()
     }
 }
-
-use cumulus_primitives_core::ParaId;
 
 struct MockApi;
 
@@ -441,47 +448,89 @@ async fn current_node_authority_should_claim_slot() {
     authorities.push(public.into());
 
     let keystore_ptr: KeystorePtr = keystore.into();
+    let mut claimed_slots = vec![];
 
-    assert!(
-        tanssi_claim_slot::<NimbusPair>(authorities.clone(), 0.into(), false, &keystore_ptr)
-            .unwrap()
-            .is_none()
-    );
-    assert!(
-        tanssi_claim_slot::<NimbusPair>(authorities.clone(), 1.into(), false, &keystore_ptr)
-            .unwrap()
-            .is_none()
-    );
-    assert!(
-        tanssi_claim_slot::<NimbusPair>(authorities.clone(), 2.into(), false, &keystore_ptr)
-            .unwrap()
-            .is_none()
-    );
-    assert!(
-        tanssi_claim_slot::<NimbusPair>(authorities.clone(), 3.into(), false, &keystore_ptr)
-            .unwrap()
-            .is_some()
-    );
-    assert!(
-        tanssi_claim_slot::<NimbusPair>(authorities.clone(), 4.into(), false, &keystore_ptr)
-            .unwrap()
-            .is_none()
-    );
-    assert!(
-        tanssi_claim_slot::<NimbusPair>(authorities.clone(), 5.into(), false, &keystore_ptr)
-            .unwrap()
-            .is_none()
-    );
-    assert!(
-        tanssi_claim_slot::<NimbusPair>(authorities.clone(), 6.into(), false, &keystore_ptr)
-            .unwrap()
-            .is_none()
-    );
-    assert!(
-        tanssi_claim_slot::<NimbusPair>(authorities.clone(), 7.into(), false, &keystore_ptr)
-            .unwrap()
-            .is_some()
-    );
+    for slot in 0..8 {
+        let dummy_head = TestHeader {
+            parent_hash: Default::default(),
+            number: Default::default(),
+            state_root: Default::default(),
+            extrinsics_root: Default::default(),
+            digest: Default::default(),
+        };
+        let aux_data = OrchestratorAuraWorkerAuxData {
+            authorities: authorities.clone(),
+            min_slot_freq: None,
+        };
+        let claim = tanssi_claim_slot::<NimbusPair, TestBlock>(
+            aux_data,
+            &dummy_head,
+            slot.into(),
+            false,
+            &keystore_ptr,
+        )
+        .unwrap();
+        if claim.is_some() {
+            claimed_slots.push(slot);
+        }
+    }
+
+    assert_eq!(claimed_slots, vec![3, 7]);
+}
+
+#[tokio::test]
+async fn claim_slot_respects_min_slot_freq() {
+    // There is only 1 authority, but it can only claim every 4 slots
+    let mut authorities: Vec<NimbusId> = vec![];
+    let min_slot_freq = 4;
+
+    let keystore_path = tempfile::tempdir().expect("Creates keystore path");
+    let keystore = LocalKeystore::open(keystore_path.path(), None).expect("Creates keystore.");
+
+    let public = keystore
+        .sr25519_generate_new(NIMBUS_KEY_ID, None)
+        .expect("Key should be created");
+    authorities.push(public.into());
+
+    let keystore_ptr: KeystorePtr = keystore.into();
+
+    let mut claimed_slots = vec![];
+
+    for slot in 0..10 {
+        let parent_slot: u64 = claimed_slots.last().copied().unwrap_or_default();
+        let parent_slot: Slot = parent_slot.into();
+        let pre_digest = Digest {
+            logs: vec![
+                DigestItem::PreRuntime(AURA_ENGINE_ID, parent_slot.encode()),
+                //DigestItem::PreRuntime(NIMBUS_ENGINE_ID, authority.encode()),
+            ],
+        };
+        let head = TestHeader {
+            parent_hash: Default::default(),
+            // If we use number=0 aura ignores the digest
+            number: claimed_slots.len() as u64,
+            state_root: Default::default(),
+            extrinsics_root: Default::default(),
+            digest: pre_digest,
+        };
+        let aux_data = OrchestratorAuraWorkerAuxData {
+            authorities: authorities.clone(),
+            min_slot_freq: Some(min_slot_freq.into()),
+        };
+        let claim = tanssi_claim_slot::<NimbusPair, TestBlock>(
+            aux_data,
+            &head,
+            slot.into(),
+            false,
+            &keystore_ptr,
+        )
+        .unwrap();
+        if claim.is_some() {
+            claimed_slots.push(slot);
+        }
+    }
+
+    assert_eq!(claimed_slots, vec![0, 4, 8]);
 }
 
 #[tokio::test]
@@ -562,10 +611,18 @@ async fn collate_returns_correct_block() {
     );
     let keystore_ptr: KeystorePtr = keystore_copy.into();
 
-    let mut claim =
-        tanssi_claim_slot::<NimbusPair>(vec![alice_public.into()], *slot, false, &keystore_ptr)
-            .unwrap()
-            .unwrap();
+    let mut claim = tanssi_claim_slot::<NimbusPair, TestBlock>(
+        OrchestratorAuraWorkerAuxData {
+            authorities: vec![alice_public.into()],
+            min_slot_freq: None,
+        },
+        &head,
+        *slot,
+        false,
+        &keystore_ptr,
+    )
+    .unwrap()
+    .unwrap();
 
     // At the end we call collate() function
     let res = collator

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -779,16 +779,15 @@ async fn start_consensus_container(
                     latest_header
                 );
 
-                let next_slot_range_inclusive =
-                    tc_consensus::slot_range::<Block, ParachainClient, NimbusPair>(
-                        orchestrator_client_for_cidp.as_ref(),
-                        &latest_header.hash(),
-                        para_id,
-                    );
+                let min_slot_freq = tc_consensus::min_slot_freq::<Block, ParachainClient, NimbusPair>(
+                    orchestrator_client_for_cidp.as_ref(),
+                    &latest_header.hash(),
+                    para_id,
+                );
 
                 let aux_data = OrchestratorAuraWorkerAuxData {
                     authorities,
-                    next_slot_range_inclusive,
+                    min_slot_freq,
                 };
 
                 Ok(aux_data)
@@ -916,7 +915,7 @@ fn start_consensus_orchestrator(
 
                     let aux_data = OrchestratorAuraWorkerAuxData {
                         authorities,
-                        next_slot_range_inclusive: None,
+                        min_slot_freq: None,
                     };
 
                     Ok(aux_data)

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -742,7 +742,7 @@ async fn start_consensus_container(
                 Ok((slot, timestamp, authorities_noting_inherent))
             }
         },
-        get_authorities_from_orchestrator: move |_block_hash, (relay_parent, _validation_data)| {
+        get_orchestrator_aux_data: move |_block_hash, (relay_parent, _validation_data)| {
             let relay_chain_interace_for_orch = relay_chain_interace_for_orch.clone();
             let orchestrator_client_for_cidp = orchestrator_client_for_cidp.clone();
 
@@ -890,37 +890,37 @@ fn start_consensus_orchestrator(
                 Ok((slot, timestamp, author_noting_inherent))
             }
         },
-        get_authorities_from_orchestrator:
-            move |block_hash: H256, (_relay_parent, _validation_data)| {
-                let client_set_aside_for_orch = client_set_aside_for_orch.clone();
+        get_orchestrator_aux_data: move |block_hash: H256, (_relay_parent, _validation_data)| {
+            let client_set_aside_for_orch = client_set_aside_for_orch.clone();
 
-                async move {
-                    let authorities = tc_consensus::authorities::<Block, ParachainClient, NimbusPair>(
-                        client_set_aside_for_orch.as_ref(),
-                        &block_hash,
-                        para_id,
-                    );
+            async move {
+                let authorities = tc_consensus::authorities::<Block, ParachainClient, NimbusPair>(
+                    client_set_aside_for_orch.as_ref(),
+                    &block_hash,
+                    para_id,
+                );
 
-                    let authorities = authorities.ok_or_else(|| {
-                        Box::<dyn std::error::Error + Send + Sync>::from(
-                            "Failed to fetch authorities with error",
-                        )
-                    })?;
+                let authorities = authorities.ok_or_else(|| {
+                    Box::<dyn std::error::Error + Send + Sync>::from(
+                        "Failed to fetch authorities with error",
+                    )
+                })?;
 
-                    log::info!(
-                        "Authorities {:?} found for header {:?}",
-                        authorities,
-                        block_hash
-                    );
+                log::info!(
+                    "Authorities {:?} found for header {:?}",
+                    authorities,
+                    block_hash
+                );
 
-                    let aux_data = OrchestratorAuraWorkerAuxData {
-                        authorities,
-                        min_slot_freq: None,
-                    };
+                let aux_data = OrchestratorAuraWorkerAuxData {
+                    authorities,
+                    // This is the orchestrator consensus, it does not have a slot frequency
+                    min_slot_freq: None,
+                };
 
-                    Ok(aux_data)
-                }
-            },
+                Ok(aux_data)
+            }
+        },
         block_import,
         para_client: client,
         relay_client: relay_chain_interface,

--- a/pallets/registrar/rpc/runtime-api/src/lib.rs
+++ b/pallets/registrar/rpc/runtime-api/src/lib.rs
@@ -42,13 +42,13 @@ sp_api::decl_runtime_apis! {
         ParaId: parity_scale_codec::Codec,
         Slot: parity_scale_codec::Codec,
     {
-        /// Inclusive range of slots during which collators can propose the next block.
+        /// Return the minimum number of slots that must pass between to blocks before parathread collators can propose
+        /// the next block.
         ///
         /// # Returns
         ///
-        /// Range `Some((start, end))`, where the condition for the slot to be valid is
-        /// `(slot - parent_slot) >= start && (slot - parent_slot) <= end`.
-        /// `None` if the `para_id` is not a parathread.
-        fn next_slot_range_inclusive(para_id: ParaId) -> Option<(Slot, Slot)>;
+        /// * `Some(min)`, where the condition for the slot to be valid is `(slot - parent_slot) >= min`.
+        /// * `None` if the `para_id` is not a parathread.
+        fn min_slot_freq(para_id: ParaId) -> Option<Slot>;
     }
 }

--- a/pallets/registrar/rpc/runtime-api/src/lib.rs
+++ b/pallets/registrar/rpc/runtime-api/src/lib.rs
@@ -36,3 +36,19 @@ sp_api::decl_runtime_apis! {
         fn boot_nodes(para_id: ParaId) -> Vec<Vec<u8>>;
     }
 }
+
+sp_api::decl_runtime_apis! {
+    pub trait OnDemandBlockProductionApi<ParaId, Slot> where
+        ParaId: parity_scale_codec::Codec,
+        Slot: parity_scale_codec::Codec,
+    {
+        /// Inclusive range of slots during which collators can propose the next block.
+        ///
+        /// # Returns
+        ///
+        /// Range `Some((start, end))`, where the condition for the slot to be valid is
+        /// `(slot - parent_slot) >= start && (slot - parent_slot) <= end`.
+        /// `None` if the `para_id` is not a parathread.
+        fn next_slot_range_inclusive(para_id: ParaId) -> Option<(Slot, Slot)>;
+    }
+}

--- a/runtime/dancebox/src/lib.rs
+++ b/runtime/dancebox/src/lib.rs
@@ -204,6 +204,8 @@ pub mod opaque {
     pub type BlockId = generic::BlockId<Block>;
     /// Opaque block hash type.
     pub type Hash = <BlakeTwo256 as HashT>::Output;
+    /// Opaque signature type.
+    pub use super::Signature;
 }
 
 impl_opaque_keys! {
@@ -1829,6 +1831,22 @@ impl_runtime_apis! {
 
             bounded_vec.into_iter().map(|x| x.into()).collect()
         }
+    }
+
+    impl pallet_registrar_runtime_api::OnDemandBlockProductionApi<Block, ParaId, Slot> for Runtime {
+        /// Inclusive range of slots during which collators can propose the next block.
+        ///
+        /// # Returns
+        ///
+        /// Range `Some((start, end))`, where the condition for the slot to be valid is
+        /// `(slot - parent_slot) >= start && (slot - parent_slot) <= end`.
+        /// `None` if the `para_id` is not a parathread.
+        fn next_slot_range_inclusive(para_id: ParaId) -> Option<(Slot, Slot)> {
+            Registrar::parathread_params(para_id).map(|params| {
+                (Slot::from(params.slot_frequency.min as u64), Slot::from(params.slot_frequency.max as u64))
+            })
+        }
+
     }
 
     impl pallet_author_noting_runtime_api::AuthorNotingApi<Block, AccountId, BlockNumber, ParaId> for Runtime

--- a/runtime/dancebox/src/lib.rs
+++ b/runtime/dancebox/src/lib.rs
@@ -1834,16 +1834,16 @@ impl_runtime_apis! {
     }
 
     impl pallet_registrar_runtime_api::OnDemandBlockProductionApi<Block, ParaId, Slot> for Runtime {
-        /// Inclusive range of slots during which collators can propose the next block.
+        /// Return the minimum number of slots that must pass between to blocks before parathread collators can propose
+        /// the next block.
         ///
         /// # Returns
         ///
-        /// Range `Some((start, end))`, where the condition for the slot to be valid is
-        /// `(slot - parent_slot) >= start && (slot - parent_slot) <= end`.
-        /// `None` if the `para_id` is not a parathread.
-        fn next_slot_range_inclusive(para_id: ParaId) -> Option<(Slot, Slot)> {
+        /// * `Some(min)`, where the condition for the slot to be valid is `(slot - parent_slot) >= min`.
+        /// * `None` if the `para_id` is not a parathread.
+        fn min_slot_freq(para_id: ParaId) -> Option<Slot> {
             Registrar::parathread_params(para_id).map(|params| {
-                (Slot::from(params.slot_frequency.min as u64), Slot::from(params.slot_frequency.max as u64))
+                Slot::from(u64::from(params.slot_frequency.min))
             })
         }
 

--- a/test/configs/zombieTanssiParathreads.json
+++ b/test/configs/zombieTanssiParathreads.json
@@ -1,0 +1,105 @@
+{
+    "settings": {
+        "timeout": 1000,
+        "provider": "native"
+    },
+    "relaychain": {
+        "chain": "rococo-local",
+        "default_command": "tmp/polkadot",
+        "default_args": ["--no-hardware-benchmarks", "-lparachain=debug", "--database=paritydb", "--no-beefy"],
+        "nodes": [
+            {
+                "name": "alice",
+                "ws_port": "9947",
+                "validator": true
+            },
+            {
+                "name": "bob",
+                "validator": true
+            },
+            {
+                "name": "charlie",
+                "validator": true
+            },
+            {
+                "name": "dave",
+                "validator": true
+            }
+        ]
+    },
+    "parachains": [
+        {
+            "id": 1000,
+            "chain_spec_path": "specs/parathreads-tanssi-1000.json",
+            "COMMENT": "Important: these collators will not be injected to pallet-invulnerables because zombienet does not support that. When changing the collators list, make sure to update `scripts/build-spec-parathreads.sh`",
+            "collators": [
+                {
+                    "name": "Collator-01",
+                    "ws_port": "9948",
+                    "command": "../target/release/tanssi-node"
+                },
+                {
+                    "name": "Collator-02",
+                    "command": "../target/release/tanssi-node"
+                },
+                {
+                    "name": "Collator-03",
+                    "command": "../target/release/tanssi-node"
+                },
+                {
+                    "name": "Collator-04",
+                    "command": "../target/release/tanssi-node"
+                },
+                {
+                    "name": "Collator-05",
+                    "command": "../target/release/tanssi-node"
+                },
+                {
+                    "name": "Collator-06",
+                    "command": "../target/release/tanssi-node"
+                },
+                {
+                    "name": "Collator-07",
+                    "command": "../target/release/tanssi-node"
+                },
+                {
+                    "name": "Collator-08",
+                    "command": "../target/release/tanssi-node"
+                }
+            ]
+        },
+        {
+            "id": 2000,
+            "chain_spec_path": "specs/parathreads-template-container-2000.json",
+            "collators": [
+                {
+                    "name": "FullNode-2000",
+                    "validator": false,
+                    "command": "../target/release/container-chain-template-simple-node",
+                    "ws_port": 9949,
+                    "p2p_port": 33049
+                }
+            ]
+        },
+        {
+            "id": 2001,
+            "chain_spec_path": "specs/parathreads-template-container-2001.json",
+            "collators": [
+                {
+                    "name": "FullNode-2001",
+                    "validator": false,
+                    "command": "../target/release/container-chain-template-frontier-node",
+                    "ws_port": 9950,
+                    "p2p_port": 33050
+                }
+            ]
+        }
+    ],
+    "types": {
+        "Header": {
+            "number": "u64",
+            "parent_hash": "Hash",
+            "post_state": "Hash"
+        }
+    }
+}

--- a/test/moonwall.config.json
+++ b/test/moonwall.config.json
@@ -194,6 +194,51 @@
             ]
         },
         {
+            "name": "zombie_tanssi_parathreads",
+            "timeout": 600000,
+            "testFileDir": ["suites/parathreads"],
+            "runScripts": ["build-spec-parathreads.sh", "download-polkadot.sh"],
+            "foundation": {
+                "type": "zombie",
+                "zombieSpec": {
+                    "configPath": "./configs/zombieTanssiParathreads.json",
+                    "skipBlockCheck": ["Container2000", "Container2001"]
+                }
+            },
+            "connections": [
+                {
+                    "name": "Relay",
+                    "type": "polkadotJs",
+                    "endpoints": ["ws://127.0.0.1:9947"]
+                },
+                {
+                    "name": "Tanssi",
+                    "type": "polkadotJs",
+                    "endpoints": ["ws://127.0.0.1:9948"]
+                },
+                {
+                    "name": "Container2000",
+                    "type": "polkadotJs",
+                    "endpoints": ["ws://127.0.0.1:9949"]
+                },
+                {
+                    "name": "Container2001",
+                    "type": "polkadotJs",
+                    "endpoints": ["ws://127.0.0.1:9950"]
+                },
+                {
+                    "name": "ethers",
+                    "type": "ethers",
+                    "endpoints": ["ws://127.0.0.1:9950"]
+                },
+                {
+                    "name": "w3",
+                    "type": "web3",
+                    "endpoints": ["ws://127.0.0.1:9950"]
+                }
+            ]
+        },
+        {
             "name": "zombie_tanssi_rotation",
             "testFileDir": ["suites/rotation-para"],
             "runScripts": ["build-spec.sh", "download-polkadot.sh"],

--- a/test/scripts/build-spec-parathreads.sh
+++ b/test/scripts/build-spec-parathreads.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Exit on any error
+set -e
+
+# Always run the commands from the "test" dir
+cd $(dirname $0)/..
+
+mkdir -p specs
+../target/release/container-chain-template-simple-node build-spec --disable-default-bootnode --add-bootnode "/ip4/127.0.0.1/tcp/33049/ws/p2p/12D3KooWHVMhQDHBpj9vQmssgyfspYecgV6e3hH1dQVDUkUbCYC9" --parachain-id 2000 --raw > specs/parathreads-template-container-2000.json
+../target/release/container-chain-template-frontier-node build-spec --disable-default-bootnode --add-bootnode "/ip4/127.0.0.1/tcp/33050/ws/p2p/12D3KooWFGaw1rxB6MSuN3ucuBm7hMq5pBFJbEoqTyth4cG483Cc" --parachain-id 2001 --raw > specs/parathreads-template-container-2001.json
+# TODO: add parathreads to genesis when supported by pallet_registrar
+../target/release/tanssi-node build-spec --chain dancebox-local --parachain-id 1000 --invulnerable "Collator-01" --invulnerable "Collator-02" --invulnerable "Collator-03" --invulnerable "Collator-04" --invulnerable "Collator-05" --invulnerable "Collator-06" --invulnerable "Collator-07" --invulnerable "Collator-08" > specs/parathreads-tanssi-1000.json

--- a/test/suites/parathreads/test_tanssi_parathreads.ts
+++ b/test/suites/parathreads/test_tanssi_parathreads.ts
@@ -4,7 +4,7 @@ import { ApiPromise, Keyring } from "@polkadot/api";
 import { Signer } from "ethers";
 import fs from "fs/promises";
 import { getAuthorFromDigest } from "../../util/author";
-import { signAndSendAndInclude, waitSessions, waitToSession } from "../../util/block";
+import { signAndSendAndInclude, waitSessions } from "../../util/block";
 import { createTransfer, waitUntilEthTxIncluded } from "../../util/ethereum";
 import { getKeyringNimbusIdHex } from "../../util/keys";
 import { getHeaderFromRelay } from "../../util/relayInterface";

--- a/test/suites/parathreads/test_tanssi_parathreads.ts
+++ b/test/suites/parathreads/test_tanssi_parathreads.ts
@@ -259,7 +259,8 @@ describeSuite({
             title: "Check block frequency of parathreads",
             timeout: 120000,
             test: async function () {
-                await waitToSession(context, paraApi, 3);
+                // Wait 1 session so that parathreads have produced at least a few blocks each
+                await waitSessions(context, paraApi, 1);
 
                 // TODO: calculate block frequency somehow
                 assertSlotFrequency(await getBlockData(paraApi), 1);

--- a/test/suites/parathreads/test_tanssi_parathreads.ts
+++ b/test/suites/parathreads/test_tanssi_parathreads.ts
@@ -1,0 +1,379 @@
+import { beforeAll, describeSuite, expect } from "@moonwall/cli";
+import { MIN_GAS_PRICE, customWeb3Request, generateKeyringPair, getBlockArray } from "@moonwall/util";
+import { ApiPromise, Keyring } from "@polkadot/api";
+import { Signer } from "ethers";
+import fs from "fs/promises";
+import { getAuthorFromDigest } from "../../util/author";
+import { signAndSendAndInclude, waitSessions, waitToSession } from "../../util/block";
+import { createTransfer, waitUntilEthTxIncluded } from "../../util/ethereum";
+import { getKeyringNimbusIdHex } from "../../util/keys";
+import { getHeaderFromRelay } from "../../util/relayInterface";
+import { chainSpecToContainerChainGenesisData } from "../../util/genesis_data.ts";
+import jsonBg from "json-bigint";
+import Bottleneck from "bottleneck";
+import { stringToHex } from "@polkadot/util";
+const JSONbig = jsonBg({ useNativeBigInt: true });
+
+describeSuite({
+    id: "R01",
+    title: "Zombie Tanssi Rotation Test",
+    foundationMethods: "zombie",
+    testCases: function ({ it, context }) {
+        let paraApi: ApiPromise;
+        let relayApi: ApiPromise;
+        let container2000Api: ApiPromise;
+        let container2001Api: ApiPromise;
+        let ethersSigner: Signer;
+        let allCollators: string[];
+        let collatorName: Record<string, string>;
+
+        beforeAll(async () => {
+            paraApi = context.polkadotJs("Tanssi");
+            relayApi = context.polkadotJs("Relay");
+            container2000Api = context.polkadotJs("Container2000");
+            container2001Api = context.polkadotJs("Container2001");
+            ethersSigner = context.ethers();
+
+            const relayNetwork = relayApi.consts.system.version.specName.toString();
+            expect(relayNetwork, "Relay API incorrect").to.contain("rococo");
+
+            const paraNetwork = paraApi.consts.system.version.specName.toString();
+            const paraId1000 = (await paraApi.query.parachainInfo.parachainId()).toString();
+            expect(paraNetwork, "Para API incorrect").to.contain("dancebox");
+            expect(paraId1000, "Para API incorrect").to.be.equal("1000");
+
+            const container2000Network = container2000Api.consts.system.version.specName.toString();
+            const paraId2000 = (await container2000Api.query.parachainInfo.parachainId()).toString();
+            expect(container2000Network, "Container2000 API incorrect").to.contain("container-chain-template");
+            expect(paraId2000, "Container2000 API incorrect").to.be.equal("2000");
+
+            const container2001Network = container2001Api.consts.system.version.specName.toString();
+            const paraId2001 = (await container2001Api.query.parachainInfo.parachainId()).toString();
+            expect(container2001Network, "Container2001 API incorrect").to.contain("frontier-template");
+            expect(paraId2001, "Container2001 API incorrect").to.be.equal("2001");
+
+            // Test block numbers in relay are 0 yet
+            const header2000 = await getHeaderFromRelay(relayApi, 2000);
+            const header2001 = await getHeaderFromRelay(relayApi, 2001);
+
+            expect(header2000.number.toNumber()).to.be.equal(0);
+            expect(header2001.number.toNumber()).to.be.equal(0);
+
+            // Initialize list of all collators, this should match the names from build-spec.sh script
+            allCollators = [
+                "Collator-01",
+                "Collator-02",
+                "Collator-03",
+                "Collator-04",
+                "Collator-05",
+                "Collator-06",
+                "Collator-07",
+                "Collator-08",
+            ];
+            // Initialize reverse map of collator key to collator name
+            collatorName = createCollatorKeyToNameMap(paraApi, allCollators);
+            console.log(collatorName);
+        }, 120000);
+
+        it({
+            id: "T01",
+            title: "Blocks are being produced on parachain",
+            test: async function () {
+                const blockNum = (await paraApi.rpc.chain.getBlock()).block.header.number.toNumber();
+                expect(blockNum).to.be.greaterThan(0);
+            },
+        });
+
+        it({
+            id: "T02",
+            title: "Disable full_rotation",
+            timeout: 60000,
+            test: async function () {
+                const keyring = new Keyring({ type: "sr25519" });
+                const alice = keyring.addFromUri("//Alice", { name: "Alice default" });
+
+                //const tx2 = await paraApi.tx.configuration.setMinOrchestratorCollators(1);
+                //const tx3 = await paraApi.tx.configuration.setMaxOrchestratorCollators(1);
+                const tx4 = await paraApi.tx.configuration.setFullRotationPeriod(0);
+                //const tx1234 = paraApi.tx.utility.batchAll([tx1, tx2, tx3, tx4]);
+                await signAndSendAndInclude(paraApi.tx.sudo.sudo(tx4), alice);
+            },
+        });
+
+        it({
+            id: "T03a",
+            title: "Register parathreads 2000 and 2001",
+            timeout: 60000,
+            test: async function () {
+                const keyring = new Keyring({ type: "sr25519" });
+                const alice = keyring.addFromUri("//Alice", { name: "Alice default" });
+                const txs2000 = await registerParathread(paraApi, alice.address, 2000);
+                const txs2001 = await registerParathread(paraApi, alice.address, 2001);
+
+                const slotFrequency2000 = paraApi.createType("TpTraitsSlotFrequency", {
+                    min: 5,
+                    max: 5,
+                });
+                const tx1 = await paraApi.tx.registrar.setParathreadParams(2000, slotFrequency2000);
+                const slotFrequency2001 = paraApi.createType("TpTraitsSlotFrequency", {
+                    min: 2,
+                    max: 2,
+                });
+                const tx2 = await paraApi.tx.registrar.setParathreadParams(2001, slotFrequency2001);
+                const txs = paraApi.tx.utility.batchAll([...txs2000, ...txs2001, tx1, tx2]);
+                await signAndSendAndInclude(paraApi.tx.sudo.sudo(txs), alice);
+            },
+        });
+
+        it({
+            id: "T03b",
+            title: "Wait for parathreads 2000 and 2001 to be assigned collators",
+            timeout: 600000,
+            test: async function () {
+                await waitSessions(context, paraApi, 2);
+            },
+        });
+
+        it({
+            id: "T04",
+            title: "Blocks are being produced on container 2000",
+            test: async function () {
+                // Produces 1 block every 5 slots, which is every 60 seconds
+                await sleep(60000);
+                const blockNum = (await container2000Api.rpc.chain.getBlock()).block.header.number.toNumber();
+                expect(blockNum).to.be.greaterThan(0);
+            },
+        });
+
+        it({
+            id: "T05",
+            title: "Blocks are being produced on container 2001",
+            test: async function () {
+                // Produces 1 block every 2 slots, which is every 24 seconds
+                await sleep(24000);
+                const blockNum = (await container2001Api.rpc.chain.getBlock()).block.header.number.toNumber();
+
+                expect(blockNum).to.be.greaterThan(0);
+                expect(await ethersSigner.provider.getBlockNumber(), "Safe tag is not present").to.be.greaterThan(0);
+            },
+        });
+
+        it({
+            id: "T06",
+            title: "Test container chain 2000 assignation is correct",
+            test: async function () {
+                const currentSession = (await paraApi.query.session.currentIndex()).toNumber();
+                const paraId = (await container2000Api.query.parachainInfo.parachainId()).toString();
+                const containerChainCollators = (
+                    await paraApi.query.authorityAssignment.collatorContainerChain(currentSession)
+                ).toJSON().containerChains[paraId];
+
+                // TODO: fix once we have types
+                const writtenCollators = (await container2000Api.query.authoritiesNoting.authorities()).toJSON();
+
+                expect(containerChainCollators).to.deep.equal(writtenCollators);
+            },
+        });
+
+        it({
+            id: "T07",
+            title: "Test container chain 2001 assignation is correct",
+            test: async function () {
+                const currentSession = (await paraApi.query.session.currentIndex()).toNumber();
+                const paraId = (await container2001Api.query.parachainInfo.parachainId()).toString();
+                const containerChainCollators = (
+                    await paraApi.query.authorityAssignment.collatorContainerChain(currentSession)
+                ).toJSON().containerChains[paraId];
+
+                const writtenCollators = (await container2001Api.query.authoritiesNoting.authorities()).toJSON();
+
+                expect(containerChainCollators).to.deep.equal(writtenCollators);
+            },
+        });
+
+        it({
+            id: "T08",
+            title: "Test author noting is correct for both containers",
+            timeout: 60000,
+            test: async function () {
+                const assignment = await paraApi.query.collatorAssignment.collatorContainerChain();
+                const paraId2000 = await container2000Api.query.parachainInfo.parachainId();
+                const paraId2001 = await container2001Api.query.parachainInfo.parachainId();
+
+                // TODO: fix once we have types
+                const containerChainCollators2000 = assignment.containerChains.toJSON()[paraId2000.toString()];
+                const containerChainCollators2001 = assignment.containerChains.toJSON()[paraId2001.toString()];
+
+                await context.waitBlock(3, "Tanssi");
+                const author2000 = await paraApi.query.authorNoting.latestAuthor(paraId2000);
+                const author2001 = await paraApi.query.authorNoting.latestAuthor(paraId2001);
+
+                expect(containerChainCollators2000.includes(author2000.toJSON().author)).to.be.true;
+                expect(containerChainCollators2001.includes(author2001.toJSON().author)).to.be.true;
+            },
+        });
+
+        it({
+            id: "T09",
+            title: "Test author is correct in Orchestrator",
+            test: async function () {
+                const sessionIndex = (await paraApi.query.session.currentIndex()).toNumber();
+                const authorities = await paraApi.query.authorityAssignment.collatorContainerChain(sessionIndex);
+                const author = await getAuthorFromDigest(paraApi);
+                // TODO: fix once we have types
+                expect(authorities.toJSON().orchestratorChain.includes(author.toString())).to.be.true;
+            },
+        });
+
+        it({
+            id: "T10",
+            title: "Test frontier template isEthereum",
+            test: async function () {
+                // TODO: fix once we have types
+                const genesisData2000 = await paraApi.query.registrar.paraGenesisData(2000);
+                expect(genesisData2000.toJSON().properties.isEthereum).to.be.false;
+                const genesisData2001 = await paraApi.query.registrar.paraGenesisData(2001);
+                expect(genesisData2001.toJSON().properties.isEthereum).to.be.true;
+            },
+        });
+        it({
+            id: "T11",
+            title: "Transactions can be made with ethers",
+            timeout: 60000,
+            test: async function () {
+                const randomAccount = generateKeyringPair();
+                const tx = await createTransfer(context, randomAccount.address, 1_000_000_000_000, {
+                    gasPrice: MIN_GAS_PRICE,
+                });
+                const txHash = await customWeb3Request(context.web3(), "eth_sendRawTransaction", [tx]);
+                await waitUntilEthTxIncluded(
+                    () => context.waitBlock(1, "Container2001"),
+                    context.web3(),
+                    txHash.result
+                );
+                expect(Number(await context.web3().eth.getBalance(randomAccount.address))).to.be.greaterThan(0);
+            },
+        });
+        it({
+            id: "T12",
+            title: "Check block frequency of parathreads",
+            timeout: 120000,
+            test: async function () {
+                await waitToSession(context, paraApi, 3);
+
+                // TODO: calculate block frequency somehow
+                assertSlotFrequency(await getBlockData(paraApi), 1);
+                assertSlotFrequency(await getBlockData(container2000Api), 5);
+                assertSlotFrequency(await getBlockData(container2001Api), 2);
+            },
+        });
+    },
+});
+
+async function getBlockData(api) {
+    const timePeriod = 1 * 60 * 60 * 1000; // 1 hour
+    const blockNumArray = await getBlockArray(api, timePeriod);
+
+    const getBlockData = async (blockNum: number) => {
+        const blockHash = await api.rpc.chain.getBlockHash(blockNum);
+        const signedBlock = await api.rpc.chain.getBlock(blockHash);
+        const apiAt = await api.at(blockHash);
+
+        return {
+            blockNum: blockNum,
+            extrinsics: signedBlock.block.extrinsics,
+            events: await apiAt.query.system.events(),
+            logs: signedBlock.block.header.digest.logs,
+        };
+    };
+    const limiter = new Bottleneck({ maxConcurrent: 5, minTime: 100 });
+    const blockData = await Promise.all(blockNumArray.map((num) => limiter.schedule(() => getBlockData(num))));
+    return blockData;
+}
+
+async function assertSlotFrequency(blockData, expectedSlotDiff) {
+    const slotNumbers = blockData
+        .map(({ logs }) => {
+            const slotLog = logs.find(
+                (log) => log.isPreRuntime === true && log.asPreRuntime[0].toHex() === stringToHex("aura")
+            );
+            return slotLog ? parseInt(slotLog.asPreRuntime[1].reverse().toString("hex"), 16) : null;
+        })
+        .filter((slot) => slot !== null); // Filter out nulls (blocks without slotLog)
+
+    if (slotNumbers.length < 2) {
+        throw new Error("Insufficient data for slot time calculation.");
+    }
+
+    // Calculate differences between consecutive slots
+    const slotDiffs = [];
+    for (let i = 1; i < slotNumbers.length; i++) {
+        slotDiffs.push(slotNumbers[i] - slotNumbers[i - 1]);
+    }
+
+    // Calculate average slot difference
+    const avgSlotDiff = slotDiffs.reduce((acc, diff) => acc + diff, 0) / slotDiffs.length;
+    expect(
+        Math.abs(avgSlotDiff - expectedSlotDiff),
+        `Average slot time is different from expected: average ${avgSlotDiff}, expected ${expectedSlotDiff}`
+    ).to.be.lessThan(0.5);
+}
+
+/// Create a map of collator key "5C5p..." to collator name "Collator1000-01".
+function createCollatorKeyToNameMap(paraApi, collatorNames: string[]): Record<string, string> {
+    const collatorName: Record<string, string> = {};
+
+    collatorNames.forEach((name) => {
+        const hexAddress = getKeyringNimbusIdHex(name);
+        const k = paraApi.createType("AccountId", hexAddress);
+        collatorName[k] = name;
+    });
+
+    return collatorName;
+}
+
+async function registerParathread(api, manager, paraId) {
+    const specPaths = {
+        2000: "specs/parathreads-template-container-2000.json",
+        2001: "specs/parathreads-template-container-2001.json",
+    };
+    if (!specPaths[paraId]) {
+        throw new Error(`Unknown chain spec path for paraId ${paraId}`);
+    }
+    const chain = specPaths[paraId];
+    const parathread = true;
+    const rawSpec = JSONbig.parse(await fs.readFile(chain, "utf8"));
+
+    const containerChainGenesisData = chainSpecToContainerChainGenesisData(api, rawSpec);
+    const txs = [];
+    let tx1;
+    if (parathread) {
+        const slotFreq = api.createType("TpTraitsSlotFrequency", {
+            min: 1,
+            max: 1,
+        });
+        tx1 = api.tx.registrar.registerParathread(rawSpec.para_id, slotFreq, containerChainGenesisData);
+    } else {
+        tx1 = api.tx.registrar.registerParathread(rawSpec.para_id, containerChainGenesisData);
+    }
+    txs.push(
+        api.tx.utility.dispatchAs(
+            {
+                system: { Signed: manager },
+            } as any,
+            tx1
+        )
+    );
+    if (rawSpec.bootNodes?.length) {
+        const tx2 = api.tx.dataPreservers.setBootNodes(rawSpec.para_id, rawSpec.bootNodes);
+        txs.push(tx2);
+    }
+    const tx3 = api.tx.registrar.markValidForCollating(rawSpec.para_id);
+    txs.push(tx3);
+
+    return txs;
+}
+
+const sleep = (ms: number): Promise<void> => {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+};


### PR DESCRIPTION
Allows registered parathreads to produce blocks every n slots, where n is defined on chain.

This is ready to be tested, but it may need a refactor (`get_authorities_from_orchestrator` will probably need to be renamed)

How to test this:

* `pnpm moonwall test zombie_tanssi_parathreads`

This is a new zombienet test suite that is not being run in CI.

Or, to test manually:

* `pnpm moonwall run zombie_tanssi`

* Manually call Registrar.deregister for para id 2000

* `pnpm run sudo-register-para register --parathread --url ws://127.0.0.1:9948 --account //Alice --chain specs/template-container-2000.json`

* Manually call Registrar.setParathreadParams to adjust slotFrequency. Set min=max=5 to produce 1 block every 5 slots (60 seconds)

* Observe how parachain 2000 produces 1 block every 60 seconds.