### PR TITLE
Always use wasm executor in container collators

### DIFF
--- a/client/node-common/src/service.rs
+++ b/client/node-common/src/service.rs
@@ -35,8 +35,9 @@ use {
         run_manual_seal, ConsensusDataProvider, EngineCommand, ManualSealParams,
     },
     sc_executor::{
-        HeapAllocStrategy, NativeElseWasmExecutor, NativeExecutionDispatch, WasmExecutor,
-        DEFAULT_HEAP_ALLOC_STRATEGY,
+        sp_wasm_interface::{ExtendedHostFunctions, HostFunctions},
+        HeapAllocStrategy, NativeElseWasmExecutor, NativeExecutionDispatch, RuntimeVersionOf,
+        WasmExecutor, DEFAULT_HEAP_ALLOC_STRATEGY,
     },
     sc_network::{config::FullNetworkConfiguration, NetworkBlock, NetworkService},
     sc_network_sync::SyncingService,
@@ -52,6 +53,7 @@ use {
     sp_api::ConstructRuntimeApi,
     sp_block_builder::BlockBuilder,
     sp_consensus::SelectChain,
+    sp_core::traits::CodeExecutor,
     sp_inherents::CreateInherentDataProviders,
     sp_offchain::OffchainWorkerApi,
     sp_runtime::Percent,
@@ -64,7 +66,7 @@ use {
 pub trait NodeBuilderConfig {
     type Block;
     type RuntimeApi;
-    type ParachainNativeExecutor;
+    type ParachainExecutor;
 
     /// Create a new `NodeBuilder` using the types of this `Config`, along
     /// with the parachain `Configuration` and an optional `HwBench`.
@@ -75,7 +77,8 @@ pub trait NodeBuilderConfig {
     where
         Self: Sized,
         BlockOf<Self>: cumulus_primitives_core::BlockT,
-        ParachainNativeExecutorOf<Self>: NativeExecutionDispatch + 'static,
+        ExecutorOf<Self>:
+            Clone + CodeExecutor + RuntimeVersionOf + TanssiExecutorExt + Sync + Send + 'static,
         RuntimeApiOf<Self>:
             ConstructRuntimeApi<BlockOf<Self>, ClientOf<Self>> + Sync + Send + 'static,
         ConstructedRuntimeApiOf<Self>:
@@ -89,8 +92,7 @@ pub type BlockOf<T> = <T as NodeBuilderConfig>::Block;
 pub type BlockHashOf<T> = <BlockOf<T> as cumulus_primitives_core::BlockT>::Hash;
 pub type BlockHeaderOf<T> = <BlockOf<T> as cumulus_primitives_core::BlockT>::Header;
 pub type RuntimeApiOf<T> = <T as NodeBuilderConfig>::RuntimeApi;
-pub type ParachainNativeExecutorOf<T> = <T as NodeBuilderConfig>::ParachainNativeExecutor;
-pub type ExecutorOf<T> = NativeElseWasmExecutor<ParachainNativeExecutorOf<T>>;
+pub type ExecutorOf<T> = <T as NodeBuilderConfig>::ParachainExecutor;
 pub type ClientOf<T> = TFullClient<BlockOf<T>, RuntimeApiOf<T>, ExecutorOf<T>>;
 pub type BackendOf<T> = TFullBackend<BlockOf<T>>;
 pub type ConstructedRuntimeApiOf<T> =
@@ -130,7 +132,7 @@ pub struct NodeBuilder<
     SImportQueueService = (),
 > where
     BlockOf<T>: cumulus_primitives_core::BlockT,
-    ParachainNativeExecutorOf<T>: NativeExecutionDispatch + 'static,
+    ExecutorOf<T>: Clone + CodeExecutor + RuntimeVersionOf + Sync + Send + 'static,
     RuntimeApiOf<T>: ConstructRuntimeApi<BlockOf<T>, ClientOf<T>> + Sync + Send + 'static,
     ConstructedRuntimeApiOf<T>: TaggedTransactionQueue<BlockOf<T>> + BlockBuilder<BlockOf<T>>,
 {
@@ -157,13 +159,39 @@ pub struct Network<Block: cumulus_primitives_core::BlockT> {
     pub sync_service: Arc<SyncingService<Block>>,
 }
 
+/// Allows to create a parachain-defined executor from a `WasmExecutor`
+pub trait TanssiExecutorExt {
+    type HostFun: HostFunctions;
+    fn new_with_wasm_executor(wasm_executor: WasmExecutor<Self::HostFun>) -> Self;
+}
+
+impl TanssiExecutorExt for WasmExecutor<sp_io::SubstrateHostFunctions> {
+    type HostFun = sp_io::SubstrateHostFunctions;
+
+    fn new_with_wasm_executor(wasm_executor: WasmExecutor<Self::HostFun>) -> Self {
+        wasm_executor
+    }
+}
+
+impl<D> TanssiExecutorExt for NativeElseWasmExecutor<D>
+where
+    D: NativeExecutionDispatch,
+{
+    type HostFun = ExtendedHostFunctions<sp_io::SubstrateHostFunctions, D::ExtendHostFunctions>;
+
+    fn new_with_wasm_executor(wasm_executor: WasmExecutor<Self::HostFun>) -> Self {
+        NativeElseWasmExecutor::new_with_wasm_executor(wasm_executor)
+    }
+}
+
 // `new` function doesn't take self, and the Rust compiler cannot infer that
 // only one type T implements `TypeIdentity`. With thus need a separate impl
 // block with concrete types `()`.
 impl<T: NodeBuilderConfig> NodeBuilder<T>
 where
     BlockOf<T>: cumulus_primitives_core::BlockT,
-    ParachainNativeExecutorOf<T>: NativeExecutionDispatch + 'static,
+    ExecutorOf<T>:
+        Clone + CodeExecutor + RuntimeVersionOf + TanssiExecutorExt + Sync + Send + 'static,
     RuntimeApiOf<T>: ConstructRuntimeApi<BlockOf<T>, ClientOf<T>> + Sync + Send + 'static,
     ConstructedRuntimeApiOf<T>: TaggedTransactionQueue<BlockOf<T>> + BlockBuilder<BlockOf<T>>,
 {
@@ -255,7 +283,7 @@ impl<T: NodeBuilderConfig, SNetwork, STxHandler, SImportQueueService>
     NodeBuilder<T, SNetwork, STxHandler, SImportQueueService>
 where
     BlockOf<T>: cumulus_primitives_core::BlockT,
-    ParachainNativeExecutorOf<T>: NativeExecutionDispatch + 'static,
+    ExecutorOf<T>: Clone + CodeExecutor + RuntimeVersionOf + Sync + Send + 'static,
     RuntimeApiOf<T>: ConstructRuntimeApi<BlockOf<T>, ClientOf<T>> + Sync + Send + 'static,
     ConstructedRuntimeApiOf<T>: TaggedTransactionQueue<BlockOf<T>>
         + BlockBuilder<BlockOf<T>>

--- a/container-chains/templates/frontier/node/src/service.rs
+++ b/container-chains/templates/frontier/node/src/service.rs
@@ -60,7 +60,7 @@ pub struct NodeConfig;
 impl NodeBuilderConfig for NodeConfig {
     type Block = Block;
     type RuntimeApi = RuntimeApi;
-    type ParachainNativeExecutor = TemplateRuntimeExecutor;
+    type ParachainExecutor = ParachainExecutor;
 }
 
 pub fn frontier_database_dir(config: &Configuration, path: &str) -> std::path::PathBuf {

--- a/container-chains/templates/simple/node/src/service.rs
+++ b/container-chains/templates/simple/node/src/service.rs
@@ -65,7 +65,7 @@ pub struct NodeConfig;
 impl NodeBuilderConfig for NodeConfig {
     type Block = Block;
     type RuntimeApi = RuntimeApi;
-    type ParachainNativeExecutor = ParachainNativeExecutor;
+    type ParachainExecutor = ParachainExecutor;
 }
 
 thread_local!(static TIMESTAMP: std::cell::RefCell<u64> = std::cell::RefCell::new(0));

--- a/node/src/container_chain_monitor.rs
+++ b/node/src/container_chain_monitor.rs
@@ -17,7 +17,7 @@
 use {
     crate::{
         container_chain_spawner::{CcSpawnMsg, ContainerChainSpawnerState},
-        service::{ParachainBackend, ParachainClient},
+        service::{ContainerChainBackend, ContainerChainClient},
     },
     cumulus_primitives_core::ParaId,
     std::{
@@ -57,9 +57,9 @@ pub struct SpawnedContainer {
     /// This won't be precise because it is checked using polling with a high period.
     pub stop_refcount_time: Cell<Option<Instant>>,
     /// Used to check the reference count, if it's 0 it means the database has been closed
-    pub backend: std::sync::Weak<ParachainBackend>,
+    pub backend: std::sync::Weak<ContainerChainBackend>,
     /// Used to check the reference count, if it's 0 it means that the client has been closed.
-    pub client: std::sync::Weak<ParachainClient>,
+    pub client: std::sync::Weak<ContainerChainClient>,
 }
 
 impl SpawnedContainer {


### PR DESCRIPTION
We use a `NativeElseWasmExecutor` for all chains, but collators don't have the container chain's native runtime. So their executor was trying to use the native dancebox runtime as the container chain runtime, which fortunately resulted in a version mismatch and the wasm container chain runtime was always used.

This can be verified by starting zombienet with `export RUST_LOG=info,executor=trace`:

```
2024-02-13 18:33:48.286 TRACE tokio-runtime-worker executor: [Container-2000] Request for native execution failed native=dancebox-500 (dancebox-0.tx1.au1) chain=container-chain-template-500 (container-chain-template-0.tx1.au1)
```

As a bonus we now have two types of clients, `Arc<ContainerChainClient>` and `Arc<ParachainClient>`, and using one client in place of the other results in a compile error.