### PR TITLE
Use precompiled wasm in dev tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,7 +433,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "asset-test-utils"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "assets-common",
  "cumulus-pallet-parachain-system",
@@ -468,7 +468,7 @@ dependencies = [
 [[package]]
 name = "assets-common"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -788,7 +788,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "hash-db",
  "log",
@@ -1013,7 +1013,7 @@ dependencies = [
 [[package]]
 name = "bp-header-chain"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "bp-runtime",
  "finality-grandpa",
@@ -1030,7 +1030,7 @@ dependencies = [
 [[package]]
 name = "bp-messages"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -1045,7 +1045,7 @@ dependencies = [
 [[package]]
 name = "bp-parachains"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
@@ -1062,7 +1062,7 @@ dependencies = [
 [[package]]
 name = "bp-polkadot-core"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1080,7 +1080,7 @@ dependencies = [
 [[package]]
 name = "bp-relayers"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1094,7 +1094,7 @@ dependencies = [
 [[package]]
 name = "bp-runtime"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1117,7 +1117,7 @@ dependencies = [
 [[package]]
 name = "bp-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -1137,7 +1137,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "sp-std",
 ]
@@ -1145,7 +1145,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1156,7 +1156,7 @@ dependencies = [
 [[package]]
 name = "bridge-runtime-common"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -2292,7 +2292,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -2309,7 +2309,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -2332,7 +2332,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -2374,7 +2374,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -2403,7 +2403,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-proposer"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2418,7 +2418,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -2441,7 +2441,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2465,7 +2465,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2489,7 +2489,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -2525,7 +2525,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-dmp-queue"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "cumulus-primitives-core",
  "frame-benchmarking",
@@ -2543,7 +2543,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -2577,7 +2577,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -2588,7 +2588,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
 version = "3.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2602,7 +2602,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2618,7 +2618,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
@@ -2643,7 +2643,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2657,7 +2657,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2674,7 +2674,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2689,7 +2689,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2699,7 +2699,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "cumulus-primitives-core",
  "futures 0.3.30",
@@ -2712,7 +2712,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2732,7 +2732,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2756,7 +2756,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2774,7 +2774,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "array-bytes 6.2.2",
  "async-trait",
@@ -2815,7 +2815,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2854,7 +2854,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -3516,7 +3516,7 @@ dependencies = [
 [[package]]
 name = "emulated-integration-tests-common"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "asset-test-utils",
  "bp-messages",
@@ -4316,7 +4316,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -4437,7 +4437,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -4462,7 +4462,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "Inflector",
  "array-bytes 6.2.2",
@@ -4510,7 +4510,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -4521,7 +4521,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -4538,7 +4538,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4568,7 +4568,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "futures 0.3.30",
  "indicatif",
@@ -4589,7 +4589,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "aquamarine",
  "array-bytes 6.2.2",
@@ -4630,7 +4630,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -4649,7 +4649,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.1.0",
@@ -4661,7 +4661,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4671,7 +4671,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "cfg-if",
  "docify",
@@ -4691,7 +4691,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4706,7 +4706,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -4715,7 +4715,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -6734,7 +6734,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "futures 0.3.30",
  "log",
@@ -6753,7 +6753,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "anyhow",
  "jsonrpsee",
@@ -7530,7 +7530,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7548,7 +7548,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7563,7 +7563,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7581,7 +7581,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7697,7 +7697,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7727,7 +7727,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7741,7 +7741,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7765,7 +7765,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "aquamarine",
  "docify",
@@ -7787,7 +7787,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7816,7 +7816,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7836,7 +7836,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "array-bytes 6.2.2",
  "binary-merkle-tree",
@@ -7861,7 +7861,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7879,7 +7879,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-grandpa"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -7900,7 +7900,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-messages"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -7918,7 +7918,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-parachains"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -7939,7 +7939,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-relayers"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "bp-messages",
  "bp-relayers",
@@ -7959,7 +7959,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -8005,7 +8005,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8056,7 +8056,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "3.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8075,7 +8075,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8110,7 +8110,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -8151,7 +8151,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8169,7 +8169,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8192,7 +8192,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8206,7 +8206,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "5.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8402,7 +8402,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8440,7 +8440,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8479,7 +8479,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -8496,7 +8496,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8516,7 +8516,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8609,7 +8609,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8626,7 +8626,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "7.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -8665,7 +8665,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8683,7 +8683,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8699,7 +8699,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8715,7 +8715,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8734,7 +8734,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8754,7 +8754,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -8765,7 +8765,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8782,7 +8782,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8830,7 +8830,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8847,7 +8847,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8862,7 +8862,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8880,7 +8880,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8895,7 +8895,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -8970,7 +8970,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "1.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8985,7 +8985,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9023,7 +9023,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9045,7 +9045,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9062,7 +9062,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9080,7 +9080,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9103,7 +9103,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -9114,7 +9114,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -9123,7 +9123,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9133,7 +9133,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9174,7 +9174,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9190,7 +9190,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9210,7 +9210,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9229,7 +9229,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9245,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -9261,7 +9261,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -9273,7 +9273,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9292,7 +9292,7 @@ dependencies = [
 [[package]]
 name = "pallet-tx-pause"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9310,7 +9310,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9326,7 +9326,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9341,7 +9341,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9356,7 +9356,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -9379,7 +9379,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9398,7 +9398,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub-router"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "bp-xcm-bridge-hub-router",
  "frame-benchmarking",
@@ -9417,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -9454,7 +9454,7 @@ dependencies = [
 [[package]]
 name = "parachains-runtimes-test-utils"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "assets-common",
  "cumulus-pallet-parachain-system",
@@ -9807,7 +9807,7 @@ checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
 [[package]]
 name = "polkadot-approval-distribution"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "bitvec",
  "futures 0.3.30",
@@ -9827,7 +9827,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "always-assert",
  "futures 0.3.30",
@@ -9843,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "derive_more",
  "fatality",
@@ -9866,7 +9866,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-trait",
  "fatality",
@@ -9889,7 +9889,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "1.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "cfg-if",
  "clap",
@@ -9917,7 +9917,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "bitvec",
  "fatality",
@@ -9939,7 +9939,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9951,7 +9951,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "derive_more",
  "fatality",
@@ -9976,7 +9976,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -9990,7 +9990,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "futures 0.3.30",
  "futures-timer",
@@ -10011,7 +10011,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -10034,7 +10034,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "futures 0.3.30",
  "parity-scale-codec",
@@ -10052,7 +10052,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -10085,7 +10085,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "bitvec",
  "futures 0.3.30",
@@ -10107,7 +10107,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10126,7 +10126,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "futures 0.3.30",
  "polkadot-node-subsystem",
@@ -10141,7 +10141,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-trait",
  "futures 0.3.30",
@@ -10162,7 +10162,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "futures 0.3.30",
  "polkadot-node-metrics",
@@ -10176,7 +10176,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "futures 0.3.30",
  "futures-timer",
@@ -10193,7 +10193,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "fatality",
  "futures 0.3.30",
@@ -10212,7 +10212,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-trait",
  "futures 0.3.30",
@@ -10229,7 +10229,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10246,7 +10246,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10263,7 +10263,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "always-assert",
  "array-bytes 6.2.2",
@@ -10296,7 +10296,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "futures 0.3.30",
  "polkadot-node-primitives",
@@ -10312,7 +10312,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "cfg-if",
  "cpu-time",
@@ -10337,7 +10337,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "futures 0.3.30",
  "polkadot-node-metrics",
@@ -10352,7 +10352,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-jaeger"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "lazy_static",
  "log",
@@ -10370,7 +10370,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "bs58 0.5.0",
  "futures 0.3.30",
@@ -10389,7 +10389,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -10413,7 +10413,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -10436,7 +10436,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -10446,7 +10446,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -10474,7 +10474,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -10509,7 +10509,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-trait",
  "futures 0.3.30",
@@ -10531,7 +10531,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "bounded-collections",
  "derive_more",
@@ -10548,7 +10548,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "bitvec",
  "hex-literal 0.4.1",
@@ -10574,7 +10574,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -10607,7 +10607,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -10659,7 +10659,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "bs58 0.5.0",
  "frame-benchmarking",
@@ -10672,7 +10672,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -10721,7 +10721,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -10838,7 +10838,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "arrayvec 0.7.4",
  "bitvec",
@@ -10861,7 +10861,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -11635,7 +11635,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "binary-merkle-tree",
  "frame-benchmarking",
@@ -11731,7 +11731,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -11992,7 +11992,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "log",
  "sp-core",
@@ -12003,7 +12003,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-trait",
  "futures 0.3.30",
@@ -12032,7 +12032,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "futures 0.3.30",
  "futures-timer",
@@ -12054,7 +12054,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -12069,7 +12069,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "array-bytes 6.2.2",
  "docify",
@@ -12094,7 +12094,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -12105,7 +12105,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "array-bytes 6.2.2",
  "bip39",
@@ -12146,7 +12146,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "fnv",
  "futures 0.3.30",
@@ -12173,7 +12173,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -12199,7 +12199,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-trait",
  "futures 0.3.30",
@@ -12224,7 +12224,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-trait",
  "futures 0.3.30",
@@ -12253,7 +12253,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -12288,7 +12288,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "futures 0.3.30",
  "jsonrpsee",
@@ -12310,7 +12310,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "array-bytes 6.2.2",
  "async-channel 1.9.0",
@@ -12345,7 +12345,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "futures 0.3.30",
  "jsonrpsee",
@@ -12364,7 +12364,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -12377,7 +12377,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "ahash 0.8.8",
  "array-bytes 6.2.2",
@@ -12419,7 +12419,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "finality-grandpa",
  "futures 0.3.30",
@@ -12439,7 +12439,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -12474,7 +12474,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-trait",
  "futures 0.3.30",
@@ -12497,7 +12497,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -12519,7 +12519,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "sc-allocator",
  "sp-maybe-compressed-blob",
@@ -12531,7 +12531,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -12549,7 +12549,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "ansi_term",
  "futures 0.3.30",
@@ -12566,7 +12566,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "array-bytes 6.2.2",
  "parking_lot 0.12.1",
@@ -12580,7 +12580,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.1.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "array-bytes 4.2.0",
  "arrayvec 0.7.4",
@@ -12609,7 +12609,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "array-bytes 6.2.2",
  "async-channel 1.9.0",
@@ -12652,7 +12652,7 @@ dependencies = [
 [[package]]
 name = "sc-network-bitswap"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-channel 1.9.0",
  "cid",
@@ -12672,7 +12672,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -12689,7 +12689,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "ahash 0.8.8",
  "futures 0.3.30",
@@ -12708,7 +12708,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "array-bytes 6.2.2",
  "async-channel 1.9.0",
@@ -12729,7 +12729,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "array-bytes 6.2.2",
  "async-channel 1.9.0",
@@ -12765,7 +12765,7 @@ dependencies = [
 [[package]]
 name = "sc-network-test"
 version = "0.8.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-trait",
  "futures 0.3.30",
@@ -12796,7 +12796,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "array-bytes 6.2.2",
  "futures 0.3.30",
@@ -12815,7 +12815,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "array-bytes 6.2.2",
  "bytes",
@@ -12849,7 +12849,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -12858,7 +12858,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "futures 0.3.30",
  "jsonrpsee",
@@ -12890,7 +12890,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -12910,7 +12910,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "http",
  "jsonrpsee",
@@ -12925,7 +12925,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "array-bytes 6.2.2",
  "futures 0.3.30",
@@ -12954,7 +12954,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-trait",
  "directories",
@@ -13017,7 +13017,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -13028,7 +13028,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "clap",
  "fs4",
@@ -13041,7 +13041,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -13060,7 +13060,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "derive_more",
  "futures 0.3.30",
@@ -13080,7 +13080,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "chrono",
  "futures 0.3.30",
@@ -13099,7 +13099,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "ansi_term",
  "chrono",
@@ -13129,7 +13129,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -13140,7 +13140,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-trait",
  "futures 0.3.30",
@@ -13166,7 +13166,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-trait",
  "futures 0.3.30",
@@ -13182,7 +13182,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-channel 1.9.0",
  "futures 0.3.30",
@@ -13637,7 +13637,7 @@ dependencies = [
 [[package]]
 name = "slot-range-helper"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -13831,7 +13831,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "hash-db",
  "log",
@@ -13852,7 +13852,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -13866,7 +13866,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "23.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13879,7 +13879,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "16.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -13893,7 +13893,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13906,7 +13906,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -13917,7 +13917,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "futures 0.3.30",
  "log",
@@ -13935,7 +13935,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-trait",
  "futures 0.3.30",
@@ -13950,7 +13950,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -13967,7 +13967,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -13986,7 +13986,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -14005,7 +14005,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -14023,7 +14023,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14035,7 +14035,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "21.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "array-bytes 6.2.2",
  "bip39",
@@ -14080,7 +14080,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "9.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -14093,7 +14093,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "9.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "quote",
  "sp-core-hashing",
@@ -14103,7 +14103,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -14112,7 +14112,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "8.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14122,7 +14122,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.19.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -14133,7 +14133,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "serde_json",
  "sp-api",
@@ -14144,7 +14144,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -14158,7 +14158,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "23.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "bytes",
  "ed25519-dalek",
@@ -14182,7 +14182,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "24.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -14192,7 +14192,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.27.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -14204,7 +14204,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "thiserror",
  "zstd 0.12.4",
@@ -14213,7 +14213,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -14224,7 +14224,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.1.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14236,7 +14236,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "ckb-merkle-mountain-range",
  "log",
@@ -14254,7 +14254,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14268,7 +14268,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -14278,7 +14278,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "8.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -14288,7 +14288,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -14298,7 +14298,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "24.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "docify",
  "either",
@@ -14322,7 +14322,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "17.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -14340,7 +14340,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "Inflector",
  "expander 2.0.0",
@@ -14353,7 +14353,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14368,7 +14368,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -14382,7 +14382,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.28.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "hash-db",
  "log",
@@ -14403,7 +14403,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek 4.1.2",
@@ -14427,12 +14427,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "8.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 
 [[package]]
 name = "sp-storage"
 version = "13.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -14445,7 +14445,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -14458,7 +14458,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "10.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -14470,7 +14470,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -14479,7 +14479,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -14494,7 +14494,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "22.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "ahash 0.8.8",
  "hash-db",
@@ -14518,7 +14518,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "22.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -14535,7 +14535,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "8.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -14546,7 +14546,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "14.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -14559,7 +14559,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "20.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -14754,7 +14754,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-parachain-info"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -14768,7 +14768,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "array-bytes 6.2.2",
  "bounded-collections",
@@ -14786,7 +14786,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -14808,7 +14808,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -14936,12 +14936,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.30",
@@ -14960,7 +14960,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "hyper",
  "log",
@@ -14972,7 +14972,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -14985,7 +14985,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -15002,7 +15002,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "array-bytes 6.2.2",
  "async-trait",
@@ -15028,7 +15028,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "array-bytes 6.2.2",
  "frame-executive",
@@ -15069,7 +15069,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "futures 0.3.30",
  "sc-block-builder",
@@ -15087,7 +15087,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "ansi_term",
  "build-helper",
@@ -15884,7 +15884,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -15895,7 +15895,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "expander 2.0.0",
  "proc-macro-crate 3.1.0",
@@ -16025,7 +16025,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "async-trait",
  "clap",
@@ -16709,7 +16709,7 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 [[package]]
 name = "westend-runtime"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -16815,7 +16815,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -17194,7 +17194,7 @@ dependencies = [
 [[package]]
 name = "xcm-emulator"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
@@ -17237,7 +17237,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#2d5431010d3772f863c58abfee9f3b28bc1ef1ec"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12123,6 +12123,7 @@ dependencies = [
  "rpassword",
  "sc-client-api",
  "sc-client-db",
+ "sc-executor",
  "sc-keystore",
  "sc-mixnet",
  "sc-network",
@@ -12138,6 +12139,8 @@ dependencies = [
  "sp-keystore",
  "sp-panic-handler",
  "sp-runtime",
+ "sp-state-machine",
+ "sp-storage",
  "sp-version",
  "thiserror",
  "tokio",
@@ -12499,6 +12502,7 @@ name = "sc-executor"
 version = "0.10.0-dev"
 source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
+ "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "sc-executor-common",
@@ -12521,6 +12525,7 @@ name = "sc-executor-common"
 version = "0.10.0-dev"
 source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#fb422ea2572811a4d339dc100cb32d6aa63fe0c9"
 dependencies = [
+ "parity-scale-codec",
  "sc-allocator",
  "sp-maybe-compressed-blob",
  "sp-wasm-interface",
@@ -12537,10 +12542,12 @@ dependencies = [
  "cfg-if",
  "libc",
  "log",
+ "parity-scale-codec",
  "parking_lot 0.12.1",
  "rustix 0.36.17",
  "sc-allocator",
  "sc-executor-common",
+ "sp-core",
  "sp-runtime-interface",
  "sp-wasm-interface",
  "wasmtime",

--- a/client/node-common/src/service.rs
+++ b/client/node-common/src/service.rs
@@ -227,15 +227,17 @@ where
         // For now we can work with this, but it will likely need
         // to change once we start having runtime_cache_sizes, or
         // run nodes with the maximum for this value
-        let wasm = WasmExecutor::builder()
+        let mut wasm_builder = WasmExecutor::builder()
             .with_execution_method(parachain_config.wasm_method)
             .with_onchain_heap_alloc_strategy(heap_pages)
             .with_offchain_heap_alloc_strategy(heap_pages)
             .with_max_runtime_instances(parachain_config.max_runtime_instances)
-            .with_runtime_cache_size(parachain_config.runtime_cache_size)
-            .build();
+            .with_runtime_cache_size(parachain_config.runtime_cache_size);
+        if let Some(ref wasmtime_precompiled_path) = parachain_config.wasmtime_precompiled {
+            wasm_builder = wasm_builder.with_wasmtime_precompiled_path(wasmtime_precompiled_path);
+        }
 
-        let executor = ExecutorOf::<T>::new_with_wasm_executor(wasm);
+        let executor = ExecutorOf::<T>::new_with_wasm_executor(wasm_builder.build());
 
         let (client, backend, keystore_container, task_manager) =
             sc_service::new_full_parts::<BlockOf<T>, RuntimeApiOf<T>, _>(

--- a/container-chains/templates/frontier/node/src/cli.rs
+++ b/container-chains/templates/frontier/node/src/cli.rs
@@ -65,6 +65,9 @@ pub enum Subcommand {
     /// Errors since the binary was not build with `--features try-runtime`.
     #[cfg(not(feature = "try-runtime"))]
     TryRuntime,
+
+    /// Precompile the WASM runtime into native code
+    PrecompileWasm(sc_cli::PrecompileWasmCmd),
 }
 
 #[derive(Debug, Parser)]

--- a/container-chains/templates/frontier/node/src/command.rs
+++ b/container-chains/templates/frontier/node/src/command.rs
@@ -292,6 +292,16 @@ pub fn run() -> Result<()> {
             to a standalone CLI (https://github.com/paritytech/try-runtime-cli)"
                 .into())
         }
+        Some(Subcommand::PrecompileWasm(cmd)) => {
+            let runner = cli.create_runner(cmd)?;
+            runner.async_run(|mut config| {
+                let partials = NodeConfig::new_builder(&mut config, None)?;
+                Ok((
+                    cmd.run(partials.backend, config.chain_spec),
+                    partials.task_manager,
+                ))
+            })
+        }
         None => {
             let runner = cli.create_runner(&cli.run.normalize())?;
             let collator_options = cli.run.collator_options();

--- a/container-chains/templates/simple/node/src/cli.rs
+++ b/container-chains/templates/simple/node/src/cli.rs
@@ -65,6 +65,9 @@ pub enum Subcommand {
     /// Errors since the binary was not build with `--features try-runtime`.
     #[cfg(not(feature = "try-runtime"))]
     TryRuntime,
+
+    /// Precompile the WASM runtime into native code
+    PrecompileWasm(sc_cli::PrecompileWasmCmd),
 }
 
 #[derive(Debug, Parser)]

--- a/container-chains/templates/simple/node/src/command.rs
+++ b/container-chains/templates/simple/node/src/command.rs
@@ -273,6 +273,16 @@ pub fn run() -> Result<()> {
             to a standalone CLI (https://github.com/paritytech/try-runtime-cli)"
                 .into())
         }
+        Some(Subcommand::PrecompileWasm(cmd)) => {
+            let runner = cli.create_runner(cmd)?;
+            runner.async_run(|mut config| {
+                let partials = NodeConfig::new_builder(&mut config, None)?;
+                Ok((
+                    cmd.run(partials.backend, config.chain_spec),
+                    partials.task_manager,
+                ))
+            })
+        }
         None => {
             let runner = cli.create_runner(&cli.run.normalize())?;
             let collator_options = cli.run.collator_options();

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -75,6 +75,9 @@ pub enum Subcommand {
     /// Key management cli utilities
     #[command(subcommand)]
     Key(KeyCmd),
+
+    /// Precompile the WASM runtime into native code
+    PrecompileWasm(sc_cli::PrecompileWasmCmd),
 }
 
 /// The `build-spec` command used to build a specification.

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -434,6 +434,16 @@ pub fn run() -> Result<()> {
             to a standalone CLI (https://github.com/paritytech/try-runtime-cli)"
                 .into())
         }
+        Some(Subcommand::PrecompileWasm(cmd)) => {
+            let runner = cli.create_runner(cmd)?;
+            runner.async_run(|mut config| {
+                let partials = NodeConfig::new_builder(&mut config, None)?;
+                Ok((
+                    cmd.run(partials.backend, config.chain_spec),
+                    partials.task_manager,
+                ))
+            })
+        }
         None => {
             let runner = cli.create_runner(&cli.run.normalize())?;
             let collator_options = cli.run.collator_options();

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -41,7 +41,7 @@ use {
 
 fn load_spec(id: &str, para_id: ParaId) -> std::result::Result<Box<dyn ChainSpec>, String> {
     Ok(match id {
-        "dev" => Box::new(chain_spec::dancebox::development_config(
+        "dev" | "dancebox_dev" => Box::new(chain_spec::dancebox::development_config(
             para_id,
             vec![],
             vec![2000.into(), 2001.into()],

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 **/compiled/*
 **/specs/*
 html/
+wasm/precompiled*
 
 moonbeam
 polkadot

--- a/test/moonwall.config.json
+++ b/test/moonwall.config.json
@@ -9,6 +9,7 @@
             "timeout": 120000,
             "envVars": ["DEBUG_COLORS=1"],
             "testFileDir": ["suites/common-all", "suites/common-xcm", "suites/common-tanssi", "suites/dev-tanssi"],
+	    "runScripts": ["compile-wasm.ts compile -b ../target/release/tanssi-node -o wasm -c dancebox_dev"],
             "multiThreads": true,
             "reporters": ["basic"],
             "foundation": {
@@ -17,7 +18,7 @@
                     {
                         "name": "tanssi",
                         "binPath": "../target/release/tanssi-node",
-                        "options": ["--dev", "--sealing=manual", "--no-hardware-benchmarks"],
+                        "options": ["--dev", "--sealing=manual", "--no-hardware-benchmarks", "--wasmtime-precompiled=wasm"],
                         "disableDefaultEthProviders": true,
                         "newRpcBehaviour": true
                     }

--- a/test/moonwall.config.json
+++ b/test/moonwall.config.json
@@ -9,7 +9,7 @@
             "timeout": 120000,
             "envVars": ["DEBUG_COLORS=1"],
             "testFileDir": ["suites/common-all", "suites/common-xcm", "suites/common-tanssi", "suites/dev-tanssi"],
-	    "runScripts": ["compile-wasm.ts compile -b ../target/release/tanssi-node -o wasm -c dancebox_dev"],
+            "runScripts": ["compile-wasm.ts compile -b ../target/release/tanssi-node -o wasm -c dancebox_dev"],
             "multiThreads": true,
             "reporters": ["basic"],
             "foundation": {
@@ -18,7 +18,12 @@
                     {
                         "name": "tanssi",
                         "binPath": "../target/release/tanssi-node",
-                        "options": ["--dev", "--sealing=manual", "--no-hardware-benchmarks", "--wasmtime-precompiled=wasm"],
+                        "options": [
+                            "--dev",
+                            "--sealing=manual",
+                            "--no-hardware-benchmarks",
+                            "--wasmtime-precompiled=wasm"
+                        ],
                         "disableDefaultEthProviders": true,
                         "newRpcBehaviour": true
                     }
@@ -35,13 +40,7 @@
                     {
                         "name": "tanssi",
                         "binPath": "../target/release/tanssi-node",
-                        "options": [
-                            "--chain=dancebox",
-                            "--sealing=manual",
-                            "--collator",
-                            "--dev-service",
-                            "--tmp"
-                        ],
+                        "options": ["--chain=dancebox", "--sealing=manual", "--collator", "--dev-service", "--tmp"],
                         "disableDefaultEthProviders": true,
                         "newRpcBehaviour": true
                     }
@@ -51,7 +50,10 @@
         {
             "name": "dev_frontier_template",
             "testFileDir": ["suites/common-all", "suites/common-xcm", "suites/dev-frontier-template"],
-            "runScripts": ["pre-build-contracts.ts"],
+            "runScripts": [
+                "pre-build-contracts.ts",
+                "compile-wasm.ts compile -b ../target/release/container-chain-template-frontier-node -o wasm -c dev"
+            ],
             "multiThreads": true,
             "reporters": ["basic"],
             "contracts": "helpers/",
@@ -61,7 +63,12 @@
                     {
                         "name": "frontier-template",
                         "binPath": "../target/release/container-chain-template-frontier-node",
-                        "options": ["--dev", "--sealing=manual"],
+                        "options": [
+                            "--dev",
+                            "--sealing=manual",
+                            "--no-hardware-benchmarks",
+                            "--wasmtime-precompiled=wasm"
+                        ],
                         "newRpcBehaviour": true
                     }
                 ]
@@ -70,6 +77,9 @@
         {
             "name": "dev_simple_template",
             "testFileDir": ["suites/common-all", "suites/common-xcm"],
+            "runScripts": [
+                "compile-wasm.ts compile -b ../target/release/container-chain-template-simple-node -o wasm -c dev"
+            ],
             "multiThreads": true,
             "reporters": ["basic"],
             "contracts": "helpers/",
@@ -79,7 +89,12 @@
                     {
                         "name": "simple-template",
                         "binPath": "../target/release/container-chain-template-simple-node",
-                        "options": ["--dev", "--sealing=manual"],
+                        "options": [
+                            "--dev",
+                            "--sealing=manual",
+                            "--no-hardware-benchmarks",
+                            "--wasmtime-precompiled=wasm"
+                        ],
                         "newRpcBehaviour": true,
                         "disableDefaultEthProviders": true
                     }
@@ -426,6 +441,7 @@
             "name": "dev_flashbox",
             "envVars": ["DEBUG_COLORS=1"],
             "testFileDir": ["suites/common-all", "suites/common-tanssi"],
+            "runScripts": ["compile-wasm.ts compile -b ../target/release/tanssi-node -o wasm -c flashbox_dev"],
             "multiThreads": true,
             "reporters": ["basic"],
             "foundation": {
@@ -444,7 +460,8 @@
                             "--no-hardware-benchmarks",
                             "--no-prometheus",
                             "--no-telemetry",
-                            "--reserved-only"
+                            "--reserved-only",
+                            "--wasmtime-precompiled=wasm"
                         ],
                         "disableDefaultEthProviders": true,
                         "newRpcBehaviour": true

--- a/test/scripts/compile-wasm.ts
+++ b/test/scripts/compile-wasm.ts
@@ -1,19 +1,8 @@
-import { CompiledContract } from "@moonwall/cli";
-import chalk from "chalk";
 import fs from "fs/promises";
 import path from "path";
 import child_process from "child_process";
-import solc from "solc";
-import { Abi } from "viem";
-import crypto from "crypto";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-
-const sourceByReference = {} as { [ref: string]: string };
-const countByReference = {} as { [ref: string]: number };
-const refByContract = {} as { [contract: string]: string };
-const contractMd5 = {} as { [contract: string]: string };
-const solcVersion = solc.version();
 
 yargs(hideBin(process.argv))
     .usage("Usage: $0")

--- a/test/scripts/compile-wasm.ts
+++ b/test/scripts/compile-wasm.ts
@@ -47,9 +47,12 @@ async function main(args: any) {
 
     child_process.execSync(`mkdir -p ${outputDirectory}`);
 
-    const tmpDir = await fs.mkdtemp("base-path");
+    await fs.mkdir("tmp", { recursive: true });
+    const tmpDir = await fs.mkdtemp("tmp/base-path");
     try {
-        const command = `${binaryPath} precompile-wasm --log=wasmtime-runtime --base-path=${tmpDir} --chain ${args.argv.Chain} ${outputDirectory}`;
+        const command =
+            `${binaryPath} precompile-wasm --log=wasmtime-runtime --base-path=${tmpDir} ` +
+            `--chain ${args.argv.Chain} ${outputDirectory}`;
         console.log(`🗃️  ${command}`);
 
         child_process.execSync(`${command}`);

--- a/test/scripts/compile-wasm.ts
+++ b/test/scripts/compile-wasm.ts
@@ -1,0 +1,72 @@
+import { CompiledContract } from "@moonwall/cli";
+import chalk from "chalk";
+import fs from "fs/promises";
+import path from "path";
+import child_process from "child_process";
+import solc from "solc";
+import { Abi } from "viem";
+import crypto from "crypto";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+
+const sourceByReference = {} as { [ref: string]: string };
+const countByReference = {} as { [ref: string]: number };
+const refByContract = {} as { [contract: string]: string };
+const contractMd5 = {} as { [contract: string]: string };
+const solcVersion = solc.version();
+
+yargs(hideBin(process.argv))
+    .usage("Usage: $0")
+    .version("2.0.0")
+    .options({
+        OutputDirectory: {
+            type: "string",
+            alias: "o",
+            description: "Output directory for compiled contracts",
+            default: "precompiled-wasm",
+        },
+        Binary: {
+            type: "string",
+            alias: "b",
+            description: "Moonbeam binary path",
+            default: "contracts/src",
+        },
+        Chain: {
+            type: "string",
+            alias: "c",
+            description: "runtime chain to use",
+            require: true,
+        },
+        Verbose: {
+            type: "boolean",
+            alias: "v",
+            description: "Verbose mode for extra logging.",
+            default: false,
+        },
+    })
+    .command("compile", "Compile wasm", async (argv) => {
+        await main(argv as any);
+    })
+    .parse();
+
+async function main(args: any) {
+    const outputDirectory = path.join(process.cwd(), args.argv.OutputDirectory);
+    const binaryPath = args.argv.Binary;
+
+    console.log(`🗃️  Binary: ${binaryPath}`);
+    console.log(`🗃️  Output directory: ${outputDirectory}`);
+
+    child_process.execSync(`mkdir -p ${outputDirectory}`);
+
+    const tmpDir = await fs.mkdtemp("base-path");
+    try {
+        const command = `${binaryPath} precompile-wasm --log=wasmtime-runtime --base-path=${tmpDir} --chain ${args.argv.Chain} ${outputDirectory}`;
+        console.log(`🗃️  ${command}`);
+
+        child_process.execSync(`${command}`);
+    } finally {
+        if ((await fs.stat(tmpDir)).isDirectory()) {
+            await fs.rm(tmpDir, { recursive: true, force: true });
+        }
+    }
+}


### PR DESCRIPTION
`dev_tanssi` tests spawn a new `tanssi-node` process for each test. This node needs to compile the runtime wasm. That can take a long time. This pull request adds a flag to use a precompiled wasm, which means that now we only need to compile the wasm once.

Affects dev tests for tanssi, flashbox, and both templates.

Speeds up coverage job from 1h 20min to 1h 3m