### PR TITLE
Use wasmtime-precompiled in zombienet tests

### DIFF
--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -302,7 +302,9 @@ async fn start_node_impl(
             .base
             .base
             .import_params
-            .wasmtime_precompiled.is_none() {
+            .wasmtime_precompiled
+            .is_none()
+        {
             container_chain_cli
                 .base
                 .base

--- a/test/configs/zombieTanssi.json
+++ b/test/configs/zombieTanssi.json
@@ -36,35 +36,43 @@
                 {
                     "name": "Collator1000-01",
                     "ws_port": "9948",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },
                 {
                     "name": "Collator1000-02",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },
                 {
                     "name": "Collator2000-01",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },
                 {
                     "name": "Collator2000-02",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },
                 {
                     "name": "Collator2001-01",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },
                 {
                     "name": "Collator2001-02",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },
                 {
                     "name": "Collator2002-01",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },
                 {
                     "name": "Collator2002-02",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 }
             ]
         },
@@ -76,6 +84,7 @@
                     "name": "FullNode-2000",
                     "validator": false,
                     "command": "../target/release/container-chain-template-simple-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"],
                     "ws_port": 9949,
                     "p2p_port": 33049
                 }
@@ -89,6 +98,7 @@
                     "name": "FullNode-2001",
                     "validator": false,
                     "command": "../target/release/container-chain-template-frontier-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"],
                     "ws_port": 9950,
                     "p2p_port": 33050
                 }
@@ -102,6 +112,7 @@
                     "name": "FullNode-2002",
                     "validator": false,
                     "command": "../target/release/container-chain-template-simple-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"],
                     "ws_port": 9951,
                     "p2p_port": 33051
                 }

--- a/test/configs/zombieTanssiKeepDb.json
+++ b/test/configs/zombieTanssiKeepDb.json
@@ -36,24 +36,33 @@
                 {
                     "name": "Collator1000-01",
                     "ws_port": "9948",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },
                 {
                     "name": "Collator1000-02",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },
                 {
                     "name": "Collator2000-01",
                     "command": "../target/release/tanssi-node",
-                    "args": ["-- --keep-db"]
+                    "args": [
+                        "--no-hardware-benchmarks",
+                        "--database=paritydb",
+                        "--wasmtime-precompiled=wasm",
+                        "-- --keep-db"
+                    ]
                 },
                 {
                     "name": "Collator2000-02",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },
                 {
                     "name": "Collator1000-03",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 }
             ]
         },
@@ -65,6 +74,7 @@
                     "name": "FullNode-2000",
                     "validator": false,
                     "command": "../target/release/container-chain-template-simple-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"],
                     "ws_port": 9949,
                     "p2p_port": 33049
                 }

--- a/test/configs/zombieTanssiMetrics.json
+++ b/test/configs/zombieTanssiMetrics.json
@@ -36,25 +36,38 @@
                 {
                     "name": "Collator1000-01",
                     "ws_port": "9948",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },
                 {
                     "name": "Collator1000-02",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },
                 {
                     "name": "Collator2000-01",
                     "command": "../target/release/tanssi-node",
-                    "args": ["-- --tmp --prometheus-external --prometheus-port 27124"]
+                    "args": [
+                        "--no-hardware-benchmarks",
+                        "--database=paritydb",
+                        "--wasmtime-precompiled=wasm",
+                        "-- --tmp --prometheus-external --prometheus-port 27124"
+                    ]
                 },
                 {
                     "name": "Collator2000-02",
                     "command": "../target/release/tanssi-node",
-                    "args": ["-- --tmp --prometheus-external --prometheus-port 27125"]
+                    "args": [
+                        "--no-hardware-benchmarks",
+                        "--database=paritydb",
+                        "--wasmtime-precompiled=wasm",
+                        "-- --tmp --prometheus-external --prometheus-port 27125"
+                    ]
                 },
                 {
                     "name": "Collator1000-03",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 }
             ]
         },
@@ -66,6 +79,7 @@
                     "name": "FullNode-2000",
                     "validator": false,
                     "command": "../target/release/container-chain-template-simple-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"],
                     "ws_port": 9949,
                     "p2p_port": 33049
                 }

--- a/test/configs/zombieTanssiParathreads.json
+++ b/test/configs/zombieTanssiParathreads.json
@@ -36,35 +36,43 @@
                 {
                     "name": "Collator-01",
                     "ws_port": "9948",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },
                 {
                     "name": "Collator-02",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },
                 {
                     "name": "Collator-03",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },
                 {
                     "name": "Collator-04",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },
                 {
                     "name": "Collator-05",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },
                 {
                     "name": "Collator-06",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },
                 {
                     "name": "Collator-07",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },
                 {
                     "name": "Collator-08",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 }
             ]
         },
@@ -76,6 +84,7 @@
                     "name": "FullNode-2000",
                     "validator": false,
                     "command": "../target/release/container-chain-template-simple-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"],
                     "ws_port": 9949,
                     "p2p_port": 33049
                 }
@@ -89,6 +98,7 @@
                     "name": "FullNode-2001",
                     "validator": false,
                     "command": "../target/release/container-chain-template-frontier-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"],
                     "ws_port": 9950,
                     "p2p_port": 33050
                 }

--- a/test/configs/zombieTanssiRotation.json
+++ b/test/configs/zombieTanssiRotation.json
@@ -36,35 +36,43 @@
                 {
                     "name": "Collator1000-01",
                     "ws_port": "9948",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },
                 {
                     "name": "Collator1000-02",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },
                 {
                     "name": "Collator2000-01",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },
                 {
                     "name": "Collator2000-02",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },
                 {
                     "name": "Collator2001-01",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },
                 {
                     "name": "Collator2001-02",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },
                 {
                     "name": "Collator2002-01",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },
                 {
                     "name": "Collator2002-02",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 }
             ]
         },
@@ -76,6 +84,7 @@
                     "name": "FullNode-2000",
                     "validator": false,
                     "command": "../target/release/container-chain-template-simple-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"],
                     "ws_port": 9949,
                     "p2p_port": 33049
                 }
@@ -89,6 +98,7 @@
                     "name": "FullNode-2001",
                     "validator": false,
                     "command": "../target/release/container-chain-template-frontier-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"],
                     "ws_port": 9950,
                     "p2p_port": 33050
                 }

--- a/test/configs/zombieTanssiWarpSync.json
+++ b/test/configs/zombieTanssiWarpSync.json
@@ -36,23 +36,28 @@
                 {
                     "name": "Collator1000-01",
                     "ws_port": "9948",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },
                 {
                     "name": "Collator1000-02",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },
                 {
                     "name": "Collator2000-01",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },
                 {
                     "name": "Collator2000-02",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },
                 {
                     "name": "Collator1000-03",
-                    "command": "../target/release/tanssi-node"
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 }
             ]
         },
@@ -64,6 +69,7 @@
                     "name": "FullNode-2000",
                     "validator": false,
                     "command": "../target/release/container-chain-template-simple-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"],
                     "ws_port": 9949,
                     "p2p_port": 33049
                 }

--- a/test/moonwall.config.json
+++ b/test/moonwall.config.json
@@ -105,7 +105,13 @@
             "name": "zombie_tanssi",
             "timeout": 600000,
             "testFileDir": ["suites/para"],
-            "runScripts": ["build-spec.sh", "download-polkadot.sh"],
+            "runScripts": [
+                "build-spec.sh",
+                "download-polkadot.sh",
+                "compile-wasm.ts compile -b ../target/release/tanssi-node -o wasm -c specs/tanssi-1000.json",
+                "compile-wasm.ts compile -b ../target/release/container-chain-template-simple-node -o wasm -c specs/template-container-2000.json",
+                "compile-wasm.ts compile -b ../target/release/container-chain-template-frontier-node -o wasm -c specs/template-container-2001.json"
+            ],
             "foundation": {
                 "type": "zombie",
                 "zombieSpec": {
@@ -154,7 +160,12 @@
         {
             "name": "zombie_tanssi_keep_db",
             "testFileDir": ["suites/keep-db"],
-            "runScripts": ["build-spec-warp-sync.sh", "download-polkadot.sh"],
+            "runScripts": [
+                "build-spec-warp-sync.sh",
+                "download-polkadot.sh",
+                "compile-wasm.ts compile -b ../target/release/tanssi-node -o wasm -c specs/warp-sync-tanssi-1000.json",
+                "compile-wasm.ts compile -b ../target/release/container-chain-template-simple-node -o wasm -c specs/warp-sync-template-container-2000.json"
+            ],
             "timeout": 600000,
             "foundation": {
                 "type": "zombie",
@@ -183,7 +194,12 @@
         {
             "name": "zombie_tanssi_metrics",
             "testFileDir": ["suites/metrics"],
-            "runScripts": ["build-spec-warp-sync.sh", "download-polkadot.sh"],
+            "runScripts": [
+                "build-spec-warp-sync.sh",
+                "download-polkadot.sh",
+                "compile-wasm.ts compile -b ../target/release/tanssi-node -o wasm -c specs/warp-sync-tanssi-1000.json",
+                "compile-wasm.ts compile -b ../target/release/container-chain-template-simple-node -o wasm -c specs/warp-sync-template-container-2000.json"
+            ],
             "timeout": 600000,
             "foundation": {
                 "type": "zombie",
@@ -213,7 +229,13 @@
             "name": "zombie_tanssi_parathreads",
             "timeout": 600000,
             "testFileDir": ["suites/parathreads"],
-            "runScripts": ["build-spec-parathreads.sh", "download-polkadot.sh"],
+            "runScripts": [
+                "build-spec-parathreads.sh",
+                "download-polkadot.sh",
+                "compile-wasm.ts compile -b ../target/release/tanssi-node -o wasm -c specs/parathreads-tanssi-1000.json",
+                "compile-wasm.ts compile -b ../target/release/container-chain-template-simple-node -o wasm -c specs/parathreads-template-container-2000.json",
+                "compile-wasm.ts compile -b ../target/release/container-chain-template-frontier-node -o wasm -c specs/parathreads-template-container-2001.json"
+            ],
             "foundation": {
                 "type": "zombie",
                 "zombieSpec": {
@@ -257,7 +279,13 @@
         {
             "name": "zombie_tanssi_rotation",
             "testFileDir": ["suites/rotation-para"],
-            "runScripts": ["build-spec.sh", "download-polkadot.sh"],
+            "runScripts": [
+                "build-spec.sh",
+                "download-polkadot.sh",
+                "compile-wasm.ts compile -b ../target/release/tanssi-node -o wasm -c specs/tanssi-1000.json",
+                "compile-wasm.ts compile -b ../target/release/container-chain-template-simple-node -o wasm -c specs/template-container-2000.json",
+                "compile-wasm.ts compile -b ../target/release/container-chain-template-frontier-node -o wasm -c specs/template-container-2001.json"
+            ],
             "timeout": 600000,
             "foundation": {
                 "type": "zombie",
@@ -301,7 +329,12 @@
         {
             "name": "zombie_tanssi_warp_sync",
             "testFileDir": ["suites/warp-sync"],
-            "runScripts": ["build-spec-warp-sync.sh", "download-polkadot.sh"],
+            "runScripts": [
+                "build-spec-warp-sync.sh",
+                "download-polkadot.sh",
+                "compile-wasm.ts compile -b ../target/release/tanssi-node -o wasm -c specs/warp-sync-tanssi-1000.json",
+                "compile-wasm.ts compile -b ../target/release/container-chain-template-simple-node -o wasm -c specs/warp-sync-template-container-2000.json"
+            ],
             "timeout": 600000,
             "foundation": {
                 "type": "zombie",


### PR DESCRIPTION
Compile wasm once before starting all the zombienet nodes, instead of having each node compile it. This also makes rotations a bit faster, we will see if the block delay on rotation is reduced.

Also disable hardware benchmarks, they were enabled for collators and full nodes.