### PR TITLE
copy all binaries to docker image

### DIFF
--- a/docker/container-chain-evm-template.Dockerfile
+++ b/docker/container-chain-evm-template.Dockerfile
@@ -21,7 +21,7 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifi
 
 USER container-chain-template-evm
 
-COPY --chown=container-chain-template-evm build/container-chain-template-frontier-node /container-chain-template-evm
+COPY --chown=container-chain-template-evm build/container-chain-template-frontier-node* /container-chain-template-evm
 RUN chmod uog+x /container-chain-template-evm/container-chain-template-frontier*
 
 # 30333 for parachain p2p

--- a/docker/container-chain-simple-template.Dockerfile
+++ b/docker/container-chain-simple-template.Dockerfile
@@ -21,7 +21,7 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifi
 
 USER container-chain-template-simple
 
-COPY --chown=container-chain-template-simple build/container-chain-template-simple-node /container-chain-template-simple
+COPY --chown=container-chain-template-simple build/container-chain-template-simple-node* /container-chain-template-simple
 RUN chmod uog+x /container-chain-template-simple/container-chain-template-simple*
 
 # 30333 for parachain p2p

--- a/docker/tanssi.Dockerfile
+++ b/docker/tanssi.Dockerfile
@@ -21,7 +21,7 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifi
 
 USER tanssi
 
-COPY --chown=tanssi build/tanssi-node /tanssi
+COPY --chown=tanssi build/tanssi-node* /tanssi
 RUN chmod uog+x /tanssi/tanssi*
 
 # 30333 for parachain p2p


### PR DESCRIPTION
Up to now we were only copying the main binaries (tanssi-node, container-chain-simple-template-node, etc) but not those based of skylake and znver3. This PR should fix this