### PR TITLE
Build own srtool

### DIFF
--- a/.github/workflows/publish-runtime-chevdor.yml
+++ b/.github/workflows/publish-runtime-chevdor.yml
@@ -82,7 +82,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          registry: index.docker.io
       - name: Download original scripts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/publish-runtime-chevdor.yml
+++ b/.github/workflows/publish-runtime-chevdor.yml
@@ -1,0 +1,214 @@
+name: Publish Runtime Draft Chevdor
+
+# The code (like generate-release-body) will be taken from the tag versions, not master
+on:
+  workflow_dispatch:
+    inputs:
+      from:
+        description: tag (ex. runtime-53) to retrieve commit diff from
+        required: true
+      to:
+        description: tag (ex. runtime-155) to generate release note and srtool runtimes from
+        required: true
+      chains:
+        description: the chains for which we should do the release (ex. dancebox)
+        required: false
+        type: choice
+        default: tanssi-only
+        options:
+          - tanssi-only
+          - templates-only
+          - run-all
+
+jobs:
+  ####### Build runtimes with srtool #######
+
+  setup-scripts:
+    runs-on: self-hosted
+    steps:
+      ## Use scripts and tools from current branch
+      - uses: actions/checkout@v3
+      - name: Upload scripts
+        uses: actions/upload-artifact@v3
+        with:
+          name: original-scripts
+          path: scripts
+      - name: Upload tools
+        uses: actions/upload-artifact@v3
+        with:
+          name: original-tools
+          path: tools
+  
+  matrix_prep:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix_tests: ${{ steps.prepare.outputs.matrix_tests }}
+    steps:
+      - uses: actions/checkout@v3
+
+    # Build input dependent matrix
+      - name: create matrix
+        id: prepare
+        run: |
+          dancebox='{"runtime_name": "dancebox","runtime_path" : "./runtime/dancebox/src/lib.rs", "runtime_dir" : "./runtime/dancebox", "chain_name": "dancebox"}'
+          flashbox='{"runtime_name": "flashbox","runtime_path" : "./runtime/flashbox/src/lib.rs", "runtime_dir" : "./runtime/flashbox", "chain_name": "flashbox"}'
+          frontier_template='{"runtime_name": "frontier-template","runtime_path" : "./container-chains/templates/frontier/runtime/src/lib.rs", "runtime_dir" : "./container-chains/templates/frontier/runtime/", "chain_name": "container-chain-template-frontier"}'
+          simple_template='{"runtime_name": "simple-template","runtime_path" : "./container-chains/templates/simple/runtime/src/lib.rs", "runtime_dir" : "./container-chains/templates/simple/runtime/", "chain_name": "container-chain-template-simple"}'
+
+          if [[ ${{ github.event.inputs.chains }} = "tanssi-only" ]]; then
+            echo "matrix_tests=[$dancebox, $flashbox]" >> $GITHUB_OUTPUT
+          elif [[ ${{ github.event.inputs.chains }} = "templates-only" ]]; then
+            echo "matrix_tests=[$simple_template, $frontier_template]" >> $GITHUB_OUTPUT
+          else
+            echo "matrix_tests=[$dancebox, $flashbox, $simple_template, $frontier_template]" >> $GITHUB_OUTPUT
+          fi
+  build-srtool-runtimes:
+    needs: ["setup-scripts", "matrix_prep"]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        chain: ${{ fromJson(needs.matrix_prep.outputs.matrix_tests) }}
+        srtool_image:
+          - moondancelabs/srtool
+        srtool_image_tag:
+          - 1.75.0
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.to }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v2.2.0
+        if: github.repository == 'moondance-labs/tanssi'
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: index.docker.io
+      - name: Download original scripts
+        uses: actions/download-artifact@v3
+        with:
+          name: original-scripts
+          path: original-scripts
+      - name: Build & Push purestake/srtool image
+        if: github.repository == 'moondance-labs/tanssiasdas'
+        run: |
+          exit 1
+          echo ${{ matrix.chain.runtime_name }}
+          docker pull "${{ matrix.srtool_image }}:${{ matrix.srtool_image_tag }}" && image_exists=true || image_exists=false
+
+          if [[ $image_exists = "false" ]]; then
+            exit 1
+          else
+            echo skiping build "${{ matrix.srtool_image }}:${{ matrix.srtool_image_tag }}", image already exists
+          fi
+      # Build WASM with Substrate Runtime Tool
+      - name: Srtool build
+        id: srtool_build
+        uses: chevdor/srtool-actions@v0.9.2
+        with:
+          chain: ${{ matrix.chain.chain_name }}
+          runtime_dir: ${{ matrix.chain.runtime_dir }}
+      - name: Summary
+        run: |
+          echo '${{ steps.srtool_build.outputs.json }}' | jq . > ${{ matrix.chain.runtime_name }}-srtool-digest.json
+          cat ${{ matrix.chain.runtime_name }}-srtool-digest.json
+          cp ${{ steps.srtool_build.outputs.wasm_compressed }} ${{ matrix.chain.runtime_name }}-runtime.compact.compressed.wasm
+      - name: Archive Artifacts for ${{ matrix.chain }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: runtime-info
+          path: |
+            ${{ matrix.chain.runtime_name }}-runtime.compact.compressed.wasm
+            ${{ matrix.chain.runtime_name }}-srtool-digest.json
+
+          
+  ####### Prepare the release draft #######
+  prepare-draft-release:
+    runs-on: ubuntu-latest
+    needs: ["setup-scripts", "build-srtool-runtimes", "matrix_prep"]
+    outputs:
+      release_url: ${{ steps.create-release.outputs.html_url }}
+      asset_upload_url: ${{ steps.create-release.outputs.upload_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.to }}
+          fetch-depth: 0 
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x  
+      - name: Download Original Tools
+        uses: actions/download-artifact@v3
+        with:
+          name: original-tools
+          path: original-tools 
+      - name: Download runtime-info
+        uses: actions/download-artifact@v3.0.2
+        with:
+          name: runtime-info
+          path: build  
+      - name: Generate release body
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        id: generate-release-body
+        working-directory: original-tools
+        run: |
+          RUNTIMES=$(echo '${{needs.matrix_prep.outputs.matrix_tests}}' | jq -r '.[] | .runtime_name + " "')
+          yarn
+          yarn -s run ts-node github/generate-runtimes-body.ts --owner "${{ github.repository_owner }}" --repo "$(basename ${{ github.repository }})" --from "${{ github.event.inputs.from }}" --to "${{ github.event.inputs.to }}" --srtool-report-folder '../build/' --runtimes $RUNTIMES > ../body.md      - name: Get runtime version
+      - name: Create draft release
+        id: create-release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.event.inputs.to }}
+          release_name: Runtime ${{ github.event.inputs.to }}
+          body_path: body.md
+          draft: true
+
+          
+  ####### Upload asserts to the release draft #######
+  publish-draft-release:
+    runs-on: ubuntu-latest
+    needs: ["setup-scripts", "build-srtool-runtimes", "prepare-draft-release", "matrix_prep"]
+    strategy:
+      matrix:
+        chain: ${{ fromJson(needs.matrix_prep.outputs.matrix_tests) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.to }}
+          fetch-depth: 0
+      - name: Download ${{ matrix.chain }} runtime
+        uses: actions/download-artifact@v3.0.2
+        with:
+          name: runtime-info
+          path: build    
+      - name: Get runtime version
+        id: get-runtime-ver
+        run: |
+          runtime_ver="$(cat ${{ matrix.chain.runtime_path }} | grep -o 'spec_version: [0-9]*' | tail -1 | grep -o '[0-9]*')"
+          echo "runtime_ver=$runtime_ver" >> $GITHUB_OUTPUT
+          mv build/${{ matrix.chain.runtime_name }}-runtime.compact.compressed.wasm ${{ matrix.chain.runtime_name }}-runtime-${runtime_ver}.wasm
+          mv build/${{ matrix.chain.runtime_name }}-srtool-digest.json ${{ matrix.chain.runtime_name }}-runtime-${runtime_ver}-srtool-digest.json
+      - name: Upload ${{ matrix.chain }} wasm
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.prepare-draft-release.outputs.asset_upload_url }}
+          asset_path: ${{ matrix.chain.runtime_name }}-runtime-${{ steps.get-runtime-ver.outputs.runtime_ver }}.wasm
+          asset_name: ${{ matrix.chain.runtime_name }}-runtime-${{ steps.get-runtime-ver.outputs.runtime_ver }}.wasm
+          asset_content_type: application/octet-stream
+      - name: Upload ${{ matrix.chain.runtime_name }} srtool digest
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url:  ${{ needs.prepare-draft-release.outputs.asset_upload_url }}
+          asset_path: ${{ matrix.chain.runtime_name }}-runtime-${{ steps.get-runtime-ver.outputs.runtime_ver }}-srtool-digest.json
+          asset_name: ${{ matrix.chain.runtime_name }}-runtime-${{ steps.get-runtime-ver.outputs.runtime_ver }}.srtool-digest.json
+          asset_content_type: application/json

--- a/.github/workflows/publish-runtime-chevdor.yml
+++ b/.github/workflows/publish-runtime-chevdor.yml
@@ -143,7 +143,7 @@ jobs:
         run: |
           RUNTIMES=$(echo '${{needs.matrix_prep.outputs.matrix_tests}}' | jq -r '.[] | .runtime_name + " "')
           yarn
-          yarn -s run ts-node github/generate-runtimes-body.ts --owner "${{ github.repository_owner }}" --repo "$(basename ${{ github.repository }})" --from "${{ github.event.inputs.from }}" --to "${{ github.event.inputs.to }}" --srtool-report-folder '../build/' --runtimes $RUNTIMES > ../body.md      - name: Get runtime version
+          yarn -s run ts-node github/generate-runtimes-body.ts --owner "${{ github.repository_owner }}" --repo "$(basename ${{ github.repository }})" --from "${{ github.event.inputs.from }}" --to "${{ github.event.inputs.to }}" --srtool-report-folder '../build/' --runtimes $RUNTIMES > ../body.md
       - name: Create draft release
         id: create-release
         uses: actions/create-release@v1

--- a/.github/workflows/publish-runtime-chevdor.yml
+++ b/.github/workflows/publish-runtime-chevdor.yml
@@ -88,18 +88,6 @@ jobs:
         with:
           name: original-scripts
           path: original-scripts
-      - name: Build & Push purestake/srtool image
-        if: github.repository == 'moondance-labs/tanssiasdas'
-        run: |
-          exit 1
-          echo ${{ matrix.chain.runtime_name }}
-          docker pull "${{ matrix.srtool_image }}:${{ matrix.srtool_image_tag }}" && image_exists=true || image_exists=false
-
-          if [[ $image_exists = "false" ]]; then
-            exit 1
-          else
-            echo skiping build "${{ matrix.srtool_image }}:${{ matrix.srtool_image_tag }}", image already exists
-          fi
       # Build WASM with Substrate Runtime Tool
       - name: Srtool build
         id: srtool_build

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -84,10 +84,10 @@ jobs:
           ref: ${{ github.event.inputs.to }}
       - name: Login to DockerHub
         uses: docker/login-action@v2.2.0
-        if: github.repository == 'moondance-labs/tanssi'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: index.docker.io
       - name: Download original scripts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -69,9 +69,15 @@ jobs:
       matrix:
         chain: ${{ fromJson(needs.matrix_prep.outputs.matrix_tests) }}
         srtool_image:
-          - moonbeamfoundation/srtool
+          - moondancelabs/srtool
         srtool_image_tag:
-          - 1.70.0
+          - 1.75.0
+        # Change this once https://github.com/paritytech/srtool/pull/81 gets merged
+        srtool_build_base_dockerhub:
+          - moondancelabs/srtool
+        srtool_build_source_image_tag:
+          - temp-1.75
+
     steps:
       - uses: actions/checkout@v3
         with:
@@ -81,14 +87,21 @@ jobs:
         with:
           name: original-scripts
           path: original-scripts
-      - name: Build & Push purestake/srtool image
+      - name: Build & Push moondancelabs/srtool image
         if: github.repository == 'moondance-labs/tanssi'
         run: |
-          echo ${{ matrix.chain.runtime_name }}
           docker pull "${{ matrix.srtool_image }}:${{ matrix.srtool_image_tag }}" && image_exists=true || image_exists=false
 
           if [[ $image_exists = "false" ]]; then
-            exit 1
+            echo building "${{ matrix.srtool_image }}:${{ matrix.srtool_image_tag }}"
+            docker build --pull --no-cache . \
+              -f docker/moonbeam-srtool.Dockerfile \
+              --build-arg SRTOOL_IMAGE_TAG=${{ matrix.srtool_build_source_image_tag }} \
+              --build-arg SRTOOL_IMAGE_REPO=${{ matrix.srtool_build_base_dockerhub }} \
+              -t ${{ matrix.srtool_image }}:${{ matrix.srtool_image_tag }}
+
+            echo pushing "${{ matrix.srtool_image }}:${{ matrix.srtool_image_tag }}"
+            docker push "${{ matrix.srtool_image }}:${{ matrix.srtool_image_tag }}"
           else
             echo skiping build "${{ matrix.srtool_image }}:${{ matrix.srtool_image_tag }}", image already exists
           fi

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -84,7 +84,7 @@ jobs:
           ref: ${{ github.event.inputs.to }}
       - name: Login to DockerHub
         uses: docker/login-action@v2.2.0
-        if: github.repository == 'moonbeam-foundation/moonbeam'
+        if: github.repository == 'moondance-labs/tanssi'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -99,6 +99,7 @@ jobs:
         run: |
           docker pull "${{ matrix.srtool_image }}:${{ matrix.srtool_image_tag }}" && image_exists=true || image_exists=false
 
+          echo $image_exists
           if [[ $image_exists == "false" ]]; then
             echo building "${{ matrix.srtool_image }}:${{ matrix.srtool_image_tag }}"
             docker build --pull --no-cache . \

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -88,7 +88,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          registry: index.docker.io
       - name: Download original scripts
         uses: actions/download-artifact@v3
         with:
@@ -99,8 +98,7 @@ jobs:
         run: |
           docker pull "${{ matrix.srtool_image }}:${{ matrix.srtool_image_tag }}" && image_exists=true || image_exists=false
 
-          echo $image_exists
-          if [[ $image_exists == "false" ]]; then
+          if [[ $image_exists = "false" ]]; then
             echo building "${{ matrix.srtool_image }}:${{ matrix.srtool_image_tag }}"
             docker build --pull --no-cache . \
               -f docker/tanssi-srtool.Dockerfile \

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -99,7 +99,7 @@ jobs:
         run: |
           docker pull "${{ matrix.srtool_image }}:${{ matrix.srtool_image_tag }}" && image_exists=true || image_exists=false
 
-          if [[ $image_exists = "false" ]]; then
+          if [[ $image_exists == "false" ]]; then
             echo building "${{ matrix.srtool_image }}:${{ matrix.srtool_image_tag }}"
             docker build --pull --no-cache . \
               -f docker/tanssi-srtool.Dockerfile \

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Build & Push moondancelabs/srtool image
         if: github.repository == 'moondance-labs/tanssi'
         run: |
-          docker pull "${{ matrix.srtool_image }}:${{ matrix.srtool_image_tag }}" && image_exists=true || image_exists=false
+          docker pull "registry.hub.docker.com/${{ matrix.srtool_image }}:${{ matrix.srtool_image_tag }}" && image_exists=true || image_exists=false
 
           if [[ $image_exists = "false" ]]; then
             echo building "${{ matrix.srtool_image }}:${{ matrix.srtool_image_tag }}"

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -87,7 +87,7 @@ jobs:
         if: github.repository == 'moondance-labs/tanssi'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
           registry: index.docker.io
       - name: Download original scripts
         uses: actions/download-artifact@v3

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -82,6 +82,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.to }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v2.2.0
+        if: github.repository == 'moonbeam-foundation/moonbeam'
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          registry: index.docker.io
       - name: Download original scripts
         uses: actions/download-artifact@v3
         with:
@@ -95,7 +102,7 @@ jobs:
           if [[ $image_exists = "false" ]]; then
             echo building "${{ matrix.srtool_image }}:${{ matrix.srtool_image_tag }}"
             docker build --pull --no-cache . \
-              -f docker/moonbeam-srtool.Dockerfile \
+              -f docker/tanssi-srtool.Dockerfile \
               --build-arg SRTOOL_IMAGE_TAG=${{ matrix.srtool_build_source_image_tag }} \
               --build-arg SRTOOL_IMAGE_REPO=${{ matrix.srtool_build_base_dockerhub }} \
               -t ${{ matrix.srtool_image }}:${{ matrix.srtool_image_tag }}

--- a/docker/tanssi-srtool.Dockerfile
+++ b/docker/tanssi-srtool.Dockerfile
@@ -1,0 +1,11 @@
+ARG SRTOOL_IMAGE_TAG
+ARG SRTOOL_IMAGE_REPO
+
+FROM ${SRTOOL_IMAGE_REPO}:${SRTOOL_IMAGE_TAG}
+
+USER root
+
+RUN apt-get update && \
+    apt-get install openssh-server -y
+
+USER 1001


### PR DESCRIPTION
We have an issue where we need to use a specific srtool with certain components (rust-src) added, which are in this PR: https://github.com/paritytech/srtool/pull/81

I modified the publish-runtime job to have the possibility to build from a custom image (and not the official parity one) that I pushed with those changes.

Additioanlly, I also added another job that instead builds from the srtool CI action. We can use one or the other.