### PR TITLE
Wait for block to be finalized in signAndSendAndInclude

### DIFF
--- a/test/moonwall.config.json
+++ b/test/moonwall.config.json
@@ -49,7 +49,12 @@
         },
         {
             "name": "dev_frontier_template",
-            "testFileDir": ["suites/common-all", "suites/common-xcm", "suites/common-container-chains", "suites/dev-frontier-template"],
+            "testFileDir": [
+                "suites/common-all",
+                "suites/common-xcm",
+                "suites/common-container-chains",
+                "suites/dev-frontier-template"
+            ],
             "runScripts": [
                 "pre-build-contracts.ts",
                 "compile-wasm.ts compile -b ../target/release/container-chain-template-frontier-node -o wasm -c dev"

--- a/test/suites/keep-db/test_restart_keep_db.ts
+++ b/test/suites/keep-db/test_restart_keep_db.ts
@@ -241,7 +241,11 @@ describeSuite({
 
                 const tx = paraApi.tx.registrar.deregister(2000);
                 await signAndSendAndInclude(paraApi.tx.sudo.sudo(tx), alice);
-                await waitSessions(context, paraApi, 2);
+                await waitSessions(context, paraApi, 2, async () => {
+                    const registered = await paraApi.query.registrar.registeredParaIds();
+                    // Stop waiting if 2000 is no longer registered
+                    return !registered.toJSON().includes(2000);
+                });
 
                 // The node detects assignment when the block is finalized, but "waitSessions" ignores finality.
                 // So wait a few blocks more hoping that the current block will be finalized by then.

--- a/test/suites/metrics/test_metrics_stop.ts
+++ b/test/suites/metrics/test_metrics_stop.ts
@@ -156,7 +156,11 @@ describeSuite({
 
                 const tx = paraApi.tx.registrar.deregister(2000);
                 await signAndSendAndInclude(paraApi.tx.sudo.sudo(tx), alice);
-                await waitSessions(context, paraApi, 2);
+                await waitSessions(context, paraApi, 2, async () => {
+                    const registered = await paraApi.query.registrar.registeredParaIds();
+                    // Stop waiting if 2000 is no longer registered
+                    return !registered.toJSON().includes(2000);
+                });
 
                 // The node detects assignment when the block is finalized, but "waitSessions" ignores finality.
                 // So wait a few blocks more hoping that the current block will be finalized by then.


### PR DESCRIPTION
Fixes a zombienet timeout caused by an extrinsic being included, reverted, and then included again in a later block.

For example, an extrinsic to deregister chain 2002:

* Deregister extrinsic included in block 29
* Test detects that and waits 2 sessions. In block 35 the chain should already be deregistered.
* Block 29 is reverted and the new block 29 does not include the extrinsic.
* Extrinsic is included again in block 32. The chain will be deregistered after 2 sessions, in block 40.
* In block 35, the script assumes that the chain must already be deregistered, while it's not, so the expect fails.

With the new changes, the script will wait until the extrinsic is finalized, meaning that it can be reverted anymore. A drawback is that it may wait 1 session more than needed. To fix this, the waitSessions function has a new callback parameter to finish the wait early if some condition is met.