### PR TITLE
Fix registration zombienet test

### DIFF
--- a/test/suites/para/test_tanssi_containers.ts
+++ b/test/suites/para/test_tanssi_containers.ts
@@ -261,15 +261,14 @@ describeSuite({
                 // But registered does not contain 2002 yet
                 // TODO: fix once we have types
                 expect(registered3.toJSON().includes(2002)).to.be.false;
-
-                // The node starts one session before the container chain is in registered list
-                await waitSessions(context, paraApi, 1);
-                // Not registered yet, still pending
-                const registered4 = await paraApi.query.registrar.registeredParaIds();
-                // TODO: fix once we have types
-                expect(registered4.toJSON().includes(2002)).to.be.false;
-
-                await waitSessions(context, paraApi, 1);
+                // Container chain will be registered after 2 sessions, but because `signAndSendAndInclude` waits
+                // until the block that includes the extrinsic is finalized, it is possible that we only need to wait
+                // 1 session. So use a callback to wait 1 or 2 sessions.
+                await waitSessions(context, paraApi, 2, async () => {
+                    const registered = await paraApi.query.registrar.registeredParaIds();
+                    // Stop waiting when 2002 is registered
+                    return registered.toJSON().includes(2002);
+                });
                 // Check that registered para ids contains 2002
                 const registered5 = await paraApi.query.registrar.registeredParaIds();
                 // TODO: fix once we have types


### PR DESCRIPTION
Waiting always 2 sessions can cause the test to fail, we need to wait 1 or 2 sessions depending on when the block that includes the extrinsic is finalized.