### PR TITLE
Remove unused bootnodes config from pallet_registrar

### DIFF
--- a/pallets/registrar/src/lib.rs
+++ b/pallets/registrar/src/lib.rs
@@ -127,8 +127,6 @@ pub mod pallet {
         #[pallet::constant]
         type MaxGenesisDataSize: Get<u32>;
 
-        type MaxBootNodes: Get<u32>;
-        type MaxBootNodeUrlLen: Get<u32>;
         type MaxLengthTokenSymbol: Get<u32>;
 
         type SessionIndex: parity_scale_codec::FullCodec + TypeInfo + Copy + AtLeast32BitUnsigned;

--- a/pallets/registrar/src/mock.rs
+++ b/pallets/registrar/src/mock.rs
@@ -112,8 +112,6 @@ impl pallet_registrar::Config for Test {
     type RegistrarOrigin = frame_system::EnsureRoot<u64>;
     type MaxLengthParaIds = ConstU32<1000>;
     type MaxGenesisDataSize = ConstU32<5_000_000>;
-    type MaxBootNodes = ConstU32<10>;
-    type MaxBootNodeUrlLen = ConstU32<200>;
     type MaxLengthTokenSymbol = MaxLengthTokenSymbol;
     type SessionDelay = ConstU32<2>;
     type SessionIndex = u32;

--- a/runtime/dancebox/src/lib.rs
+++ b/runtime/dancebox/src/lib.rs
@@ -1002,8 +1002,6 @@ impl pallet_registrar::Config for Runtime {
     type RegistrarOrigin = EnsureRoot<AccountId>;
     type MaxLengthParaIds = MaxLengthParaIds;
     type MaxGenesisDataSize = MaxEncodedGenesisDataSize;
-    type MaxBootNodes = MaxBootNodes;
-    type MaxBootNodeUrlLen = MaxBootNodeUrlLen;
     type MaxLengthTokenSymbol = MaxLengthTokenSymbol;
     type SessionDelay = ConstU32<2>;
     type SessionIndex = u32;

--- a/runtime/flashbox/src/lib.rs
+++ b/runtime/flashbox/src/lib.rs
@@ -862,8 +862,6 @@ impl pallet_registrar::Config for Runtime {
     type RegistrarOrigin = EnsureRoot<AccountId>;
     type MaxLengthParaIds = MaxLengthParaIds;
     type MaxGenesisDataSize = MaxEncodedGenesisDataSize;
-    type MaxBootNodes = MaxBootNodes;
-    type MaxBootNodeUrlLen = MaxBootNodeUrlLen;
     type MaxLengthTokenSymbol = MaxLengthTokenSymbol;
     type SessionDelay = ConstU32<2>;
     type SessionIndex = u32;


### PR DESCRIPTION
Not needed since we moved bootnodes to the data preservers pallet