### PR TITLE
Use const syntax in thread local macro

### DIFF
--- a/container-chains/templates/frontier/node/src/service.rs
+++ b/container-chains/templates/frontier/node/src/service.rs
@@ -104,7 +104,7 @@ where
     )
 }
 
-thread_local!(static TIMESTAMP: std::cell::RefCell<u64> = std::cell::RefCell::new(0));
+thread_local!(static TIMESTAMP: std::cell::RefCell<u64> = const { std::cell::RefCell::new(0) });
 
 /// Provide a mock duration starting at 0 in millisecond for timestamp inherent.
 /// Each call will increment timestamp by slot_duration making Aura think time has passed.

--- a/container-chains/templates/simple/node/src/service.rs
+++ b/container-chains/templates/simple/node/src/service.rs
@@ -67,7 +67,7 @@ impl NodeBuilderConfig for NodeConfig {
     type ParachainExecutor = ParachainExecutor;
 }
 
-thread_local!(static TIMESTAMP: std::cell::RefCell<u64> = std::cell::RefCell::new(0));
+thread_local!(static TIMESTAMP: std::cell::RefCell<u64> = const { std::cell::RefCell::new(0) });
 
 /// Provide a mock duration starting at 0 in millisecond for timestamp inherent.
 /// Each call will increment timestamp by slot_duration making Aura think time has passed.

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -128,7 +128,7 @@ pub type ContainerChainBackend = ParachainBackend;
 type ContainerChainBlockImport =
     TParachainBlockImport<Block, Arc<ContainerChainClient>, ContainerChainBackend>;
 
-thread_local!(static TIMESTAMP: std::cell::RefCell<u64> = std::cell::RefCell::new(0));
+thread_local!(static TIMESTAMP: std::cell::RefCell<u64> = const { std::cell::RefCell::new(0) });
 
 /// Provide a mock duration starting at 0 in millisecond for timestamp inherent.
 /// Each call will increment timestamp by slot_duration making Aura think time has passed.

--- a/pallets/initializer/src/mock.rs
+++ b/pallets/initializer/src/mock.rs
@@ -66,7 +66,7 @@ impl system::Config for Test {
 }
 
 thread_local! {
-    pub static SESSION_CHANGE_VALIDATORS: RefCell<Option<(u32, Vec<u64>)>> = RefCell::new(None);
+    pub static SESSION_CHANGE_VALIDATORS: RefCell<Option<(u32, Vec<u64>)>> = const { RefCell::new(None) };
 }
 
 pub fn session_change_validators() -> Option<(u32, Vec<u64>)> {


### PR DESCRIPTION
This makes it faster to initialize a thread local variable, and if the inner type does not need to be dropped it also makes it faster to use. Shouldn't make any perf impact because this is only used in tests, but I didn't know about this feature so let's use it.

You can use this code to check if a type needs to be dropped, basically anything that uses the heap needs to be dropped:

```rust
use std::cell::RefCell;
fn main() {
    dbg!(std::mem::needs_drop::<RefCell<u8>>()); // false
    dbg!(std::mem::needs_drop::<RefCell<Option<(u32, Vec<u64>)>>>()); // true
}
```