### PR TITLE
Add compile time tests for pallet_balances consts

### DIFF
--- a/container-chains/templates/frontier/runtime/src/lib.rs
+++ b/container-chains/templates/frontier/runtime/src/lib.rs
@@ -483,10 +483,14 @@ impl pallet_transaction_payment::Config for Runtime {
 
 parameter_types! {
     pub const ExistentialDeposit: Balance = EXISTENTIAL_DEPOSIT;
+    pub const MaxFreezes: u32 = 0;
+    pub const MaxHolds: u32 = 0;
+    pub const MaxLocks: u32 = 50;
+    pub const MaxReserves: u32 = 50;
 }
 
 impl pallet_balances::Config for Runtime {
-    type MaxLocks = ConstU32<50>;
+    type MaxLocks = MaxLocks;
     /// The type for recording an account's balance.
     type Balance = Balance;
     /// The ubiquitous event type.
@@ -494,15 +498,35 @@ impl pallet_balances::Config for Runtime {
     type DustRemoval = ();
     type ExistentialDeposit = ExistentialDeposit;
     type AccountStore = System;
-    type MaxReserves = ConstU32<50>;
+    type MaxReserves = MaxReserves;
     type ReserveIdentifier = [u8; 8];
-    type FreezeIdentifier = [u8; 8];
-    type MaxFreezes = ConstU32<0>;
+    type FreezeIdentifier = RuntimeFreezeReason;
+    type MaxFreezes = MaxFreezes;
     type RuntimeHoldReason = RuntimeHoldReason;
     type RuntimeFreezeReason = RuntimeFreezeReason;
-    type MaxHolds = ConstU32<0>;
+    type MaxHolds = MaxHolds;
     type WeightInfo = pallet_balances::weights::SubstrateWeight<Runtime>;
 }
+
+const _TEST_PALLET_BALANCES_INTEGRITY: () = {
+    const fn pallet_balances_has_valid_limits()
+    {
+        use frame_support::traits::VariantCount;
+        let variant_count_freeze = <<Runtime as pallet_balances::Config>::RuntimeFreezeReason as VariantCount>::VARIANT_COUNT;
+        let variant_count_hold = <<Runtime as pallet_balances::Config>::RuntimeHoldReason as VariantCount>::VARIANT_COUNT;
+        let max_freezes = MaxFreezes::get();
+        let max_holds = MaxHolds::get();
+        assert!(
+            variant_count_freeze <= max_freezes
+        );
+        assert!(
+            variant_count_hold <= max_holds
+        );
+        assert!(EXISTENTIAL_DEPOSIT == 0);
+    }
+
+    pallet_balances_has_valid_limits()
+};
 
 parameter_types! {
     pub const ReservedXcmpWeight: Weight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4);

--- a/container-chains/templates/simple/runtime/src/lib.rs
+++ b/container-chains/templates/simple/runtime/src/lib.rs
@@ -358,10 +358,14 @@ impl frame_system::Config for Runtime {
 
 parameter_types! {
     pub const ExistentialDeposit: Balance = EXISTENTIAL_DEPOSIT;
+    pub const MaxFreezes: u32 = 0;
+    pub const MaxHolds: u32 = 0;
+    pub const MaxLocks: u32 = 50;
+    pub const MaxReserves: u32 = 50;
 }
 
 impl pallet_balances::Config for Runtime {
-    type MaxLocks = ConstU32<50>;
+    type MaxLocks = MaxLocks;
     /// The type for recording an account's balance.
     type Balance = Balance;
     /// The ubiquitous event type.
@@ -369,15 +373,35 @@ impl pallet_balances::Config for Runtime {
     type DustRemoval = ();
     type ExistentialDeposit = ExistentialDeposit;
     type AccountStore = System;
-    type MaxReserves = ConstU32<50>;
+    type MaxReserves = MaxReserves;
     type ReserveIdentifier = [u8; 8];
-    type FreezeIdentifier = [u8; 8];
-    type MaxFreezes = ConstU32<0>;
+    type FreezeIdentifier = RuntimeFreezeReason;
+    type MaxFreezes = MaxFreezes;
     type RuntimeHoldReason = RuntimeHoldReason;
     type RuntimeFreezeReason = RuntimeFreezeReason;
-    type MaxHolds = ConstU32<0>;
+    type MaxHolds = MaxHolds;
     type WeightInfo = pallet_balances::weights::SubstrateWeight<Runtime>;
 }
+
+const _TEST_PALLET_BALANCES_INTEGRITY: () = {
+    const fn pallet_balances_has_valid_limits()
+    {
+        use frame_support::traits::VariantCount;
+        let variant_count_freeze = <<Runtime as pallet_balances::Config>::RuntimeFreezeReason as VariantCount>::VARIANT_COUNT;
+        let variant_count_hold = <<Runtime as pallet_balances::Config>::RuntimeHoldReason as VariantCount>::VARIANT_COUNT;
+        let max_freezes = MaxFreezes::get();
+        let max_holds = MaxHolds::get();
+        assert!(
+            variant_count_freeze <= max_freezes
+        );
+        assert!(
+            variant_count_hold <= max_holds
+        );
+        assert!(EXISTENTIAL_DEPOSIT != 0);
+    }
+
+    pallet_balances_has_valid_limits()
+};
 
 parameter_types! {
     pub const TransactionByteFee: Balance = 1;

--- a/pallets/stream-payment/src/lib.rs
+++ b/pallets/stream-payment/src/lib.rs
@@ -361,12 +361,6 @@ pub mod pallet {
         },
     }
 
-    /// Freeze reason to use if needed.
-    #[pallet::composite_enum]
-    pub enum FreezeReason {
-        StreamPayment,
-    }
-
     /// Hold reason to use if needed.
     #[pallet::composite_enum]
     pub enum HoldReason {

--- a/pallets/stream-payment/src/mock.rs
+++ b/pallets/stream-payment/src/mock.rs
@@ -100,10 +100,10 @@ impl pallet_balances::Config for Runtime {
     type DustRemoval = ();
     type ExistentialDeposit = ExistentialDeposit;
     type AccountStore = System;
-    type FreezeIdentifier = RuntimeFreezeReason;
-    type MaxFreezes = ConstU32<1>;
+    type FreezeIdentifier = ();
+    type MaxFreezes = ();
     type RuntimeHoldReason = RuntimeHoldReason;
-    type RuntimeFreezeReason = RuntimeFreezeReason;
+    type RuntimeFreezeReason = ();
     type MaxHolds = ConstU32<5>;
     type WeightInfo = ();
 }

--- a/runtime/dancebox/src/lib.rs
+++ b/runtime/dancebox/src/lib.rs
@@ -398,10 +398,14 @@ impl pallet_author_inherent::Config for Runtime {
 
 parameter_types! {
     pub const ExistentialDeposit: Balance = EXISTENTIAL_DEPOSIT;
+    pub const MaxFreezes: u32 = 10;
+    pub const MaxHolds: u32 = 10;
+    pub const MaxLocks: u32 = 50;
+    pub const MaxReserves: u32 = 10;
 }
 
 impl pallet_balances::Config for Runtime {
-    type MaxLocks = ConstU32<50>;
+    type MaxLocks = MaxLocks;
     /// The type for recording an account's balance.
     type Balance = Balance;
     /// The ubiquitous event type.
@@ -409,15 +413,35 @@ impl pallet_balances::Config for Runtime {
     type DustRemoval = ();
     type ExistentialDeposit = ExistentialDeposit;
     type AccountStore = System;
-    type MaxReserves = ConstU32<50>;
+    type MaxReserves = MaxReserves;
     type ReserveIdentifier = [u8; 8];
     type FreezeIdentifier = RuntimeFreezeReason;
-    type MaxFreezes = ConstU32<10>;
+    type MaxFreezes = MaxFreezes;
     type RuntimeHoldReason = RuntimeHoldReason;
     type RuntimeFreezeReason = RuntimeFreezeReason;
-    type MaxHolds = ConstU32<10>;
+    type MaxHolds = MaxHolds;
     type WeightInfo = pallet_balances::weights::SubstrateWeight<Runtime>;
 }
+
+const _TEST_PALLET_BALANCES_INTEGRITY: () = {
+    const fn pallet_balances_has_valid_limits()
+    {
+        use frame_support::traits::VariantCount;
+        let variant_count_freeze = <<Runtime as pallet_balances::Config>::RuntimeFreezeReason as VariantCount>::VARIANT_COUNT;
+        let variant_count_hold = <<Runtime as pallet_balances::Config>::RuntimeHoldReason as VariantCount>::VARIANT_COUNT;
+        let max_freezes = MaxFreezes::get();
+        let max_holds = MaxHolds::get();
+        assert!(
+            variant_count_freeze <= max_freezes
+        );
+        assert!(
+            variant_count_hold <= max_holds
+        );
+        assert!(EXISTENTIAL_DEPOSIT != 0);
+    }
+
+    pallet_balances_has_valid_limits()
+};
 
 pub struct DealWithFees<R>(sp_std::marker::PhantomData<R>);
 impl<R> OnUnbalanced<NegativeImbalance<R>> for DealWithFees<R>


### PR DESCRIPTION
Add compile time checks for some constants used in pallet_balances.

For example, this will make it impossible to add a new pallet that declares a freeze reason when `MaxFreezes` is set to 0, because then the runtime will not compile.

Also fixes that some runtimes had an invalid value for `FreezeIdentifier`. Shouldn't matter because we don't use freezes in those runtimes yet:

```diff
-type FreezeIdentifier = [u8; 8];
+type FreezeIdentifier = RuntimeFreezeReason;
```

TODO: move this tests to a separate module, and perhaps use a macro to call them.