### PR TITLE
Use `CollatorId` instead of `AccountId` - Part 1 of N

### DIFF
--- a/pallets/invulnerables/src/benchmarking.rs
+++ b/pallets/invulnerables/src/benchmarking.rs
@@ -79,13 +79,9 @@ fn invulnerable<T: Config + session::Config + pallet_balances::Config>(
     c: u32,
 ) -> (T::AccountId, T::CollatorId, <T as session::Config>::Keys) {
     let funded_user = create_funded_user::<T>("candidate", c, 100);
-    let collator_id = T::CollatorIdOf::convert(funded_user)
+    let collator_id = T::CollatorIdOf::convert(funded_user.clone())
         .expect("Converstion of account id of collator id failed.");
-    (
-        create_funded_user::<T>("candidate", c, 100),
-        collator_id,
-        keys::<T>(c),
-    )
+    (funded_user, collator_id, keys::<T>(c))
 }
 
 fn invulnerables<

--- a/runtime/dancebox/src/lib.rs
+++ b/runtime/dancebox/src/lib.rs
@@ -107,6 +107,9 @@ pub type SignedBlock = generic::SignedBlock<Block>;
 /// BlockId type as expected by this runtime.
 pub type BlockId = generic::BlockId<Block>;
 
+/// CollatorId type expected by this runtime.
+pub type CollatorId = AccountId;
+
 /// The SignedExtension to the basic transaction logic.
 pub type SignedExtra = (
     frame_system::CheckNonZeroSender<Runtime>,
@@ -621,8 +624,8 @@ impl parachain_info::Config for Runtime {}
 pub struct CollatorsFromInvulnerablesAndThenFromStaking;
 
 /// Play the role of the session manager.
-impl SessionManager<AccountId> for CollatorsFromInvulnerablesAndThenFromStaking {
-    fn new_session(index: SessionIndex) -> Option<Vec<AccountId>> {
+impl SessionManager<CollatorId> for CollatorsFromInvulnerablesAndThenFromStaking {
+    fn new_session(index: SessionIndex) -> Option<Vec<CollatorId>> {
         log::info!(
             "assembling new collators for new session {} at #{:?}",
             index,
@@ -673,7 +676,7 @@ parameter_types! {
 
 impl pallet_session::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
-    type ValidatorId = <Self as frame_system::Config>::AccountId;
+    type ValidatorId = CollatorId;
     // we don't have stash and controller, thus we don't need the convert as well.
     type ValidatorIdOf = pallet_invulnerables::IdentityCollator;
     type ShouldEndSession = pallet_session::PeriodicSessions<Period, Offset>;
@@ -729,11 +732,11 @@ impl GetRandomnessForNextBlock<u32> for BabeGetRandomnessForNextBlock {
 
 pub struct RemoveInvulnerablesImpl;
 
-impl RemoveInvulnerables<AccountId> for RemoveInvulnerablesImpl {
+impl RemoveInvulnerables<CollatorId> for RemoveInvulnerablesImpl {
     fn remove_invulnerables(
-        collators: &mut Vec<AccountId>,
+        collators: &mut Vec<CollatorId>,
         num_invulnerables: usize,
-    ) -> Vec<AccountId> {
+    ) -> Vec<CollatorId> {
         if num_invulnerables == 0 {
             return vec![];
         }

--- a/runtime/flashbox/src/lib.rs
+++ b/runtime/flashbox/src/lib.rs
@@ -100,6 +100,9 @@ pub type SignedBlock = generic::SignedBlock<Block>;
 /// BlockId type as expected by this runtime.
 pub type BlockId = generic::BlockId<Block>;
 
+/// CollatorId type expected by this runtime.
+pub type CollatorId = AccountId;
+
 /// The SignedExtension to the basic transaction logic.
 pub type SignedExtra = (
     frame_system::CheckNonZeroSender<Runtime>,
@@ -536,8 +539,8 @@ impl parachain_info::Config for Runtime {}
 pub struct CollatorsFromInvulnerables;
 
 /// Play the role of the session manager.
-impl SessionManager<AccountId> for CollatorsFromInvulnerables {
-    fn new_session(index: SessionIndex) -> Option<Vec<AccountId>> {
+impl SessionManager<CollatorId> for CollatorsFromInvulnerables {
+    fn new_session(index: SessionIndex) -> Option<Vec<CollatorId>> {
         log::info!(
             "assembling new collators for new session {} at #{:?}",
             index,
@@ -583,11 +586,11 @@ impl pallet_session::Config for Runtime {
 
 pub struct RemoveInvulnerablesImpl;
 
-impl RemoveInvulnerables<AccountId> for RemoveInvulnerablesImpl {
+impl RemoveInvulnerables<CollatorId> for RemoveInvulnerablesImpl {
     fn remove_invulnerables(
-        collators: &mut Vec<AccountId>,
+        collators: &mut Vec<CollatorId>,
         num_invulnerables: usize,
-    ) -> Vec<AccountId> {
+    ) -> Vec<CollatorId> {
         if num_invulnerables == 0 {
             return vec![];
         }
@@ -775,7 +778,7 @@ impl pallet_invulnerables::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type UpdateOrigin = EnsureRoot<AccountId>;
     type MaxInvulnerables = MaxInvulnerables;
-    type CollatorId = <Self as frame_system::Config>::AccountId;
+    type CollatorId = CollatorId;
     type CollatorIdOf = pallet_invulnerables::IdentityCollator;
     type CollatorRegistration = Session;
     type WeightInfo = pallet_invulnerables::weights::SubstrateWeight<Runtime>;

--- a/typescript-api/src/dancebox/interfaces/augment-api-errors.ts
+++ b/typescript-api/src/dancebox/interfaces/augment-api-errors.ts
@@ -201,6 +201,8 @@ declare module "@polkadot/api-base/types/errors" {
             NotInvulnerable: AugmentedError<ApiType>;
             /** There are too many Invulnerables. */
             TooManyInvulnerables: AugmentedError<ApiType>;
+            /** Unable to derive collator id from account id */
+            UnableToDeriveCollatorId: AugmentedError<ApiType>;
             /** Generic error */
             [key: string]: AugmentedError<ApiType>;
         };

--- a/typescript-api/src/dancebox/interfaces/lookup.ts
+++ b/typescript-api/src/dancebox/interfaces/lookup.ts
@@ -3632,7 +3632,13 @@ export default {
     },
     /** Lookup424: pallet_invulnerables::pallet::Error<T> */
     PalletInvulnerablesError: {
-        _enum: ["TooManyInvulnerables", "AlreadyInvulnerable", "NotInvulnerable", "NoKeysRegistered"],
+        _enum: [
+            "TooManyInvulnerables",
+            "AlreadyInvulnerable",
+            "NotInvulnerable",
+            "NoKeysRegistered",
+            "UnableToDeriveCollatorId",
+        ],
     },
     /** Lookup429: sp_core::crypto::KeyTypeId */
     SpCoreCryptoKeyTypeId: "[u8;4]",

--- a/typescript-api/src/dancebox/interfaces/types-lookup.ts
+++ b/typescript-api/src/dancebox/interfaces/types-lookup.ts
@@ -4884,7 +4884,13 @@ declare module "@polkadot/types/lookup" {
         readonly isAlreadyInvulnerable: boolean;
         readonly isNotInvulnerable: boolean;
         readonly isNoKeysRegistered: boolean;
-        readonly type: "TooManyInvulnerables" | "AlreadyInvulnerable" | "NotInvulnerable" | "NoKeysRegistered";
+        readonly isUnableToDeriveCollatorId: boolean;
+        readonly type:
+            | "TooManyInvulnerables"
+            | "AlreadyInvulnerable"
+            | "NotInvulnerable"
+            | "NoKeysRegistered"
+            | "UnableToDeriveCollatorId";
     }
 
     /** @name SpCoreCryptoKeyTypeId (429) */

--- a/typescript-api/src/flashbox/interfaces/augment-api-errors.ts
+++ b/typescript-api/src/flashbox/interfaces/augment-api-errors.ts
@@ -134,6 +134,8 @@ declare module "@polkadot/api-base/types/errors" {
             NotInvulnerable: AugmentedError<ApiType>;
             /** There are too many Invulnerables. */
             TooManyInvulnerables: AugmentedError<ApiType>;
+            /** Unable to derive collator id from account id */
+            UnableToDeriveCollatorId: AugmentedError<ApiType>;
             /** Generic error */
             [key: string]: AugmentedError<ApiType>;
         };

--- a/typescript-api/src/flashbox/interfaces/lookup.ts
+++ b/typescript-api/src/flashbox/interfaces/lookup.ts
@@ -1966,7 +1966,13 @@ export default {
     },
     /** Lookup322: pallet_invulnerables::pallet::Error<T> */
     PalletInvulnerablesError: {
-        _enum: ["TooManyInvulnerables", "AlreadyInvulnerable", "NotInvulnerable", "NoKeysRegistered"],
+        _enum: [
+            "TooManyInvulnerables",
+            "AlreadyInvulnerable",
+            "NotInvulnerable",
+            "NoKeysRegistered",
+            "UnableToDeriveCollatorId",
+        ],
     },
     /** Lookup327: sp_core::crypto::KeyTypeId */
     SpCoreCryptoKeyTypeId: "[u8;4]",

--- a/typescript-api/src/flashbox/interfaces/types-lookup.ts
+++ b/typescript-api/src/flashbox/interfaces/types-lookup.ts
@@ -2603,7 +2603,13 @@ declare module "@polkadot/types/lookup" {
         readonly isAlreadyInvulnerable: boolean;
         readonly isNotInvulnerable: boolean;
         readonly isNoKeysRegistered: boolean;
-        readonly type: "TooManyInvulnerables" | "AlreadyInvulnerable" | "NotInvulnerable" | "NoKeysRegistered";
+        readonly isUnableToDeriveCollatorId: boolean;
+        readonly type:
+            | "TooManyInvulnerables"
+            | "AlreadyInvulnerable"
+            | "NotInvulnerable"
+            | "NoKeysRegistered"
+            | "UnableToDeriveCollatorId";
     }
 
     /** @name SpCoreCryptoKeyTypeId (327) */


### PR DESCRIPTION
## Description
Currently, we are using `AccountId` and `CollatorId` interchangeably in the runtime. This works right now, since our `CollatorId` config type is set to  `AccountId` in runtime.

To be more idiomatic, we need to replace direct use of `AccountId` with `CollatorId` both in pallets and runtime. With `CollatorId` currently only type alias of `AccountId`. This make sure that both types are equivalent for now, but can be changed just by setting different type while building runtime.

### What's changed?
This PR modifies `pallet_invulnerables` to use `CollatorId` instead of `AccountId` with some minor refactor involved.

In the runtime, we define type alias, and replace `AccountId` with `CollatorId` at required places.


## Note
This PR does not completely modifies runtime and all pallets to use `CollatorId`, only `pallet_invulnerables` and defining the core distinction between `AccountId` and `CollatorId` in runtime.

The changes involved to do it completely will require quite a few PR both in this repository and dancekit.