### PR TITLE
Limit block production to one block per slot in basic collator

### DIFF
--- a/client/consensus/src/collators.rs
+++ b/client/consensus/src/collators.rs
@@ -264,6 +264,7 @@ where
 pub struct SlotClaim<Pub> {
     author_pub: Pub,
     pre_digest: Vec<DigestItem>,
+    slot: Slot,
 }
 
 impl<Pub: Clone> SlotClaim<Pub> {
@@ -276,6 +277,7 @@ impl<Pub: Clone> SlotClaim<Pub> {
         SlotClaim {
             author_pub: author_pub.clone(),
             pre_digest: pre_digest_data::<P>(slot, author_pub),
+            slot,
         }
     }
 
@@ -287,6 +289,11 @@ impl<Pub: Clone> SlotClaim<Pub> {
     /// Get the pre-digest.
     pub fn pre_digest(&self) -> &Vec<DigestItem> {
         &self.pre_digest
+    }
+
+    /// Get the slot assigned to this claim.
+    pub fn slot(&self) -> Slot {
+        self.slot
     }
 }
 

--- a/client/consensus/src/collators/basic.rs
+++ b/client/consensus/src/collators/basic.rs
@@ -130,6 +130,8 @@ pub async fn run<Block, P, BI, CIDP, Client, RClient, SO, Proposer, CS, GOH>(
         collator_util::Collator::<Block, P, _, _, _, _, _>::new(params)
     };
 
+    let mut last_processed_slot = 0;
+
     while let Some(request) = collation_requests.next().await {
         macro_rules! reject_with_error {
 				($err:expr) => {{
@@ -211,6 +213,18 @@ pub async fn run<Block, P, BI, CIDP, Client, RClient, SO, Proposer, CS, GOH>(
             Ok(Some(h)) => h,
         };
 
+        // With async backing this function will be called every relay chain block.
+        //
+        // Most parachains currently run with 12 seconds slots and thus, they would try to
+        // produce multiple blocks per slot which very likely would fail on chain. Thus, we have
+        // this "hack" to only produce on block per slot.
+        //
+        // With https://github.com/paritytech/polkadot-sdk/issues/3168 this implementation will be
+        // obsolete and also the underlying issue will be fixed.
+        if last_processed_slot >= *claim.slot() {
+            continue;
+        }
+
         let (parachain_inherent_data, other_inherent_data) = try_request!(
             collator
                 .create_inherent_data(*request.relay_parent(), validation_data, parent_hash, None,)
@@ -244,5 +258,6 @@ pub async fn run<Block, P, BI, CIDP, Client, RClient, SO, Proposer, CS, GOH>(
             request.complete(None);
             tracing::debug!(target: crate::LOG_TARGET, "No block proposal");
         }
+        last_processed_slot = *claim.slot();
     }
 }


### PR DESCRIPTION
Fixes the following panic present in the logs:

```
2024-03-13 16:56:06.023  INFO tokio-runtime-worker sc_basic_authorship::basic_authorship: [Container-2002] :raised_hands: Starting consensus session on top of parent 0x35551d29498f418c033e7faa19b69df6b8df0f7cffbdce9ca4076a95efd6ad29    
2024-03-13 16:56:06.024 ERROR tokio-runtime-worker runtime: [Container-2002] panicked at /home/builder/cargo/git/checkouts/moonkit-c6defa46a244ac75/9d006f9/pallets/async-backing/src/consensus_hook.rs:73:21:
Block invalid; Supplied slot number is not high enough
```
As related to https://github.com/paritytech/polkadot-sdk/pull/3308, it seems that with the current configuration of the basic collator, every para-block is attempted to be imported twice in the same slot, which is not the expected case with this "basic" kind of collator.