### PR TITLE
Move some logs to debug level

### DIFF
--- a/pallets/collator-assignment/src/lib.rs
+++ b/pallets/collator-assignment/src/lib.rs
@@ -237,7 +237,7 @@ pub mod pallet {
             // we use the config scheduled at the target_session_index
             let new_assigned =
                 if T::ShouldRotateAllCollators::should_rotate_all_collators(target_session_index) {
-                    log::info!(
+                    log::debug!(
                         "Collator assignment: rotating collators. Session {:?}, Seed: {:?}",
                         current_session_index.encode(),
                         random_seed
@@ -255,7 +255,7 @@ pub mod pallet {
                         chains,
                     )
                 } else {
-                    log::info!(
+                    log::debug!(
                         "Collator assignment: keep old assigned. Session {:?}, Seed: {:?}",
                         current_session_index.encode(),
                         random_seed

--- a/runtime/dancebox/src/lib.rs
+++ b/runtime/dancebox/src/lib.rs
@@ -626,11 +626,20 @@ pub struct CollatorsFromInvulnerablesAndThenFromStaking;
 /// Play the role of the session manager.
 impl SessionManager<CollatorId> for CollatorsFromInvulnerablesAndThenFromStaking {
     fn new_session(index: SessionIndex) -> Option<Vec<CollatorId>> {
-        log::info!(
-            "assembling new collators for new session {} at #{:?}",
-            index,
-            <frame_system::Pallet<Runtime>>::block_number(),
-        );
+        if <frame_system::Pallet<Runtime>>::block_number() == 0 {
+            // Do not show this log in genesis
+            log::debug!(
+                "assembling new collators for new session {} at #{:?}",
+                index,
+                <frame_system::Pallet<Runtime>>::block_number(),
+            );
+        } else {
+            log::info!(
+                "assembling new collators for new session {} at #{:?}",
+                index,
+                <frame_system::Pallet<Runtime>>::block_number(),
+            );
+        }
 
         let invulnerables = Invulnerables::invulnerables().to_vec();
         let candidates_staking =


### PR DESCRIPTION
We see some ugly logs when running the precompile-wasm script:

```
2024-03-14 13:43:07.955  INFO main dancebox_runtime: assembling new collators for new session 0 at #0    
2024-03-14 13:43:07.955  INFO main dancebox_runtime: assembling new collators for new session 1 at #0    
2024-03-14 13:43:07.955  INFO main pallet_collator_assignment::pallet: Collator assignment: keep old assigned. Session [0, 0, 0, 0], Seed: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]    
2024-03-14 13:43:08.494  INFO main sc_service::client::client: 🔨 Initializing Genesis block/state (state: 0x95bd…6339, header-hash: 0xedd5…ab9e)    
2024-03-14 13:43:08.509 TRACE main wasmtime-runtime: Computing wasm runtime hash [allow_missing_func_imports: false, code_hash: 0x5fb084f2de3a4346e75b87ea6138cc5d0bef444ea275df18e927739a91c0fc87, semantics: Semantics { instantiation_strategy: PoolingCopyOnWrite, deterministic_stack_limit: None, canonicalize_nans: false, parallel_compilation: true, heap_alloc_strategy: Static { extra_pages: 2048 }, wasm_multi_value: false, wasm_bulk_memory: false, wasm_reference_types: false, wasm_simd: false }]    
2024-03-14 13:43:08.509 DEBUG main wasmtime-runtime: Generated precompiled wasm hash: 0x74214c2c20e15283c528103375c747d0069cca631178a00b0930b3a7d8b69409    
2024-03-14 13:43:08.511 ERROR tokio-runtime-worker sc_service::task_manager: Essential task `txpool-background` failed. Shutting down service.    
2024-03-14 13:43:08.511 ERROR tokio-runtime-worker sc_service::task_manager: Essential task `transaction-pool-task-0` failed. Shutting down service.    
2024-03-14 13:43:08.511 ERROR tokio-runtime-worker sc_service::task_manager: Essential task `transaction-pool-task-1` failed. Shutting down service.    
```

This PR moves the first 3 to debug level. The log about "assembling new collators for new session" will only be shown if the block is not 0, so any tools that need to create a genesis block will have fewer logs.