### PR TITLE
Push whole version as docker image tag to dockerhub

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -53,6 +53,8 @@ jobs:
             -f docker/${{matrix.image.name}}.Dockerfile \
             -t "${DOCKER_IMAGE}:${VERSION}" \
             . 
+          echo tagging "${DOCKER_IMAGE}:${VERSION}"
+          docker push "${DOCKER_IMAGE}:${VERSION}"
 
             if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
               MINOR=${VERSION%.*}


### PR DESCRIPTION
## Description
While we create a tag with entire version i.e `vX.Y.Z` we are not pushing it to docker hub. This results in a scenario where while `vX` and `vX.Y` is updated on dockerhub, `vX.Y.Z` is not.

To fix this, we are pushing the `vX.Y.Z` image tag to DockerHub.