### PR TITLE
Use `SlowAdjustingFeeUpdate` instead of `ConstFeeMultiplier`

### DIFF
--- a/container-chains/templates/frontier/runtime/src/lib.rs
+++ b/container-chains/templates/frontier/runtime/src/lib.rs
@@ -70,8 +70,9 @@ use {
         FeeCalculator, GasWeightMapping, IdentityAddressMapping,
         OnChargeEVMTransaction as OnChargeEVMTransactionT, Runner,
     },
-    pallet_transaction_payment::{ConstFeeMultiplier, CurrencyAdapter, Multiplier},
+    pallet_transaction_payment::CurrencyAdapter,
     parity_scale_codec::{Decode, Encode},
+    polkadot_runtime_common::SlowAdjustingFeeUpdate,
     scale_info::TypeInfo,
     smallvec::smallvec,
     sp_api::impl_runtime_apis,
@@ -468,7 +469,6 @@ impl frame_system::Config for Runtime {
 
 parameter_types! {
     pub const TransactionByteFee: Balance = 1;
-    pub const FeeMultiplier: Multiplier = Multiplier::from_u32(1);
 }
 
 impl pallet_transaction_payment::Config for Runtime {
@@ -478,7 +478,7 @@ impl pallet_transaction_payment::Config for Runtime {
     type OperationalFeeMultiplier = ConstU8<5>;
     type WeightToFee = WeightToFee;
     type LengthToFee = ConstantMultiplier<Balance, TransactionByteFee>;
-    type FeeMultiplierUpdate = ConstFeeMultiplier<FeeMultiplier>;
+    type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Self>;
 }
 
 parameter_types! {

--- a/container-chains/templates/simple/runtime/src/lib.rs
+++ b/container-chains/templates/simple/runtime/src/lib.rs
@@ -58,8 +58,9 @@ use {
         EnsureRoot,
     },
     nimbus_primitives::{NimbusId, SlotBeacon},
-    pallet_transaction_payment::{ConstFeeMultiplier, CurrencyAdapter, Multiplier},
+    pallet_transaction_payment::CurrencyAdapter,
     parity_scale_codec::{Decode, Encode},
+    polkadot_runtime_common::SlowAdjustingFeeUpdate,
     scale_info::TypeInfo,
     smallvec::smallvec,
     sp_api::impl_runtime_apis,
@@ -381,7 +382,6 @@ impl pallet_balances::Config for Runtime {
 
 parameter_types! {
     pub const TransactionByteFee: Balance = 1;
-    pub const FeeMultiplier: Multiplier = Multiplier::from_u32(1);
 }
 
 impl pallet_transaction_payment::Config for Runtime {
@@ -391,7 +391,7 @@ impl pallet_transaction_payment::Config for Runtime {
     type OperationalFeeMultiplier = ConstU8<5>;
     type WeightToFee = WeightToFee;
     type LengthToFee = ConstantMultiplier<Balance, TransactionByteFee>;
-    type FeeMultiplierUpdate = ConstFeeMultiplier<FeeMultiplier>;
+    type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Self>;
 }
 
 parameter_types! {

--- a/runtime/dancebox/src/lib.rs
+++ b/runtime/dancebox/src/lib.rs
@@ -24,6 +24,7 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 pub mod xcm_config;
 
+use polkadot_runtime_common::SlowAdjustingFeeUpdate;
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 
@@ -73,7 +74,7 @@ use {
     pallet_registrar_runtime_api::ContainerChainGenesisData,
     pallet_services_payment::{ProvideBlockProductionCost, ProvideCollatorAssignmentCost},
     pallet_session::{SessionManager, ShouldEndSession},
-    pallet_transaction_payment::{ConstFeeMultiplier, CurrencyAdapter, Multiplier},
+    pallet_transaction_payment::CurrencyAdapter,
     polkadot_runtime_common::BlockHashCount,
     scale_info::TypeInfo,
     smallvec::smallvec,
@@ -465,7 +466,6 @@ where
 
 parameter_types! {
     pub const TransactionByteFee: Balance = 1;
-    pub const FeeMultiplier: Multiplier = Multiplier::from_u32(1);
 }
 
 impl pallet_transaction_payment::Config for Runtime {
@@ -475,7 +475,7 @@ impl pallet_transaction_payment::Config for Runtime {
     type OperationalFeeMultiplier = ConstU8<5>;
     type WeightToFee = WeightToFee;
     type LengthToFee = ConstantMultiplier<Balance, TransactionByteFee>;
-    type FeeMultiplierUpdate = ConstFeeMultiplier<FeeMultiplier>;
+    type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Self>;
 }
 
 parameter_types! {

--- a/runtime/dancebox/tests/common/mod.rs
+++ b/runtime/dancebox/tests/common/mod.rs
@@ -103,7 +103,7 @@ pub fn insert_authorities_and_slot_digests(slot: u64) {
     );
 }
 
-pub fn run_block_with_operation(operation_fn: fn(slot: u64)) -> RunSummary {
+pub fn run_block_with_operation<F: FnOnce(u64)>(operation_fn: F) -> RunSummary {
     let slot = current_slot() + 1;
 
     insert_authorities_and_slot_digests(slot);

--- a/runtime/dancebox/tests/common/mod.rs
+++ b/runtime/dancebox/tests/common/mod.rs
@@ -42,6 +42,7 @@ use {
 
 mod xcm;
 
+use dancebox_runtime::TransactionPayment;
 pub use dancebox_runtime::{
     AccountId, AssetRate, AuthorNoting, AuthorityAssignment, AuthorityMapping, Balance, Balances,
     CollatorAssignment, Configuration, DataPreservers, ForeignAssets, ForeignAssetsCreator,
@@ -102,7 +103,7 @@ pub fn insert_authorities_and_slot_digests(slot: u64) {
     );
 }
 
-pub fn run_block() -> RunSummary {
+pub fn run_block_with_operation(operation_fn: fn(slot: u64)) -> RunSummary {
     let slot = current_slot() + 1;
 
     insert_authorities_and_slot_digests(slot);
@@ -129,16 +130,24 @@ pub fn run_block() -> RunSummary {
     pallet_author_inherent::Pallet::<Runtime>::kick_off_authorship_validation(None.into())
         .expect("author inherent to dispatch correctly");
 
+    // Do any operation needed
+    operation_fn(slot);
+
     // Finalize the block
     CollatorAssignment::on_finalize(System::block_number());
     Session::on_finalize(System::block_number());
     Initializer::on_finalize(System::block_number());
     AuthorInherent::on_finalize(System::block_number());
+    TransactionPayment::on_finalize(System::block_number());
 
     RunSummary {
         author_id,
         inflation: new_issuance - current_issuance,
     }
+}
+
+pub fn run_block() -> RunSummary {
+    run_block_with_operation(|_slot| {})
 }
 
 /// Mock the inherent that sets validation data in ParachainSystem, which

--- a/runtime/dancebox/tests/integration_test.rs
+++ b/runtime/dancebox/tests/integration_test.rs
@@ -5627,7 +5627,7 @@ fn test_slow_adjusting_multiplier_changes_in_response_to_consumed_weight() {
                 );
             });
             let current_multiplier = TransactionPayment::next_fee_multiplier();
-            assert!(current_multiplier.gt(&before_multiplier));
+            assert!(current_multiplier > before_multiplier);
 
             // If the block is empty, the multiplier decreases
             let before_multiplier = TransactionPayment::next_fee_multiplier();
@@ -5638,6 +5638,6 @@ fn test_slow_adjusting_multiplier_changes_in_response_to_consumed_weight() {
                 );
             });
             let current_multiplier = TransactionPayment::next_fee_multiplier();
-            assert!(current_multiplier.lt(&before_multiplier));
+            assert!(current_multiplier < before_multiplier);
         });
 }

--- a/runtime/dancebox/tests/integration_test.rs
+++ b/runtime/dancebox/tests/integration_test.rs
@@ -16,6 +16,8 @@
 
 #![cfg(test)]
 
+use dancebox_runtime::TransactionPayment;
+use frame_system::ConsumedWeight;
 use {
     common::*,
     cumulus_primitives_core::ParaId,
@@ -5595,5 +5597,47 @@ fn test_max_collators_uses_pending_value() {
             let assignment = CollatorAssignment::collator_container_chain();
             assert_eq!(assignment.container_chains[&1001u32.into()].len(), 0);
             assert_eq!(assignment.orchestrator_chain.len(), 1);
+        });
+}
+
+#[test]
+fn test_slow_adjusting_multiplier_changes_in_response_to_consumed_weight() {
+    ExtBuilder::default()
+        .with_collators(vec![
+            (AccountId::from(ALICE), 210 * UNIT),
+            (AccountId::from(BOB), 100 * UNIT),
+            (AccountId::from(CHARLIE), 100 * UNIT),
+            (AccountId::from(DAVE), 100 * UNIT),
+        ])
+        .with_config(default_config())
+        .build()
+        .execute_with(|| {
+            // If the block is full, the multiplier increases
+            let before_multiplier = TransactionPayment::next_fee_multiplier();
+            run_block_with_operation(|_slot| {
+                let max_block_weights = dancebox_runtime::RuntimeBlockWeights::get();
+                frame_support::storage::unhashed::put(
+                    &frame_support::storage::storage_prefix(b"System", b"BlockWeight"),
+                    &ConsumedWeight::new(|class| {
+                        max_block_weights
+                            .get(class)
+                            .max_total
+                            .unwrap_or(Weight::MAX)
+                    }),
+                );
+            });
+            let current_multiplier = TransactionPayment::next_fee_multiplier();
+            assert!(current_multiplier.gt(&before_multiplier));
+
+            // If the block is empty, the multiplier decreases
+            let before_multiplier = TransactionPayment::next_fee_multiplier();
+            run_block_with_operation(|_slot| {
+                frame_support::storage::unhashed::put(
+                    &frame_support::storage::storage_prefix(b"System", b"BlockWeight"),
+                    &ConsumedWeight::new(|_class| Weight::zero()),
+                );
+            });
+            let current_multiplier = TransactionPayment::next_fee_multiplier();
+            assert!(current_multiplier.lt(&before_multiplier));
         });
 }

--- a/runtime/flashbox/src/lib.rs
+++ b/runtime/flashbox/src/lib.rs
@@ -23,6 +23,7 @@
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 use pallet_services_payment::ProvideCollatorAssignmentCost;
+use polkadot_runtime_common::SlowAdjustingFeeUpdate;
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 
@@ -65,7 +66,7 @@ use {
     pallet_registrar_runtime_api::ContainerChainGenesisData,
     pallet_services_payment::ProvideBlockProductionCost,
     pallet_session::{SessionManager, ShouldEndSession},
-    pallet_transaction_payment::{ConstFeeMultiplier, CurrencyAdapter, Multiplier},
+    pallet_transaction_payment::CurrencyAdapter,
     polkadot_runtime_common::BlockHashCount,
     scale_info::TypeInfo,
     smallvec::smallvec,
@@ -443,7 +444,6 @@ where
 
 parameter_types! {
     pub const TransactionByteFee: Balance = 1;
-    pub const FeeMultiplier: Multiplier = Multiplier::from_u32(1);
 }
 
 impl pallet_transaction_payment::Config for Runtime {
@@ -453,7 +453,7 @@ impl pallet_transaction_payment::Config for Runtime {
     type OperationalFeeMultiplier = ConstU8<5>;
     type WeightToFee = WeightToFee;
     type LengthToFee = ConstantMultiplier<Balance, TransactionByteFee>;
-    type FeeMultiplierUpdate = ConstFeeMultiplier<FeeMultiplier>;
+    type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Self>;
 }
 
 pub const RELAY_CHAIN_SLOT_DURATION_MILLIS: u32 = 6000;

--- a/runtime/flashbox/tests/common/mod.rs
+++ b/runtime/flashbox/tests/common/mod.rs
@@ -40,6 +40,7 @@ use {
     test_relay_sproof_builder::ParaHeaderSproofBuilder,
 };
 
+use flashbox_runtime::TransactionPayment;
 pub use flashbox_runtime::{
     AccountId, AuthorNoting, AuthorityAssignment, AuthorityMapping, Balance, Balances,
     CollatorAssignment, Configuration, DataPreservers, InflationRewards, Initializer,
@@ -78,9 +79,7 @@ pub fn run_to_block(n: u32) -> BTreeMap<u32, RunSummary> {
     summaries
 }
 
-pub fn run_block() -> RunSummary {
-    let slot = current_slot() + 1;
-
+pub fn insert_authorities_and_slot_digests(slot: u64) {
     let authorities =
         Runtime::para_id_authorities(ParachainInfo::get()).expect("authorities should be set");
 
@@ -99,6 +98,12 @@ pub fn run_block() -> RunSummary {
         &System::parent_hash(),
         &pre_digest,
     );
+}
+
+pub fn run_block_with_operation(operation_fn: fn(slot: u64)) -> RunSummary {
+    let slot = current_slot() + 1;
+
+    insert_authorities_and_slot_digests(slot);
 
     // Initialize the new block
     CollatorAssignment::on_initialize(System::block_number());
@@ -122,16 +127,24 @@ pub fn run_block() -> RunSummary {
     pallet_author_inherent::Pallet::<Runtime>::kick_off_authorship_validation(None.into())
         .expect("author inherent to dispatch correctly");
 
+    // Do any operation needed
+    operation_fn(slot);
+
     // Finalize the block
     CollatorAssignment::on_finalize(System::block_number());
     Session::on_finalize(System::block_number());
     Initializer::on_finalize(System::block_number());
     AuthorInherent::on_finalize(System::block_number());
+    TransactionPayment::on_finalize(System::block_number());
 
     RunSummary {
         author_id,
         inflation: new_issuance - current_issuance,
     }
+}
+
+pub fn run_block() -> RunSummary {
+    run_block_with_operation(|_slot| {})
 }
 
 /// Mock the inherent that sets validation data in ParachainSystem, which

--- a/runtime/flashbox/tests/common/mod.rs
+++ b/runtime/flashbox/tests/common/mod.rs
@@ -100,7 +100,7 @@ pub fn insert_authorities_and_slot_digests(slot: u64) {
     );
 }
 
-pub fn run_block_with_operation(operation_fn: fn(slot: u64)) -> RunSummary {
+pub fn run_block_with_operation<F: FnOnce(u64)>(operation_fn: F) -> RunSummary {
     let slot = current_slot() + 1;
 
     insert_authorities_and_slot_digests(slot);

--- a/runtime/flashbox/tests/integration_test.rs
+++ b/runtime/flashbox/tests/integration_test.rs
@@ -3523,6 +3523,7 @@ fn test_max_collators_uses_pending_value() {
         });
 }
 
+#[test]
 fn test_slow_adjusting_multiplier_changes_in_response_to_consumed_weight() {
     ExtBuilder::default()
         .with_collators(vec![

--- a/runtime/flashbox/tests/integration_test.rs
+++ b/runtime/flashbox/tests/integration_test.rs
@@ -3549,7 +3549,7 @@ fn test_slow_adjusting_multiplier_changes_in_response_to_consumed_weight() {
                 );
             });
             let current_multiplier = TransactionPayment::next_fee_multiplier();
-            assert!(current_multiplier.gt(&before_multiplier));
+            assert!(current_multiplier > before_multiplier);
 
             // If the block is empty, the multiplier decreases
             let before_multiplier = TransactionPayment::next_fee_multiplier();
@@ -3560,6 +3560,6 @@ fn test_slow_adjusting_multiplier_changes_in_response_to_consumed_weight() {
                 );
             });
             let current_multiplier = TransactionPayment::next_fee_multiplier();
-            assert!(current_multiplier.lt(&before_multiplier));
+            assert!(current_multiplier < before_multiplier);
         });
 }

--- a/test/suites/common-all/fee_balance_transfer/test_fee_balance_transfer.ts
+++ b/test/suites/common-all/fee_balance_transfer/test_fee_balance_transfer.ts
@@ -3,17 +3,16 @@ import { describeSuite, expect, beforeAll } from "@moonwall/cli";
 import { KeyringPair, filterAndApply } from "@moonwall/util";
 import { ApiPromise } from "@polkadot/api";
 import { extractWeight } from "@moonwall/util";
-import { extractFeeAuthor, fetchIssuance, filterRewardFromOrchestrator } from "util/block";
+import { extractFeeAuthor, filterRewardFromOrchestrator } from "util/block";
 
 describeSuite({
-    id: "CT0201",
+    id: "C0002",
     title: "Fee test suite",
     foundationMethods: "dev",
     testCases: ({ it, context }) => {
         let polkadotJs: ApiPromise;
         let alice: KeyringPair;
         let bob: KeyringPair;
-        let adjustedExpectedBasePlusWeightFee;
 
         // Difference between the refTime estimated using paymentInfo and the actual refTime reported inside a block
         // https://github.com/paritytech/substrate/blob/5e49f6e44820affccaf517fd22af564f4b495d40/frame/support/src/weights/extrinsic_weights.rs#L56
@@ -65,7 +64,7 @@ describeSuite({
                 // but when we pay fees (or compare with queryFeeDetails), we do it adjusted (with multiplier). In our case we are using
                 // a constant multiplier, but because of rounding issues with the weight, we migth obtain
                 // a +-1 difference
-                adjustedExpectedBasePlusWeightFee = basePlusWeightFee + 1n;
+                const adjustedExpectedBasePlusWeightFee = basePlusWeightFee + 1n;
 
                 const expectedFee = adjustedExpectedBasePlusWeightFee + BigInt(signedTx.encodedLength);
                 expect(fee).to.equal(expectedFee);
@@ -91,13 +90,35 @@ describeSuite({
                     signedTx.encodedLength
                 );
 
+                const feeMultiplier = (await polkadotJs.query.transactionPayment.nextFeeMultiplier()).toBigInt();
+                const feeInfo = await tx.paymentInfo(alice.address);
+                const unadjustedWeightFee = (
+                    await polkadotJs.call.transactionPaymentApi.queryWeightToFee({
+                        refTime: feeInfo.weight.refTime.toBigInt(),
+                        proofSize: feeInfo.weight.proofSize.toBigInt(),
+                    })
+                ).toBigInt();
+
+                const baseWeightToFee = (
+                    await polkadotJs.call.transactionPaymentApi.queryWeightToFee({
+                        refTime: baseWeight,
+                        proofSize: feeInfo.weight.proofSize.toBigInt(),
+                    })
+                ).toBigInt();
+
+                const lengthToFee = (
+                    await polkadotJs.call.transactionPaymentApi.queryLengthToFee(signedTx.encodedLength)
+                ).toBigInt();
+                const multiplierAdjustedWeightFee = (feeMultiplier * unadjustedWeightFee) / 1_000_000_000_000_000_000n;
+
+                const expectedFee = baseWeightToFee + multiplierAdjustedWeightFee + lengthToFee;
+
                 await context.createBlock([signedTx]);
 
                 const events = await polkadotJs.query.system.events();
                 const fee = extractFeeAuthor(events, alice.address).amount.toBigInt();
                 const reward = filterRewardFromOrchestrator(events, alice.address);
 
-                const expectedFee = adjustedExpectedBasePlusWeightFee + BigInt(signedTx.encodedLength);
                 expect(fee).to.equal(expectedFee);
 
                 const inclusionFee = feeDetails.inclusionFee.unwrapOrDefault();
@@ -118,10 +139,13 @@ describeSuite({
 
         it({
             id: "E03",
-            title: "Fee of balances.transfer does not increase after 100 full blocks",
+            title: "Fee of balances.transfer does increase after 100 full blocks due to slow adjusting multiplier",
             test: async function () {
                 const fillAmount = 600_000_000; // equal to 60% Perbill
 
+                const previousfeeMultiplier = (
+                    await polkadotJs.query.transactionPayment.nextFeeMultiplier()
+                ).toBigInt();
                 for (let i = 0; i < 100; i++) {
                     const tx = polkadotJs.tx.rootTesting.fillBlock(fillAmount);
                     const signedTx = await polkadotJs.tx.sudo.sudo(tx).signAsync(alice);
@@ -146,12 +170,35 @@ describeSuite({
                     tx,
                     signedTx.encodedLength
                 );
+                const currentfeeMultiplier = (await polkadotJs.query.transactionPayment.nextFeeMultiplier()).toBigInt();
+                expect(currentfeeMultiplier).toBeGreaterThan(previousfeeMultiplier);
+                const feeInfo = await tx.paymentInfo(alice.address);
+                const unadjustedWeightFee = (
+                    await polkadotJs.call.transactionPaymentApi.queryWeightToFee({
+                        refTime: feeInfo.weight.refTime.toBigInt(),
+                        proofSize: feeInfo.weight.proofSize.toBigInt(),
+                    })
+                ).toBigInt();
+
+                const baseWeightToFee = (
+                    await polkadotJs.call.transactionPaymentApi.queryWeightToFee({
+                        refTime: baseWeight,
+                        proofSize: feeInfo.weight.proofSize.toBigInt(),
+                    })
+                ).toBigInt();
+
+                const lengthToFee = (
+                    await polkadotJs.call.transactionPaymentApi.queryLengthToFee(signedTx.encodedLength)
+                ).toBigInt();
+                const multiplierAdjustedWeightFee =
+                    (currentfeeMultiplier * unadjustedWeightFee) / 1_000_000_000_000_000_000n;
+
+                const expectedFee = baseWeightToFee + multiplierAdjustedWeightFee + lengthToFee;
                 await context.createBlock([signedTx]);
 
                 const events = await polkadotJs.query.system.events();
                 const fee = extractFeeAuthor(events, alice.address).amount.toBigInt();
                 const reward = filterRewardFromOrchestrator(events, alice.address);
-                const expectedFee = adjustedExpectedBasePlusWeightFee + BigInt(signedTx.encodedLength);
                 expect(fee).to.equal(expectedFee);
 
                 const inclusionFee = feeDetails.inclusionFee.unwrapOrDefault();
@@ -171,35 +218,6 @@ describeSuite({
 
         it({
             id: "E04",
-            title: "80% of Fees are burned",
-            test: async function () {
-                const totalSupplyBefore = (await polkadotJs.query.balances.totalIssuance()).toBigInt();
-                const balanceBefore = (await polkadotJs.query.system.account(alice.address)).data.free.toBigInt();
-                const tx = polkadotJs.tx.balances.transferAllowDeath(bob.address, 200_000);
-                const signedTx = await tx.signAsync(alice);
-
-                await context.createBlock([signedTx]);
-
-                const events = await polkadotJs.query.system.events();
-                const fee = extractFeeAuthor(events, alice.address).amount.toBigInt();
-                const issuance = fetchIssuance(events).amount.toBigInt();
-                const reward = filterRewardFromOrchestrator(events, alice.address);
-                const expectedFee = adjustedExpectedBasePlusWeightFee + BigInt(signedTx.encodedLength);
-                expect(fee).to.equal(expectedFee);
-
-                const balanceAfter = (await polkadotJs.query.system.account(alice.address)).data.free.toBigInt();
-
-                // Balance must be old balance minus fee minus transfered value
-                expect(balanceBefore + reward - fee - 200_000n).to.equal(balanceAfter);
-
-                const totalSupplyAfter = (await polkadotJs.query.balances.totalIssuance()).toBigInt();
-
-                expect(totalSupplyAfter - totalSupplyBefore).to.equal(issuance - (fee * 4n) / 5n);
-            },
-        });
-
-        it({
-            id: "E05",
             title: "Proof size does not affect fee",
             test: async function () {
                 const refTime = 298945000n;
@@ -223,7 +241,7 @@ describeSuite({
         });
 
         it({
-            id: "E06",
+            id: "E05",
             title: "Base refTime pays base fee",
             test: async function () {
                 const fee = (

--- a/test/suites/common-tanssi/fees/test_fee_burning.ts
+++ b/test/suites/common-tanssi/fees/test_fee_burning.ts
@@ -1,0 +1,80 @@
+import "@tanssi/api-augment";
+import { describeSuite, expect, beforeAll } from "@moonwall/cli";
+import { KeyringPair } from "@moonwall/util";
+import { ApiPromise } from "@polkadot/api";
+import { extractWeight } from "@moonwall/util";
+import { extractFeeAuthor, fetchIssuance, filterRewardFromOrchestrator } from "util/block";
+
+describeSuite({
+    id: "CT0201",
+    title: "Fee  burning test suite",
+    foundationMethods: "dev",
+    testCases: ({ it, context }) => {
+        let polkadotJs: ApiPromise;
+        let alice: KeyringPair;
+        let bob: KeyringPair;
+
+        // Difference between the refTime estimated using paymentInfo and the actual refTime reported inside a block
+        // https://github.com/paritytech/substrate/blob/5e49f6e44820affccaf517fd22af564f4b495d40/frame/support/src/weights/extrinsic_weights.rs#L56
+        let baseWeight;
+
+        beforeAll(async () => {
+            alice = context.keyring.alice;
+            bob = context.keyring.bob;
+            polkadotJs = context.polkadotJs();
+            baseWeight = extractWeight(polkadotJs.consts.system.blockWeights.perClass.normal.baseExtrinsic).toBigInt();
+        });
+
+        it({
+            id: "E01",
+            title: "80% of Fees are burned",
+            test: async function () {
+                const totalSupplyBefore = (await polkadotJs.query.balances.totalIssuance()).toBigInt();
+                const balanceBefore = (await polkadotJs.query.system.account(alice.address)).data.free.toBigInt();
+                const tx = polkadotJs.tx.balances.transferAllowDeath(bob.address, 200_000);
+                const signedTx = await tx.signAsync(alice);
+
+                const feeMultiplier = (await polkadotJs.query.transactionPayment.nextFeeMultiplier()).toBigInt();
+                const feeInfo = await tx.paymentInfo(alice.address);
+                const unadjustedWeightFee = (
+                    await polkadotJs.call.transactionPaymentApi.queryWeightToFee({
+                        refTime: feeInfo.weight.refTime.toBigInt(),
+                        proofSize: feeInfo.weight.proofSize.toBigInt(),
+                    })
+                ).toBigInt();
+
+                const baseWeightToFee = (
+                    await polkadotJs.call.transactionPaymentApi.queryWeightToFee({
+                        refTime: baseWeight,
+                        proofSize: feeInfo.weight.proofSize.toBigInt(),
+                    })
+                ).toBigInt();
+
+                const lengthToFee = (
+                    await polkadotJs.call.transactionPaymentApi.queryLengthToFee(signedTx.encodedLength)
+                ).toBigInt();
+                const multiplierAdjustedWeightFee = (feeMultiplier * unadjustedWeightFee) / 1_000_000_000_000_000_000n;
+
+                const expectedFee = baseWeightToFee + multiplierAdjustedWeightFee + lengthToFee;
+
+                await context.createBlock([signedTx]);
+
+                const events = await polkadotJs.query.system.events();
+                const fee = extractFeeAuthor(events, alice.address).amount.toBigInt();
+                const issuance = fetchIssuance(events).amount.toBigInt();
+                const reward = filterRewardFromOrchestrator(events, alice.address);
+
+                expect(fee).to.equal(expectedFee);
+
+                const balanceAfter = (await polkadotJs.query.system.account(alice.address)).data.free.toBigInt();
+
+                // Balance must be old balance minus fee minus transfered value
+                expect(balanceBefore + reward - fee - 200_000n).to.equal(balanceAfter);
+
+                const totalSupplyAfter = (await polkadotJs.query.balances.totalIssuance()).toBigInt();
+
+                expect(totalSupplyAfter - totalSupplyBefore).to.equal(issuance - (fee * 4n) / 5n);
+            },
+        });
+    },
+});

--- a/test/suites/dev-tanssi/staking/test_staking_rewards_balanced.ts
+++ b/test/suites/dev-tanssi/staking/test_staking_rewards_balanced.ts
@@ -146,15 +146,30 @@ describeSuite({
                     events,
                     reward.accountId.toString()
                 );
-                expect(stakingRewardedDelegators.manualRewards).to.equal(realDistributedManualDelegatorRewards);
-                expect(stakingRewardedDelegators.autoCompoundingRewards).to.equal(delegatorsAutoCompoundRewards);
+
+                // Test ranges, as we can have rounding errors for Perbill manipulation
+                expect(stakingRewardedDelegators.manualRewards).toBeGreaterThanOrEqual(
+                    realDistributedManualDelegatorRewards - 1n
+                );
+                expect(stakingRewardedDelegators.manualRewards).toBeLessThanOrEqual(
+                    realDistributedManualDelegatorRewards + 1n
+                );
+                expect(stakingRewardedDelegators.autoCompoundingRewards).toBeGreaterThanOrEqual(
+                    delegatorsAutoCompoundRewards - 1n
+                );
+                expect(stakingRewardedDelegators.autoCompoundingRewards).toBeLessThanOrEqual(
+                    delegatorsAutoCompoundRewards + 1n
+                );
 
                 // TODO: test better what goes into auto and what goes into manual for collator
                 const delegatorDust =
                     delegatorRewards - realDistributedManualDelegatorRewards - delegatorsAutoCompoundRewards;
-                expect(stakingRewardedCollator.manualRewards + stakingRewardedCollator.autoCompoundingRewards).to.equal(
-                    collatorPercentage + delegatorDust
-                );
+                expect(
+                    stakingRewardedCollator.manualRewards + stakingRewardedCollator.autoCompoundingRewards
+                ).toBeGreaterThanOrEqual(collatorPercentage + delegatorDust - 1n);
+                expect(
+                    stakingRewardedCollator.manualRewards + stakingRewardedCollator.autoCompoundingRewards
+                ).toBeLessThanOrEqual(collatorPercentage + delegatorDust + 1n);
             },
         });
     },

--- a/test/suites/dev-tanssi/staking/test_staking_rewards_non_balanced.ts
+++ b/test/suites/dev-tanssi/staking/test_staking_rewards_non_balanced.ts
@@ -127,7 +127,7 @@ describeSuite({
                 const reward = await fetchRewardAuthorOrchestrator(events);
 
                 // 20% collator percentage
-                const collatorPercentage = (20n * reward.balance.toBigInt()) / 100n;
+                const collatorPercentage = reward.balance.toBigInt() - (80n * reward.balance.toBigInt()) / 100n;
 
                 // Rounding
                 const delegatorRewards = reward.balance.toBigInt() - collatorPercentage;
@@ -146,15 +146,30 @@ describeSuite({
                     events,
                     reward.accountId.toString()
                 );
-                expect(stakingRewardedDelegators.manualRewards).to.equal(realDistributedManualDelegatorRewards);
-                expect(stakingRewardedDelegators.autoCompoundingRewards).to.equal(delegatorsAutoCompoundRewards);
+
+                // Test ranges, as we can have rounding errors for Perbill manipulation
+                expect(stakingRewardedDelegators.manualRewards).toBeGreaterThanOrEqual(
+                    realDistributedManualDelegatorRewards - 1n
+                );
+                expect(stakingRewardedDelegators.manualRewards).toBeLessThanOrEqual(
+                    realDistributedManualDelegatorRewards + 1n
+                );
+                expect(stakingRewardedDelegators.autoCompoundingRewards).toBeGreaterThanOrEqual(
+                    delegatorsAutoCompoundRewards - 1n
+                );
+                expect(stakingRewardedDelegators.autoCompoundingRewards).toBeLessThanOrEqual(
+                    delegatorsAutoCompoundRewards + 1n
+                );
 
                 // TODO: test better what goes into auto and what goes into manual for collator
                 const delegatorDust =
                     delegatorRewards - realDistributedManualDelegatorRewards - delegatorsAutoCompoundRewards;
-                expect(stakingRewardedCollator.manualRewards + stakingRewardedCollator.autoCompoundingRewards).to.equal(
-                    collatorPercentage + delegatorDust
-                );
+                expect(
+                    stakingRewardedCollator.manualRewards + stakingRewardedCollator.autoCompoundingRewards
+                ).toBeGreaterThanOrEqual(collatorPercentage + delegatorDust - 1n);
+                expect(
+                    stakingRewardedCollator.manualRewards + stakingRewardedCollator.autoCompoundingRewards
+                ).toBeLessThanOrEqual(collatorPercentage + delegatorDust + 1n);
             },
         });
     },

--- a/test/util/block.ts
+++ b/test/util/block.ts
@@ -191,10 +191,10 @@ export function fetchIssuance(events: EventRecord[] = []) {
 
 export function filterRewardFromOrchestrator(events: EventRecord[] = [], author: string) {
     const reward = fetchRewardAuthorOrchestrator(events);
-    if (reward.accountId.toString() === author) {
-        return reward.balance.toBigInt();
-    } else {
+    if (reward === undefined || reward.accountId.toString() !== author) {
         return 0n;
+    } else {
+        return reward.balance.toBigInt();
     }
 }
 


### PR DESCRIPTION
## Description
Currently, we are using `ConstFeeMultiplier` for transaction payment, which mean that regardless of network congestion level, the transaction fee would be constant. This is not recommended since it can be DOS vector. 

Instead we need to use `SlowAdjustingFeeUpdate` which adjusts slowly, at the pace of long term tendencies, and uses tipping to give users the possibility of controlling waiting times at peak hours.