### PR TITLE
Rename Parachain Collator Template

### DIFF
--- a/container-chains/templates/frontier/node/src/command.rs
+++ b/container-chains/templates/frontier/node/src/command.rs
@@ -53,7 +53,7 @@ fn load_spec(id: &str, para_id: ParaId) -> std::result::Result<Box<dyn ChainSpec
 
 impl SubstrateCli for Cli {
     fn impl_name() -> String {
-        "Parachain Collator Template".into()
+        "Container Chain Simple Node".into()
     }
 
     fn impl_version() -> String {
@@ -62,7 +62,7 @@ impl SubstrateCli for Cli {
 
     fn description() -> String {
         format!(
-            "Parachain Collator Template\n\nThe command-line arguments provided first will be \
+            "Container Chain Simple Node\n\nThe command-line arguments provided first will be \
 		passed to the parachain node, while the arguments provided after -- will be passed \
 		to the relay chain node.\n\n\
 		{} <parachain-args> -- <relay-chain-args>",
@@ -89,7 +89,7 @@ impl SubstrateCli for Cli {
 
 impl SubstrateCli for RelayChainCli {
     fn impl_name() -> String {
-        "Parachain Collator Template".into()
+        "Container Chain Simple Node".into()
     }
 
     fn impl_version() -> String {
@@ -98,7 +98,7 @@ impl SubstrateCli for RelayChainCli {
 
     fn description() -> String {
         format!(
-            "Parachain Collator Template\n\nThe command-line arguments provided first will be \
+            "Container Chain Simple Node\n\nThe command-line arguments provided first will be \
 		passed to the parachain node, while the arguments provided after -- will be passed \
 		to the relay chain node.\n\n\
 		{} <parachain-args> -- <relay-chain-args>",

--- a/container-chains/templates/simple/node/src/command.rs
+++ b/container-chains/templates/simple/node/src/command.rs
@@ -50,7 +50,7 @@ fn load_spec(id: &str, para_id: ParaId) -> std::result::Result<Box<dyn ChainSpec
 
 impl SubstrateCli for Cli {
     fn impl_name() -> String {
-        "Parachain Collator Template".into()
+        "Container Chain Simple Node".into()
     }
 
     fn impl_version() -> String {
@@ -59,7 +59,7 @@ impl SubstrateCli for Cli {
 
     fn description() -> String {
         format!(
-            "Parachain Collator Template\n\nThe command-line arguments provided first will be \
+            "Container Chain Simple Node\n\nThe command-line arguments provided first will be \
         passed to the parachain node, while the arguments provided after -- will be passed \
         to the relay chain node.\n\n\
         {} <parachain-args> -- <relay-chain-args>",
@@ -86,7 +86,7 @@ impl SubstrateCli for Cli {
 
 impl SubstrateCli for RelayChainCli {
     fn impl_name() -> String {
-        "Parachain Collator Template".into()
+        "Container Chain Simple Node".into()
     }
 
     fn impl_version() -> String {
@@ -95,7 +95,7 @@ impl SubstrateCli for RelayChainCli {
 
     fn description() -> String {
         format!(
-            "Parachain Collator Template\n\nThe command-line arguments provided first will be \
+            "Container Chain Simple Node\n\nThe command-line arguments provided first will be \
         passed to the parachain node, while the arguments provided after -- will be passed \
         to the relay chain node.\n\n\
         {} <parachain-args> -- <relay-chain-args>",

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -95,7 +95,7 @@ fn load_spec(id: &str, para_id: ParaId) -> std::result::Result<Box<dyn ChainSpec
 
 impl SubstrateCli for Cli {
     fn impl_name() -> String {
-        "Parachain Collator Template".into()
+        "Tanssi Collator".into()
     }
 
     fn impl_version() -> String {
@@ -104,7 +104,7 @@ impl SubstrateCli for Cli {
 
     fn description() -> String {
         format!(
-            "Parachain Collator Template\n\nThe command-line arguments provided first will be \
+            "Tanssi Collator\n\nThe command-line arguments provided first will be \
 		passed to the parachain node, while the arguments provided after -- will be passed \
 		to the relay chain node.\n\n\
 		{} <parachain-args> -- <relay-chain-args>",
@@ -131,7 +131,7 @@ impl SubstrateCli for Cli {
 
 impl SubstrateCli for RelayChainCli {
     fn impl_name() -> String {
-        "Parachain Collator Template".into()
+        "Tanssi Collator".into()
     }
 
     fn impl_version() -> String {
@@ -140,7 +140,7 @@ impl SubstrateCli for RelayChainCli {
 
     fn description() -> String {
         format!(
-            "Parachain Collator Template\n\nThe command-line arguments provided first will be \
+            "Tanssi Collator\n\nThe command-line arguments provided first will be \
 		passed to the parachain node, while the arguments provided after -- will be passed \
 		to the relay chain node.\n\n\
 		{} <parachain-args> -- <relay-chain-args>",


### PR DESCRIPTION
## Description
This PR renames `Parachain Collator Template` to `Tanssi Collator` for Tanssi node and `Container Chain Simple Node` for container chain template.