### PR TITLE
Shuffle only top N collators to respect staking priority

### DIFF
--- a/pallets/collator-assignment/src/assignment.rs
+++ b/pallets/collator-assignment/src/assignment.rs
@@ -426,7 +426,8 @@ where
             let cs = old_assigned.entry(*para_id).or_default();
 
             while cs.len() < *num_collators as usize {
-                // This error should never happen because we checked that `collators.len() >= required_collators`
+                // This error should never happen because we calculated `needed_new_collators`
+                // using the same algorithm
                 let nc = new_collators
                     .next()
                     .ok_or(AssignmentError::NotEnoughCollators)?;

--- a/pallets/collator-assignment/src/assignment.rs
+++ b/pallets/collator-assignment/src/assignment.rs
@@ -39,15 +39,25 @@ where
 {
     /// Recompute collator assignment from scratch. If the list of collators and the list of
     /// container chains are shuffled, this returns a random assignment.
-    pub fn assign_collators_rotate_all(
+    pub fn assign_collators_rotate_all<TShuffle>(
         collators: Vec<T::AccountId>,
         orchestrator_chain: ChainNumCollators,
         chains: Vec<ChainNumCollators>,
-    ) -> Result<AssignedCollators<T::AccountId>, AssignmentError> {
+        shuffle: Option<TShuffle>,
+    ) -> Result<AssignedCollators<T::AccountId>, AssignmentError>
+    where
+        TShuffle: FnOnce(&mut Vec<T::AccountId>),
+    {
         // This is just the "always_keep_old" algorithm but with an empty "old"
         let old_assigned = Default::default();
 
-        Self::assign_collators_always_keep_old(collators, orchestrator_chain, chains, old_assigned)
+        Self::assign_collators_always_keep_old(
+            collators,
+            orchestrator_chain,
+            chains,
+            old_assigned,
+            shuffle,
+        )
     }
 
     /// Assign new collators to missing container_chains.
@@ -57,12 +67,23 @@ where
     /// `chains` should be shuffled or at least rotated on every session to ensure
     /// a fair distribution, because the order of that list affects container chain priority:
     /// the first chain on that list will be the first one to get new collators.
-    pub fn assign_collators_always_keep_old(
+    ///
+    /// Similarly, in the `collators` list order means priority, the first collators will be more
+    /// likely to get assigned. Unlike the list of `chains` which should already be shuffled,
+    /// collators will be shuffled using the `shuffle` callback when needed. This allows the
+    /// algorithm to truncate the list of collators and only shuffle the first N. This ensures that
+    /// shuffling doesn't cause a collator with low priority to be assigned instead of a collator
+    /// with higher priority.
+    pub fn assign_collators_always_keep_old<TShuffle>(
         collators: Vec<T::AccountId>,
         orchestrator_chain: ChainNumCollators,
         mut chains: Vec<ChainNumCollators>,
         mut old_assigned: AssignedCollators<T::AccountId>,
-    ) -> Result<AssignedCollators<T::AccountId>, AssignmentError> {
+        shuffle: Option<TShuffle>,
+    ) -> Result<AssignedCollators<T::AccountId>, AssignmentError>
+    where
+        TShuffle: FnOnce(&mut Vec<T::AccountId>),
+    {
         if collators.is_empty() {
             return Err(AssignmentError::ZeroCollators);
         }
@@ -93,7 +114,7 @@ where
         Self::prioritize_invulnerables(&collators, orchestrator_chain, &mut old_assigned);
 
         let new_assigned_chains =
-            Self::assign_full(collators, chains_with_collators, old_assigned)?;
+            Self::assign_full(collators, chains_with_collators, old_assigned, shuffle)?;
 
         let mut new_assigned = AssignedCollators {
             container_chains: new_assigned_chains,
@@ -321,6 +342,9 @@ where
     /// assigned to a para_id not present in `chains` may be reassigned to another para_id.
     /// * `chains` `num_collators` can be 0. In that case an empty vec is returned for that para id.
     /// * `old_assigned` must not have duplicate collators.
+    /// * `shuffle` is used to shuffle the list collators. The list will be truncated to only have
+    /// the number of required collators, to ensure that shuffling doesn't cause a collator with low
+    /// priority to be assigned instead of a collator with higher priority.
     ///
     /// # Returns
     ///
@@ -328,11 +352,15 @@ where
     ///
     /// Or an error if the number of collators is not enough to fill all the chains, or if the required number
     /// of collators overflows a `u32`.
-    pub fn assign_full(
+    pub fn assign_full<TShuffle>(
         collators: Vec<T::AccountId>,
         chains: Vec<(ParaId, u32)>,
         mut old_assigned: BTreeMap<ParaId, Vec<T::AccountId>>,
-    ) -> Result<BTreeMap<ParaId, Vec<T::AccountId>>, AssignmentError> {
+        shuffle: Option<TShuffle>,
+    ) -> Result<BTreeMap<ParaId, Vec<T::AccountId>>, AssignmentError>
+    where
+        TShuffle: FnOnce(&mut Vec<T::AccountId>),
+    {
         let mut required_collators = 0usize;
         for (_para_id, num_collators) in chains.iter() {
             let num_collators =
@@ -362,14 +390,36 @@ where
             entry.truncate(*num_collators as usize);
         }
 
+        // Count number of needed new collators. This is equivalent to:
+        // `required_collators - old_assigned.iter().map(|cs| cs.len()).sum()`.
+        let mut needed_new_collators = 0;
+        for (para_id, num_collators) in chains.iter() {
+            let cs = old_assigned.entry(*para_id).or_default();
+            needed_new_collators += (*num_collators as usize).saturating_sub(cs.len());
+        }
+
         let assigned_collators: BTreeSet<T::AccountId> = old_assigned
             .iter()
             .flat_map(|(_para_id, para_collators)| para_collators.iter().cloned())
             .collect();
-        let mut new_collators = collators.into_iter().filter(|x| {
-            // Keep collators not already assigned
-            !assigned_collators.contains(x)
-        });
+
+        // Truncate list of new_collators to `needed_new_collators` and shuffle it.
+        // This has the effect of keeping collator priority (the first collator of that list is more
+        // likely to be assigned to a chain than the last collator of that list), while also
+        // ensuring randomness (the original order does not directly affect which chain the
+        // collators are assigned to).
+        let mut new_collators: Vec<_> = collators
+            .into_iter()
+            .filter(|x| {
+                // Keep collators not already assigned
+                !assigned_collators.contains(x)
+            })
+            .take(needed_new_collators)
+            .collect();
+        if let Some(shuffle) = shuffle {
+            shuffle(&mut new_collators);
+        }
+        let mut new_collators = new_collators.into_iter();
 
         // Fill missing collators
         for (para_id, num_collators) in chains.iter() {

--- a/pallets/collator-assignment/src/lib.rs
+++ b/pallets/collator-assignment/src/lib.rs
@@ -186,6 +186,7 @@ pub mod pallet {
             // as paratherads because they will not be producing blocks on every slot.
             T::RemoveParaIdsWithNoCredits::remove_para_ids_with_no_credits(&mut parathreads);
 
+            let mut shuffle_collators = None;
             // If the random_seed is all zeros, we don't shuffle the list of collators nor the list
             // of container chains.
             // This should only happen in tests, and in the genesis block.
@@ -196,6 +197,9 @@ pub mod pallet {
                 // determine priority
                 container_chain_ids.shuffle(&mut rng);
                 parathreads.shuffle(&mut rng);
+                shuffle_collators = Some(move |collators: &mut Vec<T::AccountId>| {
+                    collators.shuffle(&mut rng);
+                })
             }
 
             // We read current assigned collators
@@ -253,6 +257,7 @@ pub mod pallet {
                         collators,
                         orchestrator_chain,
                         chains,
+                        shuffle_collators,
                     )
                 } else {
                     log::debug!(
@@ -272,6 +277,7 @@ pub mod pallet {
                         orchestrator_chain,
                         chains,
                         old_assigned.clone(),
+                        shuffle_collators,
                     )
                 };
 

--- a/pallets/collator-assignment/src/tests.rs
+++ b/pallets/collator-assignment/src/tests.rs
@@ -751,18 +751,18 @@ fn assign_collators_rotation() {
 
         // Random assignment depends on the seed, shouldn't change unless the algorithm changes
         let shuffled_assignment = BTreeMap::from_iter(vec![
-            (1, 1000),
-            (2, 1002),
+            (1, 1004),
+            (2, 1000),
             (3, 1000),
-            (4, 1004),
-            (5, 1003),
-            (6, 1003),
-            (7, 1000),
+            (4, 1003),
+            (5, 1001),
+            (6, 1000),
+            (7, 1002),
             (8, 1001),
             (9, 1002),
-            (10, 1004),
-            (11, 1000),
-            (12, 1001),
+            (10, 1000),
+            (11, 1003),
+            (12, 1004),
         ]);
 
         assert_eq!(assigned_collators(), shuffled_assignment,);
@@ -802,7 +802,7 @@ fn assign_collators_rotation_container_chains_are_shuffled() {
         // Random assignment depends on the seed, shouldn't change unless the algorithm changes
         // Test that container chains are shuffled because 1001 does not have priority
         let shuffled_assignment =
-            BTreeMap::from_iter(vec![(1, 1000), (2, 1002), (3, 1000), (4, 1002)]);
+            BTreeMap::from_iter(vec![(1, 1000), (2, 1002), (3, 1002), (4, 1000)]);
 
         assert_eq!(assigned_collators(), shuffled_assignment,);
     });
@@ -841,7 +841,7 @@ fn assign_collators_rotation_parathreads_are_shuffled() {
         // Random assignment depends on the seed, shouldn't change unless the algorithm changes
         // Test that container chains are shuffled because 1001 does not have priority
         let shuffled_assignment =
-            BTreeMap::from_iter(vec![(1, 1000), (2, 3002), (3, 1000), (4, 3002)]);
+            BTreeMap::from_iter(vec![(1, 1000), (2, 3002), (3, 3002), (4, 1000)]);
 
         assert_eq!(assigned_collators(), shuffled_assignment,);
     });
@@ -890,14 +890,14 @@ fn assign_collators_rotation_collators_are_shuffled() {
         // and here it is present
         let shuffled_assignment = BTreeMap::from_iter(vec![
             (1, 1000),
-            (3, 1000),
+            (3, 1001),
             (4, 1000),
-            (5, 1001),
-            (6, 1002),
-            (7, 1000),
-            (8, 1001),
+            (5, 1000),
+            (6, 1000),
+            (7, 1002),
+            (8, 1002),
             (9, 1000),
-            (10, 1002),
+            (10, 1001),
         ]);
 
         assert_eq!(assigned_collators(), shuffled_assignment,);

--- a/pallets/collator-assignment/src/tests/assign_full.rs
+++ b/pallets/collator-assignment/src/tests/assign_full.rs
@@ -24,8 +24,9 @@ use {
     sp_std::collections::btree_map::BTreeMap,
 };
 
+#[allow(unused_assignments)]
 fn no_shuffle() -> Option<impl FnOnce(&mut Vec<u64>)> {
-    let mut shuffle = Some(move |collators: &mut Vec<u64>| {
+    let mut shuffle = Some(move |_collators: &mut Vec<u64>| {
         // Create an empty closure to allow the compiler to infer the return type
     });
     // But don't return that closure, instead return `None`

--- a/pallets/collator-assignment/src/tests/assign_full.rs
+++ b/pallets/collator-assignment/src/tests/assign_full.rs
@@ -19,8 +19,20 @@ use {
         assignment::{Assignment, AssignmentError},
         tests::Test,
     },
+    rand::{seq::SliceRandom, SeedableRng},
+    rand_chacha::ChaCha20Rng,
     sp_std::collections::btree_map::BTreeMap,
 };
+
+fn no_shuffle() -> Option<impl FnOnce(&mut Vec<u64>)> {
+    let mut shuffle = Some(move |collators: &mut Vec<u64>| {
+        // Create an empty closure to allow the compiler to infer the return type
+    });
+    // But don't return that closure, instead return `None`
+    shuffle = None;
+
+    shuffle
+}
 
 #[test]
 fn assign_full_old_assigned_priority() {
@@ -30,7 +42,8 @@ fn assign_full_old_assigned_priority() {
     let old_assigned = BTreeMap::from_iter(vec![(1000.into(), vec![3, 4])]);
 
     let new_assigned =
-        Assignment::<Test>::assign_full(collators, container_chains, old_assigned).unwrap();
+        Assignment::<Test>::assign_full(collators, container_chains, old_assigned, no_shuffle())
+            .unwrap();
     let expected = BTreeMap::from_iter(vec![(1000.into(), vec![3, 4, 1, 2, 5])]);
     assert_eq!(new_assigned, expected);
 }
@@ -43,7 +56,8 @@ fn assign_full_invalid_old_assigned_collators_removed() {
     let old_assigned = BTreeMap::from_iter(vec![(1000.into(), vec![20, 21])]);
 
     let new_assigned =
-        Assignment::<Test>::assign_full(collators, container_chains, old_assigned).unwrap();
+        Assignment::<Test>::assign_full(collators, container_chains, old_assigned, no_shuffle())
+            .unwrap();
     let expected = BTreeMap::from_iter(vec![(1000.into(), vec![1, 2, 3, 4, 5])]);
     assert_eq!(new_assigned, expected);
 }
@@ -56,7 +70,8 @@ fn assign_full_invalid_chains_removed() {
     let old_assigned = BTreeMap::from_iter(vec![(1001.into(), vec![1, 2, 3, 4, 5])]);
 
     let new_assigned =
-        Assignment::<Test>::assign_full(collators, container_chains, old_assigned).unwrap();
+        Assignment::<Test>::assign_full(collators, container_chains, old_assigned, no_shuffle())
+            .unwrap();
     let expected = BTreeMap::from_iter(vec![(1000.into(), vec![1, 2, 3, 4, 5])]);
     assert_eq!(new_assigned, expected);
 }
@@ -72,7 +87,8 @@ fn assign_full_truncates_collators() {
     ]);
 
     let new_assigned =
-        Assignment::<Test>::assign_full(collators, container_chains, old_assigned).unwrap();
+        Assignment::<Test>::assign_full(collators, container_chains, old_assigned, no_shuffle())
+            .unwrap();
     let expected = BTreeMap::from_iter(vec![(1000.into(), vec![1, 2]), (2000.into(), vec![6, 7])]);
     assert_eq!(new_assigned, expected);
 }
@@ -84,9 +100,49 @@ fn assign_full_old_assigned_error_if_not_enough_collators() {
     let collators = vec![1, 2];
     let container_chains = vec![(1000.into(), 2), (2000.into(), 2)];
     let old_assigned = BTreeMap::from_iter(vec![(2000.into(), vec![1, 2])]);
-    let new_assigned = Assignment::<Test>::assign_full(collators, container_chains, old_assigned);
+    let new_assigned =
+        Assignment::<Test>::assign_full(collators, container_chains, old_assigned, no_shuffle());
     assert_eq!(
         new_assigned.unwrap_err(),
         AssignmentError::NotEnoughCollators
     );
+}
+
+#[test]
+fn assign_full_list_priority() {
+    // The order in the collators list is priority
+    let collators = vec![
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+    ];
+    let container_chains = vec![(1000.into(), 2), (2000.into(), 2)];
+    let old_assigned = BTreeMap::from_iter(vec![]);
+
+    let new_assigned =
+        Assignment::<Test>::assign_full(collators, container_chains, old_assigned, no_shuffle())
+            .unwrap();
+    let expected = BTreeMap::from_iter(vec![(1000.into(), vec![1, 2]), (2000.into(), vec![3, 4])]);
+    assert_eq!(new_assigned, expected);
+}
+
+#[test]
+fn assign_full_list_priority_shuffle() {
+    // The order in the collators list is priority
+    let collators = vec![
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+    ];
+    let container_chains = vec![(1000.into(), 2), (2000.into(), 2)];
+    let old_assigned = BTreeMap::from_iter(vec![]);
+    let shuffle = Some(move |collators: &mut Vec<u64>| {
+        // Shuffle with a fixed seed, we do not need randomness in a unit test
+        let seed = [1; 32];
+        let mut rng: ChaCha20Rng = SeedableRng::from_seed(seed);
+        collators.shuffle(&mut rng);
+    });
+
+    let new_assigned =
+        Assignment::<Test>::assign_full(collators, container_chains, old_assigned, shuffle)
+            .unwrap();
+    // Expect only [1, 2, 3, 4] to be assigned, in random order
+    let expected = BTreeMap::from_iter(vec![(1000.into(), vec![3, 2]), (2000.into(), vec![1, 4])]);
+    assert_eq!(new_assigned, expected);
 }

--- a/pallets/collator-assignment/src/tests/assign_full.rs
+++ b/pallets/collator-assignment/src/tests/assign_full.rs
@@ -24,15 +24,8 @@ use {
     sp_std::collections::btree_map::BTreeMap,
 };
 
-#[allow(unused_assignments)]
-fn no_shuffle() -> Option<impl FnOnce(&mut Vec<u64>)> {
-    let mut shuffle = Some(move |_collators: &mut Vec<u64>| {
-        // Create an empty closure to allow the compiler to infer the return type
-    });
-    // But don't return that closure, instead return `None`
-    shuffle = None;
-
-    shuffle
+fn no_shuffle() -> Option<fn(&mut Vec<u64>)> {
+    None
 }
 
 #[test]


### PR DESCRIPTION
This will give more priority to collators with more stake.

Previously when the number of collators was much greater than the required, all collators were equally likely to be selected. Now, the first ones on the list are more likely to be selected.

Example with max_collators = 100, invulnerables = 5, min_orchestrator_collators = 2, max_orchestrator_collators = 5, and one container chain with 4 collators

* We take the 5 invulnerables, then 95 more collators from staking. These are the 95 with most stake.
* We assign 2 invulnerables to the orchestrator chain (prioritize_invulnerables)
* Now we need 3 collators more for orchestrator chain and 4 collators more for the container chain, 7 in total

Previously: we always shuffle the full list of collators, so we will take 7 collators randomly out of 98 (3 invulnerables + 95 from staking, all equally likely).

After this PR: we first truncate the list to have length = 7 (so 3 invulnerables + 4 from staking, the ones with most stake), and then we shuffle that. It is still possible that a collator with less stake is given priority but only if that collator was previously assigned to that chain, and only until the next rotation. So after a full rotation all the collators with most stake will be assigned to chains. 

We shuffle to avoid always assigning the collators with more stake to the orchestrator chain, and to avoid collators with similar stake to be assigned to the same container chain.