### PR TITLE
Fix use of current max_collators instead of pending

### DIFF
--- a/pallets/collator-assignment/src/lib.rs
+++ b/pallets/collator-assignment/src/lib.rs
@@ -41,13 +41,11 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-pub use pallet::*;
 use {
     crate::{
         assignment::{Assignment, ChainNumCollators},
         weights::WeightInfo,
     },
-    dp_collator_assignment::AssignedCollators,
     frame_support::pallet_prelude::*,
     frame_system::pallet_prelude::BlockNumberFor,
     rand::{seq::SliceRandom, SeedableRng},
@@ -63,6 +61,7 @@ use {
         ShouldRotateAllCollators, Slot,
     },
 };
+pub use {dp_collator_assignment::AssignedCollators, pallet::*};
 
 mod assignment;
 #[cfg(feature = "runtime-benchmarks")]

--- a/pallets/collator-assignment/src/mock.rs
+++ b/pallets/collator-assignment/src/mock.rs
@@ -137,6 +137,10 @@ parameter_types! {
 }
 
 impl pallet_collator_assignment::GetHostConfiguration<u32> for HostConfigurationGetter {
+    fn max_collators(_session_index: u32) -> u32 {
+        unimplemented!()
+    }
+
     fn min_collators_for_orchestrator(_session_index: u32) -> u32 {
         MockData::mock().min_orchestrator_chain_collators
     }

--- a/pallets/configuration/src/lib.rs
+++ b/pallets/configuration/src/lib.rs
@@ -528,6 +528,19 @@ pub mod pallet {
     }
 
     impl<T: Config> GetHostConfiguration<T::SessionIndex> for Pallet<T> {
+        fn max_collators(session_index: T::SessionIndex) -> u32 {
+            let (past_and_present, _) = Pallet::<T>::pending_configs()
+                .into_iter()
+                .partition::<Vec<_>, _>(|&(apply_at_session, _)| apply_at_session <= session_index);
+
+            let config = if let Some(last) = past_and_present.last() {
+                last.1.clone()
+            } else {
+                Pallet::<T>::config()
+            };
+            config.max_collators
+        }
+
         fn collators_per_container(session_index: T::SessionIndex) -> u32 {
             let (past_and_present, _) = Pallet::<T>::pending_configs()
                 .into_iter()

--- a/primitives/traits/src/lib.rs
+++ b/primitives/traits/src/lib.rs
@@ -141,6 +141,7 @@ pub trait GetContainerChainAuthor<AccountId> {
 /// Returns the host configuration composed of the amount of collators assigned
 /// to the orchestrator chain, and how many collators are assigned per container chain.
 pub trait GetHostConfiguration<SessionIndex> {
+    fn max_collators(session_index: SessionIndex) -> u32;
     fn min_collators_for_orchestrator(session_index: SessionIndex) -> u32;
     fn max_collators_for_orchestrator(session_index: SessionIndex) -> u32;
     fn collators_per_container(session_index: SessionIndex) -> u32;

--- a/runtime/dancebox/src/lib.rs
+++ b/runtime/dancebox/src/lib.rs
@@ -64,7 +64,7 @@ use {
         limits::{BlockLength, BlockWeights},
         EnsureRoot,
     },
-    nimbus_primitives::{SlotBeacon, NimbusId},
+    nimbus_primitives::{NimbusId, SlotBeacon},
     pallet_balances::NegativeImbalance,
     pallet_collator_assignment::{GetRandomnessForNextBlock, RotateCollatorsEveryNSessions},
     pallet_invulnerables::InvulnerableRewardDistribution,
@@ -94,8 +94,8 @@ use {
     sp_std::{marker::PhantomData, prelude::*},
     sp_version::RuntimeVersion,
     tp_traits::{
-        GetHostConfiguration, GetSessionContainerChains, RemoveInvulnerables,
-        RemoveParaIdsWithNoCredits, GetContainerChainAuthor
+        GetContainerChainAuthor, GetHostConfiguration, GetSessionContainerChains,
+        RemoveInvulnerables, RemoveParaIdsWithNoCredits,
     },
 };
 pub use {

--- a/runtime/dancebox/src/lib.rs
+++ b/runtime/dancebox/src/lib.rs
@@ -64,7 +64,7 @@ use {
         limits::{BlockLength, BlockWeights},
         EnsureRoot,
     },
-    nimbus_primitives::NimbusId,
+    nimbus_primitives::{SlotBeacon, NimbusId},
     pallet_balances::NegativeImbalance,
     pallet_collator_assignment::{GetRandomnessForNextBlock, RotateCollatorsEveryNSessions},
     pallet_invulnerables::InvulnerableRewardDistribution,
@@ -93,7 +93,10 @@ use {
     },
     sp_std::{marker::PhantomData, prelude::*},
     sp_version::RuntimeVersion,
-    tp_traits::{GetSessionContainerChains, RemoveInvulnerables, RemoveParaIdsWithNoCredits},
+    tp_traits::{
+        GetHostConfiguration, GetSessionContainerChains, RemoveInvulnerables,
+        RemoveParaIdsWithNoCredits, GetContainerChainAuthor
+    },
 };
 pub use {
     dp_core::{AccountId, Address, Balance, BlockNumber, Hash, Header, Index, Signature},
@@ -650,7 +653,9 @@ impl SessionManager<CollatorId> for CollatorsFromInvulnerablesAndThenFromStaking
         let candidates_staking =
             pallet_pooled_staking::SortedEligibleCandidates::<Runtime>::get().to_vec();
         // Max number of collators is set in pallet_configuration
-        let max_collators = Configuration::config().max_collators;
+        let target_session_index = index.saturating_add(1);
+        let max_collators =
+            <Configuration as GetHostConfiguration<u32>>::max_collators(target_session_index);
         let collators = invulnerables
             .iter()
             .cloned()
@@ -1340,8 +1345,6 @@ parameter_types! {
     // 30% for parachain bond, so 70% for staking
     pub const RewardsPortion: Perbill = Perbill::from_percent(70);
 }
-
-use {nimbus_primitives::SlotBeacon, tp_traits::GetContainerChainAuthor};
 
 pub struct GetSelfChainBlockAuthor;
 impl Get<AccountId32> for GetSelfChainBlockAuthor {

--- a/runtime/flashbox/src/lib.rs
+++ b/runtime/flashbox/src/lib.rs
@@ -58,7 +58,7 @@ use {
         limits::{BlockLength, BlockWeights},
         EnsureRoot,
     },
-    nimbus_primitives::{SlotBeacon, NimbusId},
+    nimbus_primitives::{NimbusId, SlotBeacon},
     pallet_balances::NegativeImbalance,
     pallet_invulnerables::InvulnerableRewardDistribution,
     pallet_registrar::RegistrarHooks,
@@ -84,8 +84,8 @@ use {
     sp_std::{marker::PhantomData, prelude::*},
     sp_version::RuntimeVersion,
     tp_traits::{
-        GetHostConfiguration, GetSessionContainerChains, RemoveInvulnerables,
-        RemoveParaIdsWithNoCredits, ShouldRotateAllCollators, GetContainerChainAuthor
+        GetContainerChainAuthor, GetHostConfiguration, GetSessionContainerChains,
+        RemoveInvulnerables, RemoveParaIdsWithNoCredits, ShouldRotateAllCollators,
     },
 };
 pub use {

--- a/runtime/flashbox/tests/integration_test.rs
+++ b/runtime/flashbox/tests/integration_test.rs
@@ -3449,3 +3449,73 @@ fn test_migration_services_collator_assignment_payment() {
             );
         });
 }
+
+#[test]
+fn test_max_collators_uses_pending_value() {
+    // Start with max_collators = 100, and collators_per_container = 2
+    // Set max_collators = 2, and collators_per_container = 3
+    // It should be impossible to have more than 2 collators per container at any point in time
+    ExtBuilder::default()
+        .with_balances(vec![
+            // Alice gets 10k extra tokens for her mapping deposit
+            (AccountId::from(ALICE), 210_000 * UNIT),
+            (AccountId::from(BOB), 100_000 * UNIT),
+            (AccountId::from(CHARLIE), 100_000 * UNIT),
+            (AccountId::from(DAVE), 100_000 * UNIT),
+        ])
+        .with_collators(vec![
+            (AccountId::from(ALICE), 210 * UNIT),
+            (AccountId::from(BOB), 100 * UNIT),
+            (AccountId::from(CHARLIE), 100 * UNIT),
+            (AccountId::from(DAVE), 100 * UNIT),
+        ])
+        .with_para_ids(vec![(
+            1001,
+            empty_genesis_data(),
+            vec![],
+            u32::MAX,
+            u32::MAX,
+        )
+            .into()])
+        .with_config(pallet_configuration::HostConfiguration {
+            max_collators: 100,
+            min_orchestrator_collators: 1,
+            max_orchestrator_collators: 1,
+            collators_per_container: 2,
+            full_rotation_period: 24,
+            ..Default::default()
+        })
+        .build()
+        .execute_with(|| {
+            run_to_block(2);
+
+            // Initial assignment: 1 collator in orchestrator chain and 2 collators in container 1001
+            let assignment = CollatorAssignment::collator_container_chain();
+            assert_eq!(assignment.container_chains[&1001u32.into()].len(), 2);
+            assert_eq!(assignment.orchestrator_chain.len(), 1);
+
+            assert_ok!(Configuration::set_max_collators(root_origin(), 2));
+            assert_ok!(Configuration::set_collators_per_container(root_origin(), 3));
+
+            // Check invariant for all intermediate assignments. We set collators_per_container = 3
+            // but we also set max_collators = 2, so no collators will be assigned to container
+            // chains after the change is applied.
+            for session in 1..=4 {
+                run_to_session(session);
+
+                let assignment = CollatorAssignment::collator_container_chain();
+                assert!(
+                    assignment.container_chains[&1001u32.into()].len() <= 2,
+                    "session {}: {} collators assigned to container chain 1001",
+                    session,
+                    assignment.container_chains[&1001u32.into()].len()
+                );
+            }
+
+            // Final assignment: because max_collators = 2, there are only 2 collators, one in
+            // orchestrator chain, and the other one idle
+            let assignment = CollatorAssignment::collator_container_chain();
+            assert_eq!(assignment.container_chains[&1001u32.into()].len(), 0);
+            assert_eq!(assignment.orchestrator_chain.len(), 1);
+        });
+}


### PR DESCRIPTION
In `pallet_collator_assignment`, we use the pending config values to ensure that the current assignment always matches the current configuration state. So, if we change the value of `collators_per_container`, when the change is reflected in `configuration.config`, we should see that the number of collators per container in `pallet_collator_assignment` has also changed.

However we were not doing that with the value of `max_collators`, we were using the current value instead of the pending one. This PR fixes that.