### PR TITLE
put all pallet constants as constant

### DIFF
--- a/pallets/authority-mapping/src/lib.rs
+++ b/pallets/authority-mapping/src/lib.rs
@@ -53,6 +53,7 @@ pub mod pallet {
         type SessionIndex: parity_scale_codec::FullCodec + TypeInfo + Copy + AtLeast32BitUnsigned;
 
         // Sessions after which keys should be removed
+        #[pallet::constant]
         type SessionRemovalBoundary: Get<Self::SessionIndex>;
 
         type AuthorityId: Member

--- a/pallets/configuration/src/lib.rs
+++ b/pallets/configuration/src/lib.rs
@@ -170,6 +170,7 @@ pub mod pallet {
         // `SESSION_DELAY` is used to delay any changes to Paras registration or configurations.
         // Wait until the session index is 2 larger then the current index to apply any changes,
         // which guarantees that at least one full session has passed before any changes are applied.
+        #[pallet::constant]
         type SessionDelay: Get<Self::SessionIndex>;
 
         type CurrentSessionIndex: GetSessionIndex<Self::SessionIndex>;

--- a/pallets/data-preservers/src/lib.rs
+++ b/pallets/data-preservers/src/lib.rs
@@ -99,7 +99,9 @@ pub mod pallet {
         // Who can call set_boot_nodes?
         type SetBootNodesOrigin: EnsureOriginWithArg<Self::RuntimeOrigin, ParaId>;
 
+        #[pallet::constant]
         type MaxBootNodes: Get<u32>;
+        #[pallet::constant]
         type MaxBootNodeUrlLen: Get<u32>;
 
         type WeightInfo: WeightInfo;

--- a/pallets/inflation-rewards/src/lib.rs
+++ b/pallets/inflation-rewards/src/lib.rs
@@ -139,18 +139,21 @@ pub mod pallet {
         type GetSelfChainBlockAuthor: Get<Self::AccountId>;
 
         /// Inflation rate per orchestrator block (proportion of the total issuance)
+        #[pallet::constant]
         type InflationRate: Get<Perbill>;
 
         /// What to do with the new supply not dedicated to staking
         type OnUnbalanced: OnUnbalanced<CreditOf<Self>>;
 
         /// The account that will store rewards waiting to be paid out
+        #[pallet::constant]
         type PendingRewardsAccount: Get<Self::AccountId>;
 
         /// Staking rewards distribution implementation
         type StakingRewardsDistributor: DistributeRewards<Self::AccountId, CreditOf<Self>>;
 
         /// Proportion of the new supply dedicated to staking
+        #[pallet::constant]
         type RewardsPortion: Get<Perbill>;
     }
 
@@ -209,7 +212,7 @@ pub mod pallet {
                             balance: chains_to_reward.rewards_per_chain,
                         });
 
-                        if let Some(weight) = actual_weight {
+                        if let Some(weight) = actual_weight {   
                             total_weight += weight
                         }
                     }

--- a/pallets/inflation-rewards/src/lib.rs
+++ b/pallets/inflation-rewards/src/lib.rs
@@ -212,7 +212,7 @@ pub mod pallet {
                             balance: chains_to_reward.rewards_per_chain,
                         });
 
-                        if let Some(weight) = actual_weight {   
+                        if let Some(weight) = actual_weight {
                             total_weight += weight
                         }
                     }

--- a/pallets/invulnerables/src/lib.rs
+++ b/pallets/invulnerables/src/lib.rs
@@ -84,6 +84,7 @@ pub mod pallet {
         type UpdateOrigin: EnsureOrigin<Self::RuntimeOrigin>;
 
         /// Maximum number of invulnerables.
+        #[pallet::constant]
         type MaxInvulnerables: Get<u32>;
 
         /// A stable ID for a collator.

--- a/pallets/pooled-staking/src/lib.rs
+++ b/pallets/pooled-staking/src/lib.rs
@@ -249,22 +249,27 @@ pub mod pallet {
         type Balance: Balance + MulDiv;
 
         /// Account holding Currency of all delegators.
+        #[pallet::constant]
         type StakingAccount: Get<Self::AccountId>;
 
         /// When creating the first Shares for a candidate the supply can be arbitrary.
         /// Picking a value too low will make an higher supply, which means each share will get
         /// less rewards, and rewards calculations will have more impactful rounding errors.
         /// Picking a value too high is a barrier of entry for staking.
+        #[pallet::constant]
         type InitialManualClaimShareValue: Get<Self::Balance>;
         /// When creating the first Shares for a candidate the supply can arbitrary.
         /// Picking a value too high is a barrier of entry for staking, which will increase overtime
         /// as the value of each share will increase due to auto compounding.
+        #[pallet::constant]
         type InitialAutoCompoundingShareValue: Get<Self::Balance>;
 
         /// Minimum amount of stake a Candidate must delegate (stake) towards itself. Not reaching
         /// this minimum prevents from being elected.
+        #[pallet::constant]
         type MinimumSelfDelegation: Get<Self::Balance>;
         /// Part of the rewards that will be sent exclusively to the collator.
+        #[pallet::constant]
         type RewardsCollatorCommission: Get<Perbill>;
 
         /// The overarching runtime hold reason.
@@ -279,6 +284,7 @@ pub mod pallet {
         /// could fall out of this list if they have less stake than the top `EligibleCandidatesBufferSize`
         /// eligible candidates. One of this top candidates leaving will then not bring the dropped candidate
         /// in the list. An extrinsic is available to manually bring back such dropped candidate.
+        #[pallet::constant]
         type EligibleCandidatesBufferSize: Get<u32>;
         /// Additional filter for candidates to be eligible.
         type EligibleCandidatesFilter: IsCandidateEligible<Self::AccountId>;

--- a/pallets/registrar/src/lib.rs
+++ b/pallets/registrar/src/lib.rs
@@ -127,6 +127,7 @@ pub mod pallet {
         #[pallet::constant]
         type MaxGenesisDataSize: Get<u32>;
 
+        #[pallet::constant]
         type MaxLengthTokenSymbol: Get<u32>;
 
         type SessionIndex: parity_scale_codec::FullCodec + TypeInfo + Copy + AtLeast32BitUnsigned;

--- a/pallets/services-payment/src/lib.rs
+++ b/pallets/services-payment/src/lib.rs
@@ -73,9 +73,11 @@ pub mod pallet {
         type ProvideCollatorAssignmentCost: ProvideCollatorAssignmentCost<Self>;
 
         /// The maximum number of block production credits that can be accumulated
+        #[pallet::constant]
         type FreeBlockProductionCredits: Get<BlockNumberFor<Self>>;
 
         /// The maximum number of collator assigment production credits that can be accumulated
+        #[pallet::constant]
         type FreeCollatorAssignmentCredits: Get<u32>;
         // Who can call set_refund_address?
         type SetRefundAddressOrigin: EnsureOriginWithArg<Self::RuntimeOrigin, ParaId>;

--- a/pallets/xcm-core-buyer/src/lib.rs
+++ b/pallets/xcm-core-buyer/src/lib.rs
@@ -83,6 +83,7 @@ pub mod pallet {
             + PartialEq
             + sp_std::fmt::Debug;
         /// Limit how many in-flight XCM requests can be sent to the relay chain in one block.
+        #[pallet::constant]
         type MaxParathreads: Get<u32>;
         /// Get the parathread params. Used to verify that the para id is a parathread.
         // TODO: and in the future to restrict the ability to buy a core depending on slot frequency

--- a/typescript-api/src/dancebox/interfaces/augment-api-consts.ts
+++ b/typescript-api/src/dancebox/interfaces/augment-api-consts.ts
@@ -8,7 +8,7 @@ import "@polkadot/api-base/types/consts";
 import type { ApiTypes, AugmentedConst } from "@polkadot/api-base/types";
 import type { Option, u128, u16, u32, u64, u8 } from "@polkadot/types-codec";
 import type { Codec } from "@polkadot/types-codec/types";
-import type { Permill } from "@polkadot/types/interfaces/runtime";
+import type { AccountId32, Perbill, Permill } from "@polkadot/types/interfaces/runtime";
 import type {
     FrameSupportPalletId,
     FrameSystemLimitsBlockLength,
@@ -25,6 +25,11 @@ declare module "@polkadot/api-base/types/consts" {
         asyncBacking: {
             /** Purely informative, but used by mocking tools like chospticks to allow knowing how to mock blocks */
             expectedBlockTime: u64 & AugmentedConst<ApiType>;
+            /** Generic const */
+            [key: string]: Codec;
+        };
+        authorityMapping: {
+            sessionRemovalBoundary: u32 & AugmentedConst<ApiType>;
             /** Generic const */
             [key: string]: Codec;
         };
@@ -47,6 +52,17 @@ declare module "@polkadot/api-base/types/consts" {
             maxLocks: u32 & AugmentedConst<ApiType>;
             /** The maximum number of named reserves that can exist on an account. */
             maxReserves: u32 & AugmentedConst<ApiType>;
+            /** Generic const */
+            [key: string]: Codec;
+        };
+        configuration: {
+            sessionDelay: u32 & AugmentedConst<ApiType>;
+            /** Generic const */
+            [key: string]: Codec;
+        };
+        dataPreservers: {
+            maxBootNodes: u32 & AugmentedConst<ApiType>;
+            maxBootNodeUrlLen: u32 & AugmentedConst<ApiType>;
             /** Generic const */
             [key: string]: Codec;
         };
@@ -96,6 +112,22 @@ declare module "@polkadot/api-base/types/consts" {
             /** Generic const */
             [key: string]: Codec;
         };
+        inflationRewards: {
+            /** Inflation rate per orchestrator block (proportion of the total issuance) */
+            inflationRate: Perbill & AugmentedConst<ApiType>;
+            /** The account that will store rewards waiting to be paid out */
+            pendingRewardsAccount: AccountId32 & AugmentedConst<ApiType>;
+            /** Proportion of the new supply dedicated to staking */
+            rewardsPortion: Perbill & AugmentedConst<ApiType>;
+            /** Generic const */
+            [key: string]: Codec;
+        };
+        invulnerables: {
+            /** Maximum number of invulnerables. */
+            maxInvulnerables: u32 & AugmentedConst<ApiType>;
+            /** Generic const */
+            [key: string]: Codec;
+        };
         messageQueue: {
             /**
              * The size of the page; this implies the maximum message size which can be sent.
@@ -139,6 +171,37 @@ declare module "@polkadot/api-base/types/consts" {
             /** Generic const */
             [key: string]: Codec;
         };
+        pooledStaking: {
+            /**
+             * All eligible candidates are stored in a sorted list that is modified each time delegations changes. It is safer
+             * to bound this list, in which case eligible candidate could fall out of this list if they have less stake than
+             * the top `EligibleCandidatesBufferSize` eligible candidates. One of this top candidates leaving will then not
+             * bring the dropped candidate in the list. An extrinsic is available to manually bring back such dropped candidate.
+             */
+            eligibleCandidatesBufferSize: u32 & AugmentedConst<ApiType>;
+            /**
+             * When creating the first Shares for a candidate the supply can arbitrary. Picking a value too high is a barrier
+             * of entry for staking, which will increase overtime as the value of each share will increase due to auto compounding.
+             */
+            initialAutoCompoundingShareValue: u128 & AugmentedConst<ApiType>;
+            /**
+             * When creating the first Shares for a candidate the supply can be arbitrary. Picking a value too low will make
+             * an higher supply, which means each share will get less rewards, and rewards calculations will have more
+             * impactful rounding errors. Picking a value too high is a barrier of entry for staking.
+             */
+            initialManualClaimShareValue: u128 & AugmentedConst<ApiType>;
+            /**
+             * Minimum amount of stake a Candidate must delegate (stake) towards itself. Not reaching this minimum prevents
+             * from being elected.
+             */
+            minimumSelfDelegation: u128 & AugmentedConst<ApiType>;
+            /** Part of the rewards that will be sent exclusively to the collator. */
+            rewardsCollatorCommission: Perbill & AugmentedConst<ApiType>;
+            /** Account holding Currency of all delegators. */
+            stakingAccount: AccountId32 & AugmentedConst<ApiType>;
+            /** Generic const */
+            [key: string]: Codec;
+        };
         proxy: {
             /**
              * The base amount of currency needed to reserve for creating an announcement.
@@ -179,6 +242,7 @@ declare module "@polkadot/api-base/types/consts" {
             maxGenesisDataSize: u32 & AugmentedConst<ApiType>;
             /** Max length of para id list */
             maxLengthParaIds: u32 & AugmentedConst<ApiType>;
+            maxLengthTokenSymbol: u32 & AugmentedConst<ApiType>;
             sessionDelay: u32 & AugmentedConst<ApiType>;
             /** Generic const */
             [key: string]: Codec;
@@ -190,6 +254,14 @@ declare module "@polkadot/api-base/types/consts" {
              * `RelayStorageRoots` mapping.
              */
             maxStorageRoots: u32 & AugmentedConst<ApiType>;
+            /** Generic const */
+            [key: string]: Codec;
+        };
+        servicesPayment: {
+            /** The maximum number of block production credits that can be accumulated */
+            freeBlockProductionCredits: u32 & AugmentedConst<ApiType>;
+            /** The maximum number of collator assigment production credits that can be accumulated */
+            freeCollatorAssignmentCredits: u32 & AugmentedConst<ApiType>;
             /** Generic const */
             [key: string]: Codec;
         };
@@ -295,6 +367,8 @@ declare module "@polkadot/api-base/types/consts" {
             [key: string]: Codec;
         };
         xcmCoreBuyer: {
+            /** Limit how many in-flight XCM requests can be sent to the relay chain in one block. */
+            maxParathreads: u32 & AugmentedConst<ApiType>;
             /**
              * A configuration for base priority of unsigned transactions.
              *

--- a/typescript-api/src/flashbox/interfaces/augment-api-consts.ts
+++ b/typescript-api/src/flashbox/interfaces/augment-api-consts.ts
@@ -8,7 +8,7 @@ import "@polkadot/api-base/types/consts";
 import type { ApiTypes, AugmentedConst } from "@polkadot/api-base/types";
 import type { Option, u128, u16, u32, u64, u8 } from "@polkadot/types-codec";
 import type { Codec } from "@polkadot/types-codec/types";
-import type { Permill } from "@polkadot/types/interfaces/runtime";
+import type { AccountId32, Perbill, Permill } from "@polkadot/types/interfaces/runtime";
 import type {
     FrameSupportPalletId,
     FrameSystemLimitsBlockLength,
@@ -24,6 +24,11 @@ declare module "@polkadot/api-base/types/consts" {
         asyncBacking: {
             /** Purely informative, but used by mocking tools like chospticks to allow knowing how to mock blocks */
             expectedBlockTime: u64 & AugmentedConst<ApiType>;
+            /** Generic const */
+            [key: string]: Codec;
+        };
+        authorityMapping: {
+            sessionRemovalBoundary: u32 & AugmentedConst<ApiType>;
             /** Generic const */
             [key: string]: Codec;
         };
@@ -49,6 +54,17 @@ declare module "@polkadot/api-base/types/consts" {
             /** Generic const */
             [key: string]: Codec;
         };
+        configuration: {
+            sessionDelay: u32 & AugmentedConst<ApiType>;
+            /** Generic const */
+            [key: string]: Codec;
+        };
+        dataPreservers: {
+            maxBootNodes: u32 & AugmentedConst<ApiType>;
+            maxBootNodeUrlLen: u32 & AugmentedConst<ApiType>;
+            /** Generic const */
+            [key: string]: Codec;
+        };
         identity: {
             /** The amount held on deposit for a registered identity. */
             basicDeposit: u128 & AugmentedConst<ApiType>;
@@ -70,6 +86,22 @@ declare module "@polkadot/api-base/types/consts" {
              * size of an account ID plus 32 bytes.
              */
             subAccountDeposit: u128 & AugmentedConst<ApiType>;
+            /** Generic const */
+            [key: string]: Codec;
+        };
+        inflationRewards: {
+            /** Inflation rate per orchestrator block (proportion of the total issuance) */
+            inflationRate: Perbill & AugmentedConst<ApiType>;
+            /** The account that will store rewards waiting to be paid out */
+            pendingRewardsAccount: AccountId32 & AugmentedConst<ApiType>;
+            /** Proportion of the new supply dedicated to staking */
+            rewardsPortion: Perbill & AugmentedConst<ApiType>;
+            /** Generic const */
+            [key: string]: Codec;
+        };
+        invulnerables: {
+            /** Maximum number of invulnerables. */
+            maxInvulnerables: u32 & AugmentedConst<ApiType>;
             /** Generic const */
             [key: string]: Codec;
         };
@@ -132,6 +164,7 @@ declare module "@polkadot/api-base/types/consts" {
             maxGenesisDataSize: u32 & AugmentedConst<ApiType>;
             /** Max length of para id list */
             maxLengthParaIds: u32 & AugmentedConst<ApiType>;
+            maxLengthTokenSymbol: u32 & AugmentedConst<ApiType>;
             sessionDelay: u32 & AugmentedConst<ApiType>;
             /** Generic const */
             [key: string]: Codec;
@@ -143,6 +176,14 @@ declare module "@polkadot/api-base/types/consts" {
              * `RelayStorageRoots` mapping.
              */
             maxStorageRoots: u32 & AugmentedConst<ApiType>;
+            /** Generic const */
+            [key: string]: Codec;
+        };
+        servicesPayment: {
+            /** The maximum number of block production credits that can be accumulated */
+            freeBlockProductionCredits: u32 & AugmentedConst<ApiType>;
+            /** The maximum number of collator assigment production credits that can be accumulated */
+            freeCollatorAssignmentCredits: u32 & AugmentedConst<ApiType>;
             /** Generic const */
             [key: string]: Codec;
         };


### PR DESCRIPTION
Exposes pallet constants as constants so that they are accessible through polkadotJs