### PR TITLE
Fix calculation of Auto compounding delegation of candidate

### DIFF
--- a/test/suites/smoke-test-dancebox/test-staking-consistency.ts
+++ b/test/suites/smoke-test-dancebox/test-staking-consistency.ts
@@ -49,13 +49,31 @@ describeSuite({
                         })
                     ).toBigInt();
 
-                    const auto = (
+                    const autoCompoundingSharesTotalStaked = (
                         await api.query.pooledStaking.pools(candidate, {
-                            AutoCompoundingSharesHeldStake: {
+                            AutoCompoundingSharesTotalStaked: {},
+                        })
+                    ).toBigInt();
+
+                    const autoCompoundingSharesSupply = (
+                        await api.query.pooledStaking.pools(candidate, {
+                            AutoCompoundingSharesSupply: {},
+                        })
+                    ).toBigInt();
+
+                    const autoCompoundingSharesOfCandidate = (
+                        await api.query.pooledStaking.pools(candidate, {
+                            AutoCompoundingShares: {
                                 delegator: candidate,
                             },
                         })
                     ).toBigInt();
+
+                    // auto stake is calculated using this method as the AutoCompoundingSharesHeldStake is not updated with rewards received
+                    // by the candidate, rather the number of shares of candidate increases.
+                    const auto =
+                        (autoCompoundingSharesOfCandidate * autoCompoundingSharesTotalStaked) /
+                        autoCompoundingSharesSupply;
 
                     const manual = (
                         await api.query.pooledStaking.pools(candidate, {

--- a/test/suites/smoke-test-dancebox/test-staking-consistency.ts
+++ b/test/suites/smoke-test-dancebox/test-staking-consistency.ts
@@ -70,7 +70,7 @@ describeSuite({
                     ).toBigInt();
 
                     // auto stake is calculated using this method as the AutoCompoundingSharesHeldStake is not updated with rewards received
-                    // by the candidate, rather the number of shares of candidate increases.
+                    // by the candidate, rather the value of each share of candidate increases.
                     const auto =
                         (autoCompoundingSharesOfCandidate * autoCompoundingSharesTotalStaked) /
                         autoCompoundingSharesSupply;


### PR DESCRIPTION
## Description
Currently, we are calculating delegation amount of candidate (referred to as delegator in this scenario) in the auto compounding pool by simply querying `AutoCompoundingSharesHeldStake` which is not updated against rewards earned by that delegator as the rewards simply increases value of each shares. 

This PR attempts to correct this by calculating delegation of delegator in auto compounding pool by:
 ```
(shares of delegator in auto pool * (total staked amount in auto pool / total supply of shares in auto pool);
```