### PR TITLE
Fix Cargo.lock and add script to check for duplicate git dependencies

### DIFF
--- a/.github/scripts/check_duplicate_git_dependencies.sh
+++ b/.github/scripts/check_duplicate_git_dependencies.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Find duplicate git dependencies in Cargo.lock
+# This can happen because in Cargo.toml we only specify the branch name, so if
+# a new commit gets pushed to the branch, the Cargo.lock will be out of sync.
+# In that case we need to manually run cargo update or edit the Cargo.lock file
+# using search and replace.
+# Then after a merge conflict, it can happen that not all crates have been updated.
+
+# Always run the commands from the "tanssi" dir
+cd $(dirname $0)/../..
+
+# Extract dependencies, sort them uniquely
+deps=$(grep "source = \"git\+" Cargo.lock | sort -u)
+
+# Extract the base URLs before any query parameters or fragments
+base_urls=$(echo "$deps" | sed -E 's|^(source = "git\+https://[^?#"]+)[^"]*|\1|')
+
+# Check for duplicate base URLs
+duplicates=$(echo "$base_urls" | sort | uniq -d)
+
+if [[ -n $duplicates ]]; then
+    echo "Error: Duplicate dependencies found with the same URL:"
+    echo "$duplicates"
+    echo ""
+    echo "All git dependencies:"
+    echo "$deps"
+    echo ""
+    echo "Help: use this command to update polkadot-sdk to the latest commit:"
+    echo "cargo update -p sp_core"
+    exit 1
+else
+    echo "No duplicates found. All good!"
+fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,6 +114,9 @@ jobs:
             - name: Setup Rust toolchain
               run: rustup show
 
+            - name: Check for duplicate git dependencies
+              run: ./.github/scripts/check_duplicate_git_dependencies.sh
+
             - name: Find toml files with lints key not set
               run: ./.github/scripts/check_toml_lints.sh
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,7 +433,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "asset-test-utils"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "assets-common",
  "cumulus-pallet-parachain-system",
@@ -468,7 +468,7 @@ dependencies = [
 [[package]]
 name = "assets-common"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -788,7 +788,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "hash-db",
  "log",
@@ -1013,7 +1013,7 @@ dependencies = [
 [[package]]
 name = "bp-header-chain"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "bp-runtime",
  "finality-grandpa",
@@ -1030,7 +1030,7 @@ dependencies = [
 [[package]]
 name = "bp-messages"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -1045,7 +1045,7 @@ dependencies = [
 [[package]]
 name = "bp-parachains"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
@@ -1062,7 +1062,7 @@ dependencies = [
 [[package]]
 name = "bp-polkadot-core"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1080,7 +1080,7 @@ dependencies = [
 [[package]]
 name = "bp-relayers"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1094,7 +1094,7 @@ dependencies = [
 [[package]]
 name = "bp-runtime"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1117,7 +1117,7 @@ dependencies = [
 [[package]]
 name = "bp-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -1137,7 +1137,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "sp-std",
 ]
@@ -1145,7 +1145,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1156,7 +1156,7 @@ dependencies = [
 [[package]]
 name = "bridge-runtime-common"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -2301,7 +2301,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -2318,7 +2318,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -2341,7 +2341,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -2383,7 +2383,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -2412,7 +2412,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-proposer"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2427,7 +2427,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -2450,7 +2450,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2474,7 +2474,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2498,7 +2498,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -2534,7 +2534,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-dmp-queue"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "cumulus-primitives-core",
  "frame-benchmarking",
@@ -2597,7 +2597,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
 version = "3.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2611,7 +2611,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2627,7 +2627,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
@@ -2652,7 +2652,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2708,7 +2708,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "cumulus-primitives-core",
  "futures 0.3.30",
@@ -2721,7 +2721,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2741,7 +2741,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2783,7 +2783,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "array-bytes 6.2.2",
  "async-trait",
@@ -2824,7 +2824,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2863,7 +2863,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -3582,7 +3582,7 @@ dependencies = [
 [[package]]
 name = "emulated-integration-tests-common"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "asset-test-utils",
  "bp-messages",
@@ -4530,7 +4530,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "Inflector",
  "array-bytes 6.2.2",
@@ -4606,7 +4606,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4636,7 +4636,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "futures 0.3.30",
  "indicatif",
@@ -4759,7 +4759,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4774,7 +4774,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -4783,7 +4783,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -6802,7 +6802,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "futures 0.3.30",
  "log",
@@ -6821,7 +6821,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "anyhow",
  "jsonrpsee",
@@ -7598,7 +7598,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7616,7 +7616,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7631,7 +7631,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7649,7 +7649,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7833,7 +7833,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "aquamarine",
  "docify",
@@ -7884,7 +7884,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7904,7 +7904,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "array-bytes 6.2.2",
  "binary-merkle-tree",
@@ -7929,7 +7929,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7947,7 +7947,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-grandpa"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -7968,7 +7968,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-messages"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -7986,7 +7986,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-parachains"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -8007,7 +8007,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-relayers"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "bp-messages",
  "bp-relayers",
@@ -8073,7 +8073,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8124,7 +8124,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "3.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8143,7 +8143,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8178,7 +8178,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -8219,7 +8219,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8237,7 +8237,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8260,7 +8260,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8274,7 +8274,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "5.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8491,7 +8491,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8529,7 +8529,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8568,7 +8568,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -8585,7 +8585,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8605,7 +8605,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8698,7 +8698,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8754,7 +8754,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8772,7 +8772,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8788,7 +8788,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8804,7 +8804,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8823,7 +8823,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8843,7 +8843,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -8854,7 +8854,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8871,7 +8871,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8919,7 +8919,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8936,7 +8936,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8951,7 +8951,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8969,7 +8969,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8984,7 +8984,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -9059,7 +9059,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "1.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9074,7 +9074,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9134,7 +9134,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9151,7 +9151,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9192,7 +9192,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -9203,7 +9203,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -9212,7 +9212,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9222,7 +9222,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9263,7 +9263,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9299,7 +9299,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9318,7 +9318,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -9350,7 +9350,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -9362,7 +9362,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9381,7 +9381,7 @@ dependencies = [
 [[package]]
 name = "pallet-tx-pause"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9399,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9430,7 +9430,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9445,7 +9445,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -9468,7 +9468,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9487,7 +9487,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub-router"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "bp-xcm-bridge-hub-router",
  "frame-benchmarking",
@@ -9549,7 +9549,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -9586,7 +9586,7 @@ dependencies = [
 [[package]]
 name = "parachains-runtimes-test-utils"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "assets-common",
  "cumulus-pallet-parachain-system",
@@ -9939,7 +9939,7 @@ checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
 [[package]]
 name = "polkadot-approval-distribution"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "bitvec",
  "futures 0.3.30",
@@ -9959,7 +9959,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "always-assert",
  "futures 0.3.30",
@@ -9975,7 +9975,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "derive_more",
  "fatality",
@@ -9998,7 +9998,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "async-trait",
  "fatality",
@@ -10021,7 +10021,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "1.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "cfg-if",
  "clap",
@@ -10049,7 +10049,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10083,7 +10083,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "derive_more",
  "fatality",
@@ -10108,7 +10108,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -10122,7 +10122,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "futures 0.3.30",
  "futures-timer",
@@ -10143,7 +10143,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -10166,7 +10166,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "futures 0.3.30",
  "parity-scale-codec",
@@ -10184,7 +10184,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -10217,7 +10217,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "bitvec",
  "futures 0.3.30",
@@ -10239,7 +10239,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10258,7 +10258,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "futures 0.3.30",
  "polkadot-node-subsystem",
@@ -10273,7 +10273,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "async-trait",
  "futures 0.3.30",
@@ -10294,7 +10294,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "futures 0.3.30",
  "polkadot-node-metrics",
@@ -10308,7 +10308,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "futures 0.3.30",
  "futures-timer",
@@ -10325,7 +10325,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "fatality",
  "futures 0.3.30",
@@ -10344,7 +10344,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "async-trait",
  "futures 0.3.30",
@@ -10361,7 +10361,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10378,7 +10378,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10395,7 +10395,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "always-assert",
  "array-bytes 6.2.2",
@@ -10428,7 +10428,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "futures 0.3.30",
  "polkadot-node-primitives",
@@ -10444,7 +10444,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "cfg-if",
  "cpu-time",
@@ -10469,7 +10469,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "futures 0.3.30",
  "polkadot-node-metrics",
@@ -10568,7 +10568,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -10606,7 +10606,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -10706,7 +10706,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -10739,7 +10739,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -10853,7 +10853,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -10970,7 +10970,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "arrayvec 0.7.4",
  "bitvec",
@@ -11767,7 +11767,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "binary-merkle-tree",
  "frame-benchmarking",
@@ -11863,7 +11863,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -12164,7 +12164,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "futures 0.3.30",
  "futures-timer",
@@ -12359,7 +12359,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "async-trait",
  "futures 0.3.30",
@@ -12388,7 +12388,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -12423,7 +12423,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "futures 0.3.30",
  "jsonrpsee",
@@ -12445,7 +12445,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "array-bytes 6.2.2",
  "async-channel 1.9.0",
@@ -12480,7 +12480,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "futures 0.3.30",
  "jsonrpsee",
@@ -12499,7 +12499,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -12512,7 +12512,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "ahash 0.8.8",
  "array-bytes 6.2.2",
@@ -12554,7 +12554,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "finality-grandpa",
  "futures 0.3.30",
@@ -12574,7 +12574,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -12609,7 +12609,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "async-trait",
  "futures 0.3.30",
@@ -12828,7 +12828,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "ahash 0.8.8",
  "futures 0.3.30",
@@ -12904,7 +12904,7 @@ dependencies = [
 [[package]]
 name = "sc-network-test"
 version = "0.8.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "async-trait",
  "futures 0.3.30",
@@ -12954,7 +12954,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "array-bytes 6.2.2",
  "bytes",
@@ -12988,7 +12988,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -13167,7 +13167,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "clap",
  "fs4",
@@ -13180,7 +13180,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -13776,7 +13776,7 @@ dependencies = [
 [[package]]
 name = "slot-range-helper"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -14125,7 +14125,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -14375,7 +14375,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "ckb-merkle-mountain-range",
  "log",
@@ -14893,7 +14893,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-parachain-info"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -14925,7 +14925,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -15075,12 +15075,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.30",
@@ -15111,7 +15111,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -15124,7 +15124,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -15141,7 +15141,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "array-bytes 6.2.2",
  "async-trait",
@@ -15167,7 +15167,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "array-bytes 6.2.2",
  "frame-executive",
@@ -15208,7 +15208,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "futures 0.3.30",
  "sc-block-builder",
@@ -15226,7 +15226,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "ansi_term",
  "build-helper",
@@ -16162,7 +16162,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "async-trait",
  "clap",
@@ -16846,7 +16846,7 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 [[package]]
 name = "westend-runtime"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -16952,7 +16952,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -17331,7 +17331,7 @@ dependencies = [
 [[package]]
 name = "xcm-emulator"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",


### PR DESCRIPTION
For some reason we have 2 instances of polkadot-sdk with the same branch name but different commit hash. This PR fixes that and adds a bash script to detect this case in the future. This is the output of the script in master:

```
Error: Duplicate dependencies found with the same URL:
source = "git+https://github.com/moondance-labs/polkadot-sdk"

All git dependencies:
source = "git+https://github.com/kianenigma/simple-mermaid.git?rev=e48b187bcfd5cc75111acd9d241f1bd36604344b#e48b187bcfd5cc75111acd9d241f1bd36604344b"
source = "git+https://github.com/moondance-labs/dancekit?branch=tanssi-polkadot-v1.6.0#d377abf69ad58b3a2c7a143b4501f6c3b813d1ed"
source = "git+https://github.com/moondance-labs/frontier?branch=tanssi-polkadot-v1.6.0#4414529b910e8cf802969b11505a14665e4a55d1"
source = "git+https://github.com/moondance-labs/jsonrpsee?branch=tanssi-polkadot-v1.1.0#d6435421dba9d33886251d07c27c40403c954fa3"
source = "git+https://github.com/moondance-labs/moonkit?branch=tanssi-polkadot-v1.6.0#8179e4329c8a5a4ea55cd1d7bd9fa0d293e964b0"
source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#49f36c06480dc6db9d8a4f06e0c4bcc4d8c4d18d"
source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#9e728156cabd8f4b62492e9ecb2715f574323a90"

Help: use this command to update polkadot-sdk to the latest commit:
cargo update -p sp_core
```