### PR TITLE
Fix compile-wasm script

### DIFF
--- a/test/scripts/compile-wasm.ts
+++ b/test/scripts/compile-wasm.ts
@@ -78,21 +78,10 @@ async function main(args: any) {
     await fs.mkdir("tmp", { recursive: true });
     const tmpDir = await fs.mkdtemp("tmp/base-path");
     try {
-        // Generate plain chain spec
-        const generateChainSpecCmd = `${binaryPath} build-spec --chain ${args.argv.Chain} > tmp/${args.argv.Chain}.json`;
-        console.log(`🗃️  ${generateChainSpecCmd}`);
-        await spawn(generateChainSpecCmd);
-
-        // Generate raw chain spec
-        const generateRawChainSpecCmd =
-            `${binaryPath} build-spec --chain tmp/${args.argv.Chain}.json ` + `--raw > tmp/${args.argv.Chain}-raw.json`;
-        console.log(`🗃️  ${generateRawChainSpecCmd}`);
-        await spawn(generateRawChainSpecCmd);
-
         // Generate precompiled wasm
         const command =
             `${binaryPath} precompile-wasm --log=wasmtime-runtime --base-path=${tmpDir} ` +
-            `--chain tmp/${args.argv.Chain}-raw.json ${outputDirectory}`;
+            `--chain ${args.argv.Chain} ${outputDirectory}`;
         console.log(`🗃️  ${command}`);
         await spawn(command);
     } finally {

--- a/test/scripts/compile-wasm.ts
+++ b/test/scripts/compile-wasm.ts
@@ -78,12 +78,34 @@ async function main(args: any) {
     await fs.mkdir("tmp", { recursive: true });
     const tmpDir = await fs.mkdtemp("tmp/base-path");
     try {
-        // Generate precompiled wasm
-        const command =
-            `${binaryPath} precompile-wasm --log=wasmtime-runtime --base-path=${tmpDir} ` +
-            `--chain ${args.argv.Chain} ${outputDirectory}`;
-        console.log(`🗃️  ${command}`);
-        await spawn(command);
+        if (args.argv.Chain.endsWith(".json")) {
+            // Do not generate chain spec if Chain argument is already a chain spec
+            // Generate precompiled wasm
+            const command =
+                `${binaryPath} precompile-wasm --log=wasmtime-runtime --base-path=${tmpDir} ` +
+                `--chain ${args.argv.Chain} ${outputDirectory}`;
+            console.log(`🗃️  ${command}`);
+            await spawn(command);
+        } else {
+            // Generate plain chain spec
+            const generateChainSpecCmd = `${binaryPath} build-spec --chain ${args.argv.Chain} > tmp/${args.argv.Chain}.json`;
+            console.log(`🗃️  ${generateChainSpecCmd}`);
+            await spawn(generateChainSpecCmd);
+
+            // Generate raw chain spec
+            const generateRawChainSpecCmd =
+                `${binaryPath} build-spec --chain tmp/${args.argv.Chain}.json ` +
+                `--raw > tmp/${args.argv.Chain}-raw.json`;
+            console.log(`🗃️  ${generateRawChainSpecCmd}`);
+            await spawn(generateRawChainSpecCmd);
+
+            // Generate precompiled wasm
+            const command =
+                `${binaryPath} precompile-wasm --log=wasmtime-runtime --base-path=${tmpDir} ` +
+                `--chain tmp/${args.argv.Chain}-raw.json ${outputDirectory}`;
+            console.log(`🗃️  ${command}`);
+            await spawn(command);
+        }
     } finally {
         if ((await fs.stat(tmpDir)).isDirectory()) {
             await fs.rm(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
Do not generate raw chain spec when the argument is already a json chain spec.

Fixes this error that we see in CI:

```
Error: /bin/sh: 1: cannot create tmp/specs/parathreads-tanssi-1000.json.json: Directory nonexistent
```

The error breaks the wasm compilation step, but that's only an optimization, so tests will still pass without the precompiled wasm.

Caused by #469

I hope this doesn't revert the improvements from that PR...