### PR TITLE
Avoid executing html in download polkadot script

### DIFF
--- a/test/scripts/download-polkadot.sh
+++ b/test/scripts/download-polkadot.sh
@@ -3,19 +3,33 @@
 # Exit on any error
 set -e
 
-# Grab Polkadot version
-branch=$(egrep -o '/polkadot.*#([^\"]*)' $(dirname $0)/../../Cargo.lock | head -1 | sed 's/.*release-//#')
-polkadot_release=$(echo $branch | sed 's/#.*//' | sed 's/\/polkadot-sdk?branch=tanssi-polkadot-v//')
-
 # Always run the commands from the "test" dir
 cd $(dirname $0)/..
 
-if [[ -f tmp/polkadot ]]; then
+# Grab Polkadot version
+branch=$(egrep -o '/polkadot.*#([^\"]*)' ../Cargo.lock | head -1 | sed 's/.*release-//#')
+polkadot_release=$(echo $branch | sed 's/#.*//' | sed 's/\/polkadot-sdk?branch=tanssi-polkadot-v//')
+
+# There is a bug where moonwall saves a html file as an executable, and we try to execute that html file.
+# To avoid it, delete any files that are not executables according to "file".
+delete_if_not_binary() {
+	if [[ -f "$1" ]]; then
+		if ! file "$1" | grep -q 'executable'; then
+			rm "$1"
+		fi
+	fi
+}
+
+delete_if_not_binary tmp/polkadot
+delete_if_not_binary tmp/polkadot-execute-worker
+delete_if_not_binary tmp/polkadot-prepare-worker
+
+if [[ -f tmp/polkadot && -f tmp/polkadot-execute-worker && -f tmp/polkadot-prepare-worker ]]; then
 	POLKADOT_VERSION=$(tmp/polkadot --version)
 	if [[ $POLKADOT_VERSION == *$polkadot_release* ]]; then
 		exit 0
 	else
-		echo "Updating polkadot binary..."
+		echo "Updating polkadot binary from $POLKADOT_VERSION to $polkadot_release"
 
 		pnpm moonwall download polkadot $polkadot_release tmp
 		chmod +x tmp/polkadot
@@ -28,7 +42,7 @@ if [[ -f tmp/polkadot ]]; then
 
 	fi
 else
-	echo "Polkadot binary not found, downloading..."
+	echo "Polkadot binary not found, downloading $polkadot_release"
 	pnpm moonwall download polkadot $polkadot_release tmp
 	chmod +x tmp/polkadot
 


### PR DESCRIPTION
If the polkadot-sdk binary fails to download, an html error page is saved instead of the binary. And the script tries to execute that html page as if it was a binary, resulting in funny errors like:

```
tmp/polkadot: line 1: !DOCTYPE: No such file or directory
```

Example: https://github.com/moondance-labs/tanssi/actions/runs/8615938633/job/23613523615?pr=489

This PR fixes that by removing any files that are not executables. Note that unfortunately it can still happen that we save an html file as `tmp/polkadot`, but with this PR it will be fixed by running the tests again.