### PR TITLE
Stream payment deposit on opening a stream

### DIFF
--- a/pallets/stream-payment/src/lib.rs
+++ b/pallets/stream-payment/src/lib.rs
@@ -113,13 +113,6 @@ pub trait Assets<AccountId, AssetId, Balance> {
     fn bench_set_balance(asset_id: &AssetId, account: &AccountId, amount: Balance);
 }
 
-/// Interactions the pallet needs with assets.
-pub trait StreamCreationHook<AccountId, Get, StreamId> {
-    fn stream_opened(stream_id: StreamId, account: &AccountId) -> DispatchResult;
-
-    fn stream_closed(stream_id: StreamId, account: &AccountId) -> DispatchResult;
-}
-
 #[pallet]
 pub mod pallet {
     use super::*;

--- a/pallets/stream-payment/src/lib.rs
+++ b/pallets/stream-payment/src/lib.rs
@@ -155,6 +155,7 @@ pub mod pallet {
 
         type RuntimeHoldReason: From<HoldReason>;
 
+        #[pallet::constant]
         type OpenStreamHoldAmount: Get<Self::Balance>;
 
         /// Represents which units of time can be used. Designed to be an enum

--- a/pallets/stream-payment/src/mock.rs
+++ b/pallets/stream-payment/src/mock.rs
@@ -235,6 +235,10 @@ impl pallet_stream_payment::TimeProvider<TimeUnit, Balance> for TimeProvider {
     }
 }
 
+parameter_types! {
+    pub const OpenStreamHoldAmount: Balance = 100;
+}
+
 impl pallet_stream_payment::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type StreamId = u64;
@@ -242,6 +246,9 @@ impl pallet_stream_payment::Config for Runtime {
     type Balance = Balance;
     type AssetId = StreamPaymentAssetId;
     type Assets = StreamPaymentAssets;
+    type Currency = Balances;
+    type OpenStreamHoldAmount = OpenStreamHoldAmount;
+    type RuntimeHoldReason = RuntimeHoldReason;
     type TimeProvider = TimeProvider;
     type WeightInfo = ();
 }

--- a/pallets/stream-payment/src/tests.rs
+++ b/pallets/stream-payment/src/tests.rs
@@ -400,7 +400,7 @@ mod perform_payment {
             let opening_deposit = OpenStreamHoldAmount::get();
             let open_stream = OpenStream::default();
             assert_ok!(open_stream.call());
-            
+
             assert_balance_change!(-, ALICE, open_stream.deposit + opening_deposit);
             assert_eq!(get_deposit(ALICE), open_stream.deposit);
 
@@ -446,7 +446,7 @@ mod perform_payment {
                 ..default()
             };
             assert_ok!(open_stream.call());
-            
+
             assert_balance_change!(-, ALICE, open_stream.deposit + opening_deposit);
             assert_eq!(get_deposit(ALICE), open_stream.deposit);
 
@@ -496,7 +496,7 @@ mod perform_payment {
                 ..default()
             };
             assert_ok!(open_stream.call());
-            
+
             assert_balance_change!(-, ALICE, open_stream.deposit + opening_deposit);
             assert_eq!(get_deposit(ALICE), open_stream.deposit);
 
@@ -544,7 +544,7 @@ mod perform_payment {
                 ..default()
             };
             assert_ok!(open_stream.call());
-            
+
             assert_balance_change!(-, ALICE, open_stream.deposit + opening_deposit);
             assert_eq!(get_deposit(ALICE), open_stream.deposit);
 
@@ -589,9 +589,9 @@ mod perform_payment {
                 deposit: config.rate * 9,
                 ..default()
             };
-            
+
             assert_ok!(open_stream.call());
-            
+
             assert_balance_change!(-, ALICE, open_stream.deposit + opening_deposit);
             assert_eq!(get_deposit(ALICE), open_stream.deposit,);
 
@@ -638,7 +638,7 @@ mod perform_payment {
                 ..default()
             };
             assert_ok!(open_stream.call());
-            
+
             assert_balance_change!(-, ALICE, open_stream.deposit + opening_deposit);
             assert_eq!(get_deposit(ALICE), open_stream.deposit);
 
@@ -681,13 +681,13 @@ mod perform_payment {
                 time_unit: TimeUnit::Decreasing,
                 ..default_config()
             };
-            
+
             assert_ok!(OpenStream {
                 config,
                 ..default()
             }
             .call());
-        
+
             assert_balance_change!(-, ALICE, initial_deposit + opening_deposit);
             assert_eq!(get_deposit(ALICE), initial_deposit);
 

--- a/runtime/dancebox/src/lib.rs
+++ b/runtime/dancebox/src/lib.rs
@@ -1531,7 +1531,8 @@ impl pallet_stream_payment::TimeProvider<TimeUnit, Balance> for TimeProvider {
 type StreamId = u64;
 
 parameter_types! {
-    pub const OpenStreamHoldAmount: Balance = 100 * UNIT;
+    // 1 entry, storing 173 bytes on-chain
+    pub const OpenStreamHoldAmount: Balance = currency::deposit(1, 173);
 }
 
 impl pallet_stream_payment::Config for Runtime {

--- a/runtime/dancebox/src/lib.rs
+++ b/runtime/dancebox/src/lib.rs
@@ -1530,6 +1530,10 @@ impl pallet_stream_payment::TimeProvider<TimeUnit, Balance> for TimeProvider {
 
 type StreamId = u64;
 
+parameter_types! {
+    pub const OpenStreamHoldAmount: Balance = 100 * UNIT;
+}
+
 impl pallet_stream_payment::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type StreamId = StreamId;
@@ -1537,6 +1541,9 @@ impl pallet_stream_payment::Config for Runtime {
     type Balance = Balance;
     type AssetId = StreamPaymentAssetId;
     type Assets = StreamPaymentAssets;
+    type Currency = Balances;
+    type OpenStreamHoldAmount = OpenStreamHoldAmount;
+    type RuntimeHoldReason = RuntimeHoldReason;
     type TimeProvider = TimeProvider;
     type WeightInfo = ();
 }

--- a/runtime/flashbox/src/lib.rs
+++ b/runtime/flashbox/src/lib.rs
@@ -1284,6 +1284,10 @@ impl pallet_stream_payment::TimeProvider<TimeUnit, Balance> for TimeProvider {
 
 type StreamId = u64;
 
+parameter_types! {
+    pub const OpenStreamHoldAmount: Balance = 100 * UNIT;
+}
+
 impl pallet_stream_payment::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type StreamId = StreamId;
@@ -1291,6 +1295,9 @@ impl pallet_stream_payment::Config for Runtime {
     type Balance = Balance;
     type AssetId = StreamPaymentAssetId;
     type Assets = StreamPaymentAssets;
+    type Currency = Balances;
+    type OpenStreamHoldAmount = OpenStreamHoldAmount;
+    type RuntimeHoldReason = RuntimeHoldReason;
     type TimeProvider = TimeProvider;
     type WeightInfo = ();
 }

--- a/runtime/flashbox/src/lib.rs
+++ b/runtime/flashbox/src/lib.rs
@@ -1285,7 +1285,8 @@ impl pallet_stream_payment::TimeProvider<TimeUnit, Balance> for TimeProvider {
 type StreamId = u64;
 
 parameter_types! {
-    pub const OpenStreamHoldAmount: Balance = 100 * UNIT;
+    // 1 entry, storing 173 bytes on-chain
+    pub const OpenStreamHoldAmount: Balance = currency::deposit(1, 173);
 }
 
 impl pallet_stream_payment::Config for Runtime {

--- a/runtime/flashbox/src/lib.rs
+++ b/runtime/flashbox/src/lib.rs
@@ -403,7 +403,7 @@ impl pallet_balances::Config for Runtime {
     type MaxFreezes = ConstU32<10>;
     type RuntimeHoldReason = RuntimeHoldReason;
     type RuntimeFreezeReason = RuntimeFreezeReason;
-    type MaxHolds = ConstU32<1>;
+    type MaxHolds = ConstU32<10>;
     type WeightInfo = pallet_balances::weights::SubstrateWeight<Runtime>;
 }
 

--- a/test/suites/common-tanssi/stream-payment/test_stream_payment.ts
+++ b/test/suites/common-tanssi/stream-payment/test_stream_payment.ts
@@ -42,6 +42,12 @@ describeSuite({
                 });
                 expect(openStreamEvents.length).to.be.equal(1);
 
+                // Check opening storage hold
+                const openingHold = (await polkadotJs.query.balances.holds(alice.address)).find((h) =>
+                    h.id.value.eq("StreamOpened")
+                );
+                expect(openingHold.amount.toBigInt()).eq(11_730_000_000_000n);
+
                 // 2nd block
                 const txPerformPayment = await polkadotJs.tx.streamPayment
                     .performPayment(0)
@@ -100,6 +106,10 @@ describeSuite({
                     return a.event.method == "StreamClosed";
                 });
                 expect(closeStreamEvents.length).to.be.equal(1);
+
+                // Check all holds have been released
+                const holds = await polkadotJs.query.balances.holds(alice.address);
+                expect(holds.length).toBe(0);
             },
         });
     },

--- a/typescript-api/src/dancebox/interfaces/augment-api-consts.ts
+++ b/typescript-api/src/dancebox/interfaces/augment-api-consts.ts
@@ -265,6 +265,11 @@ declare module "@polkadot/api-base/types/consts" {
             /** Generic const */
             [key: string]: Codec;
         };
+        streamPayment: {
+            openStreamHoldAmount: u128 & AugmentedConst<ApiType>;
+            /** Generic const */
+            [key: string]: Codec;
+        };
         system: {
             /** Maximum number of block number to block hash mappings to keep (oldest pruned first). */
             blockHashCount: u32 & AugmentedConst<ApiType>;

--- a/typescript-api/src/dancebox/interfaces/lookup.ts
+++ b/typescript-api/src/dancebox/interfaces/lookup.ts
@@ -3516,11 +3516,11 @@ export default {
         source: "AccountId32",
         target: "AccountId32",
         config: "PalletStreamPaymentStreamConfig",
-        openingDeposit: "u128",
         deposit: "u128",
         lastTimeUpdated: "u128",
         requestNonce: "u32",
         pendingRequest: "Option<PalletStreamPaymentChangeRequest>",
+        openingDeposit: "u128",
     },
     /**
      * Lookup379: pallet_stream_payment::pallet::ChangeRequest<dancebox_runtime::TimeUnit,

--- a/typescript-api/src/dancebox/interfaces/lookup.ts
+++ b/typescript-api/src/dancebox/interfaces/lookup.ts
@@ -3456,7 +3456,7 @@ export default {
     },
     /** Lookup367: pallet_stream_payment::pallet::HoldReason */
     PalletStreamPaymentHoldReason: {
-        _enum: ["StreamPayment"],
+        _enum: ["StreamPayment", "StreamOpened"],
     },
     /** Lookup368: pallet_pooled_staking::pallet::HoldReason */
     PalletPooledStakingHoldReason: {
@@ -3516,6 +3516,7 @@ export default {
         source: "AccountId32",
         target: "AccountId32",
         config: "PalletStreamPaymentStreamConfig",
+        openingDeposit: "u128",
         deposit: "u128",
         lastTimeUpdated: "u128",
         requestNonce: "u32",

--- a/typescript-api/src/dancebox/interfaces/types-lookup.ts
+++ b/typescript-api/src/dancebox/interfaces/types-lookup.ts
@@ -4620,7 +4620,8 @@ declare module "@polkadot/types/lookup" {
     /** @name PalletStreamPaymentHoldReason (367) */
     interface PalletStreamPaymentHoldReason extends Enum {
         readonly isStreamPayment: boolean;
-        readonly type: "StreamPayment";
+        readonly isStreamOpened: boolean;
+        readonly type: "StreamPayment" | "StreamOpened";
     }
 
     /** @name PalletPooledStakingHoldReason (368) */
@@ -4685,6 +4686,7 @@ declare module "@polkadot/types/lookup" {
         readonly source: AccountId32;
         readonly target: AccountId32;
         readonly config: PalletStreamPaymentStreamConfig;
+        readonly openingDeposit: u128;
         readonly deposit: u128;
         readonly lastTimeUpdated: u128;
         readonly requestNonce: u32;

--- a/typescript-api/src/dancebox/interfaces/types-lookup.ts
+++ b/typescript-api/src/dancebox/interfaces/types-lookup.ts
@@ -4686,11 +4686,11 @@ declare module "@polkadot/types/lookup" {
         readonly source: AccountId32;
         readonly target: AccountId32;
         readonly config: PalletStreamPaymentStreamConfig;
-        readonly openingDeposit: u128;
         readonly deposit: u128;
         readonly lastTimeUpdated: u128;
         readonly requestNonce: u32;
         readonly pendingRequest: Option<PalletStreamPaymentChangeRequest>;
+        readonly openingDeposit: u128;
     }
 
     /** @name PalletStreamPaymentChangeRequest (379) */

--- a/typescript-api/src/flashbox/interfaces/augment-api-consts.ts
+++ b/typescript-api/src/flashbox/interfaces/augment-api-consts.ts
@@ -187,6 +187,11 @@ declare module "@polkadot/api-base/types/consts" {
             /** Generic const */
             [key: string]: Codec;
         };
+        streamPayment: {
+            openStreamHoldAmount: u128 & AugmentedConst<ApiType>;
+            /** Generic const */
+            [key: string]: Codec;
+        };
         system: {
             /** Maximum number of block number to block hash mappings to keep (oldest pruned first). */
             blockHashCount: u32 & AugmentedConst<ApiType>;

--- a/typescript-api/src/flashbox/interfaces/lookup.ts
+++ b/typescript-api/src/flashbox/interfaces/lookup.ts
@@ -1771,7 +1771,7 @@ export default {
     },
     /** Lookup261: pallet_stream_payment::pallet::HoldReason */
     PalletStreamPaymentHoldReason: {
-        _enum: ["StreamPayment"],
+        _enum: ["StreamPayment", "StreamOpened"],
     },
     /** Lookup264: pallet_balances::types::IdAmount<flashbox_runtime::RuntimeFreezeReason, Balance> */
     PalletBalancesIdAmountRuntimeFreezeReason: {
@@ -1827,6 +1827,7 @@ export default {
         source: "AccountId32",
         target: "AccountId32",
         config: "PalletStreamPaymentStreamConfig",
+        openingDeposit: "u128",
         deposit: "u128",
         lastTimeUpdated: "u128",
         requestNonce: "u32",

--- a/typescript-api/src/flashbox/interfaces/lookup.ts
+++ b/typescript-api/src/flashbox/interfaces/lookup.ts
@@ -1827,11 +1827,11 @@ export default {
         source: "AccountId32",
         target: "AccountId32",
         config: "PalletStreamPaymentStreamConfig",
-        openingDeposit: "u128",
         deposit: "u128",
         lastTimeUpdated: "u128",
         requestNonce: "u32",
         pendingRequest: "Option<PalletStreamPaymentChangeRequest>",
+        openingDeposit: "u128",
     },
     /**
      * Lookup272: pallet_stream_payment::pallet::ChangeRequest<flashbox_runtime::TimeUnit,

--- a/typescript-api/src/flashbox/interfaces/types-lookup.ts
+++ b/typescript-api/src/flashbox/interfaces/types-lookup.ts
@@ -2372,11 +2372,11 @@ declare module "@polkadot/types/lookup" {
         readonly source: AccountId32;
         readonly target: AccountId32;
         readonly config: PalletStreamPaymentStreamConfig;
-        readonly openingDeposit: u128;
         readonly deposit: u128;
         readonly lastTimeUpdated: u128;
         readonly requestNonce: u32;
         readonly pendingRequest: Option<PalletStreamPaymentChangeRequest>;
+        readonly openingDeposit: u128;
     }
 
     /** @name PalletStreamPaymentChangeRequest (272) */

--- a/typescript-api/src/flashbox/interfaces/types-lookup.ts
+++ b/typescript-api/src/flashbox/interfaces/types-lookup.ts
@@ -2312,7 +2312,8 @@ declare module "@polkadot/types/lookup" {
     /** @name PalletStreamPaymentHoldReason (261) */
     interface PalletStreamPaymentHoldReason extends Enum {
         readonly isStreamPayment: boolean;
-        readonly type: "StreamPayment";
+        readonly isStreamOpened: boolean;
+        readonly type: "StreamPayment" | "StreamOpened";
     }
 
     /** @name PalletBalancesIdAmountRuntimeFreezeReason (264) */
@@ -2371,6 +2372,7 @@ declare module "@polkadot/types/lookup" {
         readonly source: AccountId32;
         readonly target: AccountId32;
         readonly config: PalletStreamPaymentStreamConfig;
+        readonly openingDeposit: u128;
         readonly deposit: u128;
         readonly lastTimeUpdated: u128;
         readonly requestNonce: u32;


### PR DESCRIPTION
Adds a balance hold (to the origin) when opening a `pallet_stream_payment` Stream to prevent possible storage bloat.