### PR TITLE
Fix zombienet test by undoing a change

### DIFF
--- a/test/suites/para/test_tanssi_containers.ts
+++ b/test/suites/para/test_tanssi_containers.ts
@@ -482,13 +482,15 @@ async function countUniqueBlockAuthors(
 
     const uniq = [...new Set(actualAuthors)];
 
-    if (uniq.length != numAuthors) {
-        console.log(formatAuthoritySets(authoritiesBySession));
+    if (uniq.length > numAuthors || (uniq.length == 1 && numAuthors > 1)) {
         console.error(
-            "Mismatch between authorities and actual block authors: actual authors: ",
+            "Mismatch between authorities and actual block authors: authorities: ",
+            formatAuthoritySets(authoritiesBySession),
+            "",
             actualAuthors,
             ", block numbers: ",
-            blockNumbers
+            blockNumbers,
+            `uniq.length=${uniq.length}, numAuthors=${numAuthors}`
         );
         expect(false).to.be.true;
     }


### PR DESCRIPTION
It can sometimes fail when we expect 4 different authors in 10 blocks, and we only see 3 authors. That's because the 4th author has just rotated from a container chain, and has not had enough time to propose a block for the orchestrator chain.

This test was broken by #492, I was too optimistic.