### PR TITLE
Improve more timeouts in zombienet tests

### DIFF
--- a/test/suites/keep-db/test_restart_keep_db.ts
+++ b/test/suites/keep-db/test_restart_keep_db.ts
@@ -249,7 +249,7 @@ describeSuite({
 
                 // The node detects assignment when the block is finalized, but "waitSessions" ignores finality.
                 // So wait a few blocks more hoping that the current block will be finalized by then.
-                await context.waitBlock(3, "Tanssi");
+                await context.waitBlock(6, "Tanssi");
 
                 // Check that pending para ids removes 2000
                 const registered = await paraApi.query.registrar.registeredParaIds();

--- a/test/suites/metrics/test_metrics_stop.ts
+++ b/test/suites/metrics/test_metrics_stop.ts
@@ -164,7 +164,7 @@ describeSuite({
 
                 // The node detects assignment when the block is finalized, but "waitSessions" ignores finality.
                 // So wait a few blocks more hoping that the current block will be finalized by then.
-                await context.waitBlock(3, "Tanssi");
+                await context.waitBlock(6, "Tanssi");
 
                 // Check that pending para ids removes 2000
                 const registered = await paraApi.query.registrar.registeredParaIds();

--- a/test/suites/para/test_tanssi_containers.ts
+++ b/test/suites/para/test_tanssi_containers.ts
@@ -242,17 +242,20 @@ describeSuite({
                 const tx1 = paraApi.tx.registrar.register(2002, containerChainGenesisData);
                 const purchasedCredits = 100000n;
                 const requiredBalance = purchasedCredits * 1_000_000n;
-
                 const tx2 = paraApi.tx.servicesPayment.purchaseCredits(2002, requiredBalance);
-                const tx12 = paraApi.tx.utility.batchAll([tx1, tx2]);
-                await signAndSendAndInclude(tx12, alice);
                 const bootNodes = [
                     "/ip4/127.0.0.1/tcp/33051/ws/p2p/12D3KooWSDsmAa7iFbHdQW4X8B2KbeRYPDLarK6EbevUSYfGkeQw",
                 ];
                 const tx3 = paraApi.tx.dataPreservers.setBootNodes(2002, bootNodes);
                 const tx4 = paraApi.tx.registrar.markValidForCollating(2002);
-                const tx34 = paraApi.tx.utility.batchAll([tx3, tx4]);
-                await signAndSendAndInclude(paraApi.tx.sudo.sudo(tx34), alice);
+                // Send the batch transaction: [register, purchaseCredits, sudo(setBootNodes), sudo(markValidForCollating)]
+                const txBatch = paraApi.tx.utility.batchAll([
+                    tx1,
+                    tx2,
+                    paraApi.tx.sudo.sudo(tx3),
+                    paraApi.tx.sudo.sudo(tx4),
+                ]);
+                await signAndSendAndInclude(txBatch, alice);
                 // Check that pending para ids contains 2002
                 const registered2 = await paraApi.query.registrar.pendingParaIds();
                 const registered3 = await paraApi.query.registrar.registeredParaIds();

--- a/test/suites/rotation-para/test_rotation.ts
+++ b/test/suites/rotation-para/test_rotation.ts
@@ -255,7 +255,7 @@ describeSuite({
 
                 // The node detects assignment when the block is finalized, but "waitSessions" ignores finality.
                 // So wait a few blocks more hoping that the current block will be finalized by then.
-                await context.waitBlock(3, "Tanssi");
+                await context.waitBlock(6, "Tanssi");
                 const assignment = await paraApi.query.collatorAssignment.collatorContainerChain();
                 assignment3 = assignment.toJSON();
                 console.log("assignment session 3:");

--- a/test/suites/warp-sync/test_warp_sync.ts
+++ b/test/suites/warp-sync/test_warp_sync.ts
@@ -170,7 +170,17 @@ describeSuite({
                 const tx = paraApi.tx.invulnerables.setInvulnerables(newInvuln);
                 await signAndSendAndInclude(paraApi.tx.sudo.sudo(tx), alice);
 
-                await waitSessions(context, paraApi, 2);
+                // New collators will be set after 2 sessions, but because `signAndSendAndInclude` waits
+                // until the block that includes the extrinsic is finalized, it is possible that we only need to wait
+                // 1 session. So use a callback to wait 1 or 2 sessions.
+                await waitSessions(context, paraApi, 2, async () => {
+                    const currentSession = (await paraApi.query.session.currentIndex()).toNumber();
+                    const allCollators = (
+                        await paraApi.query.authorityAssignment.collatorContainerChain(currentSession)
+                    ).toJSON();
+                    // Stop waiting if orchestrator chain has 2 collators instead of 3
+                    return allCollators.orchestratorChain.length == 2;
+                });
 
                 // Collator1000-03 should rotate to container chain 2000
 
@@ -193,7 +203,7 @@ describeSuite({
 
                 // The node detects assignment when the block is finalized, but "waitSessions" ignores finality.
                 // So wait a few blocks more hoping that the current block will be finalized by then.
-                await context.waitBlock(3, "Tanssi");
+                await context.waitBlock(6, "Tanssi");
 
                 // Collator2000-02 container chain db should have been deleted
                 expect(await directoryExists(container200002DbPath)).to.be.false;


### PR DESCRIPTION
Increase some test timeouts.

With the change from 12 second block time to 6 second, some timeouts were not increased. Previously we waited for 3 tanssi block to assume finality, but finality depends on the relay chain, so we should have been waiting for 6 relay blocks. With this change we wait for 6 tanssi blocks, which should be the same.

Also I merged 2 batches of transactions into 1 batch, because using `signAndSendAndInclude` twice in the same test can make it time out depending on finality.