### PR TITLE
MD325/MD326 - invulnerables

### DIFF
--- a/client/consensus/src/collators/lookahead.rs
+++ b/client/consensus/src/collators/lookahead.rs
@@ -31,8 +31,6 @@
 //! The main limitation is block propagation time - i.e. the new blocks created by an author
 //! must be propagated to the next author before their turn.
 
-use tokio::select;
-use tokio_util::sync::CancellationToken;
 use {
     crate::{
         collators::{self as collator_util, tanssi_claim_slot, SlotClaim},
@@ -69,6 +67,8 @@ use {
     sp_keystore::KeystorePtr,
     sp_runtime::traits::{Block as BlockT, Header as HeaderT, Member},
     std::{convert::TryFrom, error::Error, sync::Arc, time::Duration},
+    tokio::select,
+    tokio_util::sync::CancellationToken,
 };
 
 /// Parameters for [`run`].

--- a/node/src/container_chain_spawner.rs
+++ b/node/src/container_chain_spawner.rs
@@ -21,7 +21,6 @@
 //! For more information about when the database is deleted, check the
 //! [Keep db flowchart](https://raw.githubusercontent.com/moondance-labs/tanssi/master/docs/keep_db_flowchart.png)
 
-use tokio_util::sync::CancellationToken;
 use {
     crate::{
         cli::ContainerChainCli,
@@ -55,6 +54,7 @@ use {
         sync::{mpsc, oneshot},
         time::{sleep, Duration},
     },
+    tokio_util::sync::CancellationToken,
 };
 
 /// Struct with all the params needed to start a container chain node given the CLI arguments,

--- a/pallets/invulnerables/src/benchmarking.rs
+++ b/pallets/invulnerables/src/benchmarking.rs
@@ -194,8 +194,9 @@ mod benchmarks {
         // now we need to fill up invulnerables
         let mut invulnerables = invulnerables::<T>(r);
         invulnerables.sort();
-        
-        let (account_ids, _collator_ids): (Vec<T::AccountId>, Vec<T::CollatorId>) = invulnerables.into_iter().unzip();
+
+        let (account_ids, _collator_ids): (Vec<T::AccountId>, Vec<T::CollatorId>) =
+            invulnerables.into_iter().unzip();
 
         for account in account_ids.into_iter() {
             <InvulnerablesPallet<T>>::add_invulnerable(origin.clone(), account)

--- a/pallets/invulnerables/src/benchmarking.rs
+++ b/pallets/invulnerables/src/benchmarking.rs
@@ -198,7 +198,7 @@ mod benchmarks {
         let (account_ids, _collator_ids): (Vec<T::AccountId>, Vec<T::CollatorId>) =
             invulnerables.into_iter().unzip();
 
-        for account in account_ids.into_iter() {
+        for account in account_ids {
             <InvulnerablesPallet<T>>::add_invulnerable(origin.clone(), account)
                 .expect("add invulnerable failed");
         }

--- a/pallets/invulnerables/src/benchmarking.rs
+++ b/pallets/invulnerables/src/benchmarking.rs
@@ -169,7 +169,8 @@ mod benchmarks {
         let invulnerables: frame_support::BoundedVec<_, T::MaxInvulnerables> =
             frame_support::BoundedVec::try_from(collator_ids).unwrap();
         <Invulnerables<T>>::put(invulnerables);
-        let to_remove = account_ids.first().unwrap().clone();
+
+        let to_remove = account_ids.last().unwrap().clone();
 
         #[extrinsic_call]
         _(origin as T::RuntimeOrigin, to_remove.clone());

--- a/pallets/invulnerables/src/lib.rs
+++ b/pallets/invulnerables/src/lib.rs
@@ -218,10 +218,7 @@ pub mod pallet {
         /// The origin for this call must be the `UpdateOrigin`.
         #[pallet::call_index(2)]
         #[pallet::weight(T::WeightInfo::remove_invulnerable(T::MaxInvulnerables::get()))]
-        pub fn remove_invulnerable(
-            origin: OriginFor<T>,
-            who: T::AccountId,
-        ) -> DispatchResult {
+        pub fn remove_invulnerable(origin: OriginFor<T>, who: T::AccountId) -> DispatchResult {
             T::UpdateOrigin::ensure_origin(origin)?;
 
             let collator_id = T::CollatorIdOf::convert(who.clone())

--- a/pallets/invulnerables/src/lib.rs
+++ b/pallets/invulnerables/src/lib.rs
@@ -175,7 +175,7 @@ pub mod pallet {
         /// Add a new account `who` to the list of `Invulnerables` collators.
         ///
         /// The origin for this call must be the `UpdateOrigin`.
-        #[pallet::call_index(0)]
+        #[pallet::call_index(1)]
         #[pallet::weight(T::WeightInfo::add_invulnerable(
 			T::MaxInvulnerables::get().saturating_sub(1),
 		))]
@@ -216,20 +216,19 @@ pub mod pallet {
         /// be sorted.
         ///
         /// The origin for this call must be the `UpdateOrigin`.
-        #[pallet::call_index(1)]
+        #[pallet::call_index(2)]
         #[pallet::weight(T::WeightInfo::remove_invulnerable(T::MaxInvulnerables::get()))]
         pub fn remove_invulnerable(
             origin: OriginFor<T>,
             who: T::AccountId,
-        ) -> DispatchResultWithPostInfo {
+        ) -> DispatchResult {
             T::UpdateOrigin::ensure_origin(origin)?;
 
             let collator_id = T::CollatorIdOf::convert(who.clone())
                 .ok_or(Error::<T>::UnableToDeriveCollatorId)?;
 
-            let mut pos = 0;
             <Invulnerables<T>>::try_mutate(|invulnerables| -> DispatchResult {
-                pos = invulnerables
+                let pos = invulnerables
                     .iter()
                     .position(|x| x == &collator_id)
                     .ok_or(Error::<T>::NotInvulnerable)?;
@@ -238,8 +237,7 @@ pub mod pallet {
             })?;
 
             Self::deposit_event(Event::InvulnerableRemoved { account_id: who });
-            let actual_weight = T::WeightInfo::remove_invulnerable((pos as u32) + 1);
-            Ok(Some(actual_weight).into())
+            Ok(())
         }
     }
 

--- a/pallets/invulnerables/src/lib.rs
+++ b/pallets/invulnerables/src/lib.rs
@@ -172,7 +172,6 @@ pub mod pallet {
 
     #[pallet::call]
     impl<T: Config> Pallet<T> {
-        
         /// Add a new account `who` to the list of `Invulnerables` collators.
         ///
         /// The origin for this call must be the `UpdateOrigin`.
@@ -219,7 +218,10 @@ pub mod pallet {
         /// The origin for this call must be the `UpdateOrigin`.
         #[pallet::call_index(1)]
         #[pallet::weight(T::WeightInfo::remove_invulnerable(T::MaxInvulnerables::get()))]
-        pub fn remove_invulnerable(origin: OriginFor<T>, who: T::AccountId) -> DispatchResultWithPostInfo {
+        pub fn remove_invulnerable(
+            origin: OriginFor<T>,
+            who: T::AccountId,
+        ) -> DispatchResultWithPostInfo {
             T::UpdateOrigin::ensure_origin(origin)?;
 
             let collator_id = T::CollatorIdOf::convert(who.clone())
@@ -236,7 +238,7 @@ pub mod pallet {
             })?;
 
             Self::deposit_event(Event::InvulnerableRemoved { account_id: who });
-            let actual_weight = T::WeightInfo::remove_invulnerable((pos as u32) + 1); 
+            let actual_weight = T::WeightInfo::remove_invulnerable((pos as u32) + 1);
             Ok(Some(actual_weight).into())
         }
     }

--- a/pallets/invulnerables/src/tests.rs
+++ b/pallets/invulnerables/src/tests.rs
@@ -34,24 +34,6 @@ fn basic_setup_works() {
 }
 
 #[test]
-fn it_should_set_invulnerables() {
-    new_test_ext().execute_with(|| {
-        let new_set = vec![1, 4, 3, 2];
-        assert_ok!(Invulnerables::set_invulnerables(
-            RuntimeOrigin::signed(RootAccount::get()),
-            new_set.clone()
-        ));
-        assert_eq!(Invulnerables::invulnerables(), new_set);
-
-        // cannot set with non-root.
-        assert_noop!(
-            Invulnerables::set_invulnerables(RuntimeOrigin::signed(1), new_set),
-            BadOrigin
-        );
-    });
-}
-
-#[test]
 fn add_invulnerable_works() {
     new_test_ext().execute_with(|| {
         initialize_to_block(1);
@@ -119,17 +101,6 @@ fn invulnerable_limit_works() {
             }
         }
         let expected: Vec<u64> = (1..=20).collect();
-        assert_eq!(Invulnerables::invulnerables(), expected);
-
-        // Cannot set too many Invulnerables
-        let too_many_invulnerables: Vec<u64> = (1..=21).collect();
-        assert_noop!(
-            Invulnerables::set_invulnerables(
-                RuntimeOrigin::signed(RootAccount::get()),
-                too_many_invulnerables
-            ),
-            Error::<Test>::TooManyInvulnerables
-        );
         assert_eq!(Invulnerables::invulnerables(), expected);
     });
 }

--- a/pallets/invulnerables/src/weights.rs
+++ b/pallets/invulnerables/src/weights.rs
@@ -50,7 +50,6 @@ use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
 use core::marker::PhantomData;
 
 pub trait WeightInfo {
-	fn set_invulnerables(_b: u32) -> Weight;
 	fn add_invulnerable(_b: u32) -> Weight;
 	fn remove_invulnerable(_b: u32) -> Weight;
 	fn new_session(_b: u32) -> Weight;
@@ -60,20 +59,6 @@ pub trait WeightInfo {
 /// Weight functions for `pallet_invulnerables`.
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
-	/// Storage: Invulnerables Invulnerables (r:0 w:1)
-	/// Proof: Invulnerables Invulnerables (max_values: Some(1), max_size: Some(3202), added: 3697, mode: MaxEncodedLen)
-	/// The range of component `b` is `[1, 100]`.
-	fn set_invulnerables(b: u32, ) -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `0`
-		//  Estimated: `0`
-		// Minimum execution time: 3_690_000 picoseconds.
-		Weight::from_parts(4_000_278, 0)
-			.saturating_add(Weight::from_parts(0, 0))
-			// Standard Error: 283
-			.saturating_add(Weight::from_parts(56_720, 0).saturating_mul(b.into()))
-			.saturating_add(T::DbWeight::get().writes(1))
-	}
 	/// Storage: `Session::NextKeys` (r:1 w:0)
 	/// Proof: `Session::NextKeys` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `Invulnerables::Invulnerables` (r:1 w:1)
@@ -143,20 +128,6 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 
 // For backwards compatibility and tests
 impl WeightInfo for () {
-	/// Storage: Invulnerables Invulnerables (r:0 w:1)
-	/// Proof: Invulnerables Invulnerables (max_values: Some(1), max_size: Some(3202), added: 3697, mode: MaxEncodedLen)
-	/// The range of component `b` is `[1, 100]`.
-	fn set_invulnerables(b: u32, ) -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `0`
-		//  Estimated: `0`
-		// Minimum execution time: 3_690_000 picoseconds.
-		Weight::from_parts(4_000_278, 0)
-			.saturating_add(Weight::from_parts(0, 0))
-			// Standard Error: 283
-			.saturating_add(Weight::from_parts(56_720, 0).saturating_mul(b.into()))
-			.saturating_add(RocksDbWeight::get().writes(1))
-	}
 	/// Storage: `Session::NextKeys` (r:1 w:0)
 	/// Proof: `Session::NextKeys` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `Invulnerables::Invulnerables` (r:1 w:1)

--- a/runtime/dancebox/tests/integration_test.rs
+++ b/runtime/dancebox/tests/integration_test.rs
@@ -383,10 +383,7 @@ fn test_author_collation_aura_change_of_authorities_on_session() {
                 root_origin(),
                 CHARLIE.into()
             ));
-            assert_ok!(Invulnerables::add_invulnerable(
-                root_origin(), 
-                DAVE.into()
-            ));
+            assert_ok!(Invulnerables::add_invulnerable(root_origin(), DAVE.into()));
 
             // SESSION CHANGE. First session. it takes 2 sessions to see the change
             run_to_session(1u32);
@@ -398,7 +395,7 @@ fn test_author_collation_aura_change_of_authorities_on_session() {
             // Invulnerables should have triggered on new session authorities change
             run_to_session(2u32);
             let author_after_changes = get_orchestrator_current_author().unwrap();
-            
+
             assert_eq!(current_author(), author_after_changes);
             assert_eq!(authorities(), vec![charlie_id, dave_id]);
         });

--- a/runtime/dancebox/tests/integration_test.rs
+++ b/runtime/dancebox/tests/integration_test.rs
@@ -371,24 +371,25 @@ fn test_author_collation_aura_change_of_authorities_on_session() {
             ));
 
             // Set new invulnerables
-            assert_ok!(Invulnerables::set_invulnerables(
-                root_origin(),
-                vec![CHARLIE.into(), DAVE.into()]
-            ));
+            assert_ok!(Invulnerables::add_invulnerable(root_origin(), CHARLIE.into()));
+            assert_ok!(Invulnerables::add_invulnerable(root_origin(), DAVE.into()));
 
             // SESSION CHANGE. First session. it takes 2 sessions to see the change
             run_to_session(1u32);
             let author = get_orchestrator_current_author().unwrap();
 
             assert_eq!(current_author(), author);
-            assert!(authorities() == vec![alice_id, bob_id]);
+            assert!(authorities() == vec![alice_id.clone(), bob_id.clone()]);
 
             // Invulnerables should have triggered on new session authorities change
+            // (However, Charlie and Dave should have been assigned to 1001)
             run_to_session(2u32);
-            let author_after_changes = get_orchestrator_current_author().unwrap();
-
-            assert_eq!(current_author(), author_after_changes);
-            assert_eq!(authorities(), vec![charlie_id, dave_id]);
+            assert_eq!(authorities(), vec![alice_id, bob_id]);
+            let assignment = CollatorAssignment::collator_container_chain();
+            assert_eq!(
+                assignment.container_chains[&1001u32.into()],
+                vec![CHARLIE.into(), DAVE.into()]
+            );
         });
 }
 
@@ -438,11 +439,9 @@ fn test_author_collation_aura_add_assigned_to_paras() {
                 vec![]
             ));
 
-            // Set new invulnerables
-            assert_ok!(Invulnerables::set_invulnerables(
-                root_origin(),
-                vec![ALICE.into(), BOB.into(), CHARLIE.into(), DAVE.into()]
-            ));
+            // Add new invulnerables
+            assert_ok!(Invulnerables::add_invulnerable(root_origin(), CHARLIE.into()));
+            assert_ok!(Invulnerables::add_invulnerable(root_origin(), DAVE.into()));
 
             // SESSION CHANGE. First session. it takes 2 sessions to see the change
             run_to_session(1u32);
@@ -1222,10 +1221,8 @@ fn test_author_collation_aura_add_assigned_to_paras_runtime_api() {
             ));
 
             // Set new invulnerables
-            assert_ok!(Invulnerables::set_invulnerables(
-                root_origin(),
-                vec![ALICE.into(), BOB.into(), CHARLIE.into(), DAVE.into()]
-            ));
+            assert_ok!(Invulnerables::add_invulnerable(root_origin(), CHARLIE.into()));
+            assert_ok!(Invulnerables::add_invulnerable(root_origin(), DAVE.into()));
 
             // SESSION CHANGE. First session. it takes 2 sessions to see the change
             run_to_session(1u32);
@@ -1275,10 +1272,7 @@ fn test_author_collation_aura_add_assigned_to_paras_runtime_api() {
             );
 
             // Remove BOB
-            assert_ok!(Invulnerables::set_invulnerables(
-                root_origin(),
-                vec![ALICE.into(), CHARLIE.into(), DAVE.into()]
-            ));
+            assert_ok!(Invulnerables::remove_invulnerable(root_origin(), BOB.into()));
 
             run_to_session(3u32);
             assert_eq!(
@@ -1377,10 +1371,8 @@ fn test_consensus_runtime_api() {
             ));
 
             // Set new invulnerables
-            assert_ok!(Invulnerables::set_invulnerables(
-                root_origin(),
-                vec![ALICE.into(), BOB.into(), CHARLIE.into(), DAVE.into()]
-            ));
+            assert_ok!(Invulnerables::add_invulnerable(root_origin(), CHARLIE.into()));
+            assert_ok!(Invulnerables::add_invulnerable(root_origin(), DAVE.into()));
 
             run_to_session(2u32);
             assert_eq!(
@@ -1472,10 +1464,8 @@ fn test_consensus_runtime_api_session_changes() {
             ));
 
             // Set new invulnerables
-            assert_ok!(Invulnerables::set_invulnerables(
-                root_origin(),
-                vec![ALICE.into(), BOB.into(), CHARLIE.into(), DAVE.into()]
-            ));
+            assert_ok!(Invulnerables::add_invulnerable(root_origin(), CHARLIE.into()));
+            assert_ok!(Invulnerables::add_invulnerable(root_origin(), DAVE.into()));
 
             let session_two_edge = dancebox_runtime::Period::get() * 2;
             // Let's run just 2 blocks before the session 2 change first
@@ -1606,10 +1596,8 @@ fn test_consensus_runtime_api_next_session() {
             ));
 
             // Set new invulnerables
-            assert_ok!(Invulnerables::set_invulnerables(
-                root_origin(),
-                vec![ALICE.into(), BOB.into(), CHARLIE.into(), DAVE.into()]
-            ));
+            assert_ok!(Invulnerables::add_invulnerable(root_origin(), CHARLIE.into()));
+            assert_ok!(Invulnerables::add_invulnerable(root_origin(), DAVE.into()));
 
             let session_two_edge = dancebox_runtime::Period::get() * 2;
             // Let's run just 2 blocks before the session 2 change first

--- a/runtime/dancebox/tests/integration_test.rs
+++ b/runtime/dancebox/tests/integration_test.rs
@@ -371,7 +371,10 @@ fn test_author_collation_aura_change_of_authorities_on_session() {
             ));
 
             // Set new invulnerables
-            assert_ok!(Invulnerables::add_invulnerable(root_origin(), CHARLIE.into()));
+            assert_ok!(Invulnerables::add_invulnerable(
+                root_origin(),
+                CHARLIE.into()
+            ));
             assert_ok!(Invulnerables::add_invulnerable(root_origin(), DAVE.into()));
 
             // SESSION CHANGE. First session. it takes 2 sessions to see the change
@@ -440,7 +443,10 @@ fn test_author_collation_aura_add_assigned_to_paras() {
             ));
 
             // Add new invulnerables
-            assert_ok!(Invulnerables::add_invulnerable(root_origin(), CHARLIE.into()));
+            assert_ok!(Invulnerables::add_invulnerable(
+                root_origin(),
+                CHARLIE.into()
+            ));
             assert_ok!(Invulnerables::add_invulnerable(root_origin(), DAVE.into()));
 
             // SESSION CHANGE. First session. it takes 2 sessions to see the change
@@ -1221,7 +1227,10 @@ fn test_author_collation_aura_add_assigned_to_paras_runtime_api() {
             ));
 
             // Set new invulnerables
-            assert_ok!(Invulnerables::add_invulnerable(root_origin(), CHARLIE.into()));
+            assert_ok!(Invulnerables::add_invulnerable(
+                root_origin(),
+                CHARLIE.into()
+            ));
             assert_ok!(Invulnerables::add_invulnerable(root_origin(), DAVE.into()));
 
             // SESSION CHANGE. First session. it takes 2 sessions to see the change
@@ -1272,7 +1281,10 @@ fn test_author_collation_aura_add_assigned_to_paras_runtime_api() {
             );
 
             // Remove BOB
-            assert_ok!(Invulnerables::remove_invulnerable(root_origin(), BOB.into()));
+            assert_ok!(Invulnerables::remove_invulnerable(
+                root_origin(),
+                BOB.into()
+            ));
 
             run_to_session(3u32);
             assert_eq!(
@@ -1371,7 +1383,10 @@ fn test_consensus_runtime_api() {
             ));
 
             // Set new invulnerables
-            assert_ok!(Invulnerables::add_invulnerable(root_origin(), CHARLIE.into()));
+            assert_ok!(Invulnerables::add_invulnerable(
+                root_origin(),
+                CHARLIE.into()
+            ));
             assert_ok!(Invulnerables::add_invulnerable(root_origin(), DAVE.into()));
 
             run_to_session(2u32);
@@ -1464,7 +1479,10 @@ fn test_consensus_runtime_api_session_changes() {
             ));
 
             // Set new invulnerables
-            assert_ok!(Invulnerables::add_invulnerable(root_origin(), CHARLIE.into()));
+            assert_ok!(Invulnerables::add_invulnerable(
+                root_origin(),
+                CHARLIE.into()
+            ));
             assert_ok!(Invulnerables::add_invulnerable(root_origin(), DAVE.into()));
 
             let session_two_edge = dancebox_runtime::Period::get() * 2;
@@ -1596,7 +1614,10 @@ fn test_consensus_runtime_api_next_session() {
             ));
 
             // Set new invulnerables
-            assert_ok!(Invulnerables::add_invulnerable(root_origin(), CHARLIE.into()));
+            assert_ok!(Invulnerables::add_invulnerable(
+                root_origin(),
+                CHARLIE.into()
+            ));
             assert_ok!(Invulnerables::add_invulnerable(root_origin(), DAVE.into()));
 
             let session_two_edge = dancebox_runtime::Period::get() * 2;

--- a/runtime/dancebox/tests/integration_test.rs
+++ b/runtime/dancebox/tests/integration_test.rs
@@ -370,12 +370,23 @@ fn test_author_collation_aura_change_of_authorities_on_session() {
                 vec![]
             ));
 
-            // Set new invulnerables
+            // Change invulnerables
+            assert_ok!(Invulnerables::remove_invulnerable(
+                root_origin(),
+                ALICE.into()
+            ));
+            assert_ok!(Invulnerables::remove_invulnerable(
+                root_origin(),
+                BOB.into()
+            ));
             assert_ok!(Invulnerables::add_invulnerable(
                 root_origin(),
                 CHARLIE.into()
             ));
-            assert_ok!(Invulnerables::add_invulnerable(root_origin(), DAVE.into()));
+            assert_ok!(Invulnerables::add_invulnerable(
+                root_origin(), 
+                DAVE.into()
+            ));
 
             // SESSION CHANGE. First session. it takes 2 sessions to see the change
             run_to_session(1u32);
@@ -385,14 +396,11 @@ fn test_author_collation_aura_change_of_authorities_on_session() {
             assert!(authorities() == vec![alice_id.clone(), bob_id.clone()]);
 
             // Invulnerables should have triggered on new session authorities change
-            // (However, Charlie and Dave should have been assigned to 1001)
             run_to_session(2u32);
-            assert_eq!(authorities(), vec![alice_id, bob_id]);
-            let assignment = CollatorAssignment::collator_container_chain();
-            assert_eq!(
-                assignment.container_chains[&1001u32.into()],
-                vec![CHARLIE.into(), DAVE.into()]
-            );
+            let author_after_changes = get_orchestrator_current_author().unwrap();
+            
+            assert_eq!(current_author(), author_after_changes);
+            assert_eq!(authorities(), vec![charlie_id, dave_id]);
         });
 }
 

--- a/runtime/flashbox/tests/integration_test.rs
+++ b/runtime/flashbox/tests/integration_test.rs
@@ -359,7 +359,6 @@ fn test_author_collation_aura_change_of_authorities_on_session() {
                 vec![]
             ));
 
-
             // Change invulnerables
             assert_ok!(Invulnerables::remove_invulnerable(
                 root_origin(),
@@ -373,10 +372,7 @@ fn test_author_collation_aura_change_of_authorities_on_session() {
                 root_origin(),
                 CHARLIE.into()
             ));
-            assert_ok!(Invulnerables::add_invulnerable(
-                root_origin(), 
-                DAVE.into()
-            ));
+            assert_ok!(Invulnerables::add_invulnerable(root_origin(), DAVE.into()));
 
             // SESSION CHANGE. First session. it takes 2 sessions to see the change
             run_to_session(1u32);
@@ -388,7 +384,7 @@ fn test_author_collation_aura_change_of_authorities_on_session() {
             // Invulnerables should have triggered on new session authorities change
             run_to_session(2u32);
             let author_after_changes = get_orchestrator_current_author().unwrap();
-            
+
             assert_eq!(current_author(), author_after_changes);
             assert_eq!(authorities(), vec![charlie_id, dave_id]);
         });

--- a/runtime/flashbox/tests/integration_test.rs
+++ b/runtime/flashbox/tests/integration_test.rs
@@ -359,12 +359,24 @@ fn test_author_collation_aura_change_of_authorities_on_session() {
                 vec![]
             ));
 
-            // Set new invulnerables
+
+            // Change invulnerables
+            assert_ok!(Invulnerables::remove_invulnerable(
+                root_origin(),
+                ALICE.into()
+            ));
+            assert_ok!(Invulnerables::remove_invulnerable(
+                root_origin(),
+                BOB.into()
+            ));
             assert_ok!(Invulnerables::add_invulnerable(
                 root_origin(),
                 CHARLIE.into()
             ));
-            assert_ok!(Invulnerables::add_invulnerable(root_origin(), DAVE.into()));
+            assert_ok!(Invulnerables::add_invulnerable(
+                root_origin(), 
+                DAVE.into()
+            ));
 
             // SESSION CHANGE. First session. it takes 2 sessions to see the change
             run_to_session(1u32);
@@ -374,14 +386,11 @@ fn test_author_collation_aura_change_of_authorities_on_session() {
             assert!(authorities() == vec![alice_id.clone(), bob_id.clone()]);
 
             // Invulnerables should have triggered on new session authorities change
-            // (However, Charlie and Dave should have been assigned to 1001)
             run_to_session(2u32);
-            assert_eq!(authorities(), vec![alice_id, bob_id]);
-            let assignment = CollatorAssignment::collator_container_chain();
-            assert_eq!(
-                assignment.container_chains[&1001u32.into()],
-                vec![CHARLIE.into(), DAVE.into()]
-            );
+            let author_after_changes = get_orchestrator_current_author().unwrap();
+            
+            assert_eq!(current_author(), author_after_changes);
+            assert_eq!(authorities(), vec![charlie_id, dave_id]);
         });
 }
 

--- a/runtime/flashbox/tests/integration_test.rs
+++ b/runtime/flashbox/tests/integration_test.rs
@@ -360,24 +360,25 @@ fn test_author_collation_aura_change_of_authorities_on_session() {
             ));
 
             // Set new invulnerables
-            assert_ok!(Invulnerables::set_invulnerables(
-                root_origin(),
-                vec![CHARLIE.into(), DAVE.into()]
-            ));
+            assert_ok!(Invulnerables::add_invulnerable(root_origin(), CHARLIE.into()));
+            assert_ok!(Invulnerables::add_invulnerable(root_origin(), DAVE.into()));
 
             // SESSION CHANGE. First session. it takes 2 sessions to see the change
             run_to_session(1u32);
             let author = get_orchestrator_current_author().unwrap();
 
             assert_eq!(current_author(), author);
-            assert!(authorities() == vec![alice_id, bob_id]);
+            assert!(authorities() == vec![alice_id.clone(), bob_id.clone()]);
 
             // Invulnerables should have triggered on new session authorities change
+            // (However, Charlie and Dave should have been assigned to 1001)
             run_to_session(2u32);
-            let author_after_changes = get_orchestrator_current_author().unwrap();
-
-            assert_eq!(current_author(), author_after_changes);
-            assert_eq!(authorities(), vec![charlie_id, dave_id]);
+            assert_eq!(authorities(), vec![alice_id, bob_id]);
+            let assignment = CollatorAssignment::collator_container_chain();
+            assert_eq!(
+                assignment.container_chains[&1001u32.into()],
+                vec![CHARLIE.into(), DAVE.into()]
+            );
         });
 }
 
@@ -428,10 +429,8 @@ fn test_author_collation_aura_add_assigned_to_paras() {
             ));
 
             // Set new invulnerables
-            assert_ok!(Invulnerables::set_invulnerables(
-                root_origin(),
-                vec![ALICE.into(), BOB.into(), CHARLIE.into(), DAVE.into()]
-            ));
+            assert_ok!(Invulnerables::add_invulnerable(root_origin(), CHARLIE.into()));
+            assert_ok!(Invulnerables::add_invulnerable(root_origin(), DAVE.into()));
 
             // SESSION CHANGE. First session. it takes 2 sessions to see the change
             run_to_session(1u32);
@@ -1211,10 +1210,8 @@ fn test_author_collation_aura_add_assigned_to_paras_runtime_api() {
             ));
 
             // Set new invulnerables
-            assert_ok!(Invulnerables::set_invulnerables(
-                root_origin(),
-                vec![ALICE.into(), BOB.into(), CHARLIE.into(), DAVE.into()]
-            ));
+            assert_ok!(Invulnerables::add_invulnerable(root_origin(), CHARLIE.into()));
+            assert_ok!(Invulnerables::add_invulnerable(root_origin(), DAVE.into()));
 
             // SESSION CHANGE. First session. it takes 2 sessions to see the change
             run_to_session(1u32);
@@ -1264,10 +1261,7 @@ fn test_author_collation_aura_add_assigned_to_paras_runtime_api() {
             );
 
             // Remove BOB
-            assert_ok!(Invulnerables::set_invulnerables(
-                root_origin(),
-                vec![ALICE.into(), CHARLIE.into(), DAVE.into()]
-            ));
+            assert_ok!(Invulnerables::remove_invulnerable(root_origin(), BOB.into()));
 
             run_to_session(3u32);
             assert_eq!(
@@ -1366,10 +1360,8 @@ fn test_consensus_runtime_api() {
             ));
 
             // Set new invulnerables
-            assert_ok!(Invulnerables::set_invulnerables(
-                root_origin(),
-                vec![ALICE.into(), BOB.into(), CHARLIE.into(), DAVE.into()]
-            ));
+            assert_ok!(Invulnerables::add_invulnerable(root_origin(), CHARLIE.into()));
+            assert_ok!(Invulnerables::add_invulnerable(root_origin(), DAVE.into()));
 
             run_to_session(2u32);
             assert_eq!(
@@ -1461,10 +1453,8 @@ fn test_consensus_runtime_api_session_changes() {
             ));
 
             // Set new invulnerables
-            assert_ok!(Invulnerables::set_invulnerables(
-                root_origin(),
-                vec![ALICE.into(), BOB.into(), CHARLIE.into(), DAVE.into()]
-            ));
+            assert_ok!(Invulnerables::add_invulnerable(root_origin(), CHARLIE.into()));
+            assert_ok!(Invulnerables::add_invulnerable(root_origin(), DAVE.into()));
 
             let session_two_edge = flashbox_runtime::Period::get() * 2;
             // Let's run just 2 blocks before the session 2 change first
@@ -1595,10 +1585,8 @@ fn test_consensus_runtime_api_next_session() {
             ));
 
             // Set new invulnerables
-            assert_ok!(Invulnerables::set_invulnerables(
-                root_origin(),
-                vec![ALICE.into(), BOB.into(), CHARLIE.into(), DAVE.into()]
-            ));
+            assert_ok!(Invulnerables::add_invulnerable(root_origin(), CHARLIE.into()));
+            assert_ok!(Invulnerables::add_invulnerable(root_origin(), DAVE.into()));
 
             let session_two_edge = flashbox_runtime::Period::get() * 2;
             // Let's run just 2 blocks before the session 2 change first

--- a/runtime/flashbox/tests/integration_test.rs
+++ b/runtime/flashbox/tests/integration_test.rs
@@ -360,7 +360,10 @@ fn test_author_collation_aura_change_of_authorities_on_session() {
             ));
 
             // Set new invulnerables
-            assert_ok!(Invulnerables::add_invulnerable(root_origin(), CHARLIE.into()));
+            assert_ok!(Invulnerables::add_invulnerable(
+                root_origin(),
+                CHARLIE.into()
+            ));
             assert_ok!(Invulnerables::add_invulnerable(root_origin(), DAVE.into()));
 
             // SESSION CHANGE. First session. it takes 2 sessions to see the change
@@ -429,7 +432,10 @@ fn test_author_collation_aura_add_assigned_to_paras() {
             ));
 
             // Set new invulnerables
-            assert_ok!(Invulnerables::add_invulnerable(root_origin(), CHARLIE.into()));
+            assert_ok!(Invulnerables::add_invulnerable(
+                root_origin(),
+                CHARLIE.into()
+            ));
             assert_ok!(Invulnerables::add_invulnerable(root_origin(), DAVE.into()));
 
             // SESSION CHANGE. First session. it takes 2 sessions to see the change
@@ -1210,7 +1216,10 @@ fn test_author_collation_aura_add_assigned_to_paras_runtime_api() {
             ));
 
             // Set new invulnerables
-            assert_ok!(Invulnerables::add_invulnerable(root_origin(), CHARLIE.into()));
+            assert_ok!(Invulnerables::add_invulnerable(
+                root_origin(),
+                CHARLIE.into()
+            ));
             assert_ok!(Invulnerables::add_invulnerable(root_origin(), DAVE.into()));
 
             // SESSION CHANGE. First session. it takes 2 sessions to see the change
@@ -1261,7 +1270,10 @@ fn test_author_collation_aura_add_assigned_to_paras_runtime_api() {
             );
 
             // Remove BOB
-            assert_ok!(Invulnerables::remove_invulnerable(root_origin(), BOB.into()));
+            assert_ok!(Invulnerables::remove_invulnerable(
+                root_origin(),
+                BOB.into()
+            ));
 
             run_to_session(3u32);
             assert_eq!(
@@ -1360,7 +1372,10 @@ fn test_consensus_runtime_api() {
             ));
 
             // Set new invulnerables
-            assert_ok!(Invulnerables::add_invulnerable(root_origin(), CHARLIE.into()));
+            assert_ok!(Invulnerables::add_invulnerable(
+                root_origin(),
+                CHARLIE.into()
+            ));
             assert_ok!(Invulnerables::add_invulnerable(root_origin(), DAVE.into()));
 
             run_to_session(2u32);
@@ -1453,7 +1468,10 @@ fn test_consensus_runtime_api_session_changes() {
             ));
 
             // Set new invulnerables
-            assert_ok!(Invulnerables::add_invulnerable(root_origin(), CHARLIE.into()));
+            assert_ok!(Invulnerables::add_invulnerable(
+                root_origin(),
+                CHARLIE.into()
+            ));
             assert_ok!(Invulnerables::add_invulnerable(root_origin(), DAVE.into()));
 
             let session_two_edge = flashbox_runtime::Period::get() * 2;
@@ -1585,7 +1603,10 @@ fn test_consensus_runtime_api_next_session() {
             ));
 
             // Set new invulnerables
-            assert_ok!(Invulnerables::add_invulnerable(root_origin(), CHARLIE.into()));
+            assert_ok!(Invulnerables::add_invulnerable(
+                root_origin(),
+                CHARLIE.into()
+            ));
             assert_ok!(Invulnerables::add_invulnerable(root_origin(), DAVE.into()));
 
             let session_two_edge = flashbox_runtime::Period::get() * 2;

--- a/test/suites/dev-tanssi/session-keys/test_remove_session_key_staking.ts
+++ b/test/suites/dev-tanssi/session-keys/test_remove_session_key_staking.ts
@@ -25,13 +25,13 @@ describeSuite({
             // We need to remove all the invulnerables and add to staking
             // Remove all invulnerables, otherwise they have priority
             await createBlockAndRemoveInvulnerables(context);
-            
+
             // We delegate with manual rewards to make sure the candidate does not update position
             // We also need charlie to join staking because the settings for the dev environment are 1 collator for
             // tanssi and 2 collators for containers, so we need 3 collators for bob to be assigned.
             let aliceNonce = (await polkadotJs.rpc.system.accountNextIndex(alice.address)).toNumber();
             let bobNonce = (await polkadotJs.rpc.system.accountNextIndex(bob.address)).toNumber();
-            
+
             await context.createBlock([
                 await polkadotJs.tx.pooledStaking
                     .requestDelegate(alice.address, "ManualRewards", 10000n * DANCE)

--- a/test/suites/dev-tanssi/session-keys/test_remove_session_key_staking.ts
+++ b/test/suites/dev-tanssi/session-keys/test_remove_session_key_staking.ts
@@ -24,7 +24,10 @@ describeSuite({
 
             // We need to remove all the invulnerables and add to staking
             // Remove all invulnerables, otherwise they have priority
-            await createBlockAndRemoveInvulnerables(context);
+            await createBlockAndRemoveInvulnerables(context, alice);
+
+            const invulnerables = await polkadotJs.query.invulnerables.invulnerables();
+            expect(invulnerables.length).to.be.equal(0);
 
             // We delegate with manual rewards to make sure the candidate does not update position
             // We also need charlie to join staking because the settings for the dev environment are 1 collator for

--- a/test/suites/dev-tanssi/session-keys/test_remove_session_key_staking.ts
+++ b/test/suites/dev-tanssi/session-keys/test_remove_session_key_staking.ts
@@ -4,6 +4,7 @@ import { KeyringPair } from "@moonwall/util";
 import { ApiPromise } from "@polkadot/api";
 import { jumpSessions } from "../../../util/block";
 import { DANCE } from "util/constants";
+import { createBlockAndRemoveInvulnerables } from "util/invulnerables";
 
 describeSuite({
     id: "DT0202",
@@ -14,38 +15,24 @@ describeSuite({
         let alice: KeyringPair;
         let bob: KeyringPair;
         let charlie: KeyringPair;
-        let dave: KeyringPair;
 
         beforeAll(async () => {
             alice = context.keyring.alice;
             bob = context.keyring.bob;
             charlie = context.keyring.charlie;
-            dave = context.keyring.dave;
             polkadotJs = context.polkadotJs();
 
-            let aliceNonce = (await polkadotJs.rpc.system.accountNextIndex(alice.address)).toNumber();
-            let bobNonce = (await polkadotJs.rpc.system.accountNextIndex(bob.address)).toNumber();
-
-            // We need to remove from invulnerables and add to staking
-            // for that we need to remove Alice and Bob from invulnerables first
-
+            // We need to remove all the invulnerables and add to staking
+            // Remove all invulnerables, otherwise they have priority
+            await createBlockAndRemoveInvulnerables(context);
+            
             // We delegate with manual rewards to make sure the candidate does not update position
             // We also need charlie to join staking because the settings for the dev environment are 1 collator for
             // tanssi and 2 collators for containers, so we need 3 collators for bob to be assigned.
+            let aliceNonce = (await polkadotJs.rpc.system.accountNextIndex(alice.address)).toNumber();
+            let bobNonce = (await polkadotJs.rpc.system.accountNextIndex(bob.address)).toNumber();
+            
             await context.createBlock([
-                // Remove all invulnerables, otherwise they have priority
-                await polkadotJs.tx.sudo
-                    .sudo(polkadotJs.tx.invulnerables.removeInvulnerable(alice.address))
-                    .signAsync(context.keyring.alice, { nonce: aliceNonce++ }),
-                await polkadotJs.tx.sudo
-                    .sudo(polkadotJs.tx.invulnerables.removeInvulnerable(bob.address))
-                    .signAsync(context.keyring.alice, { nonce: aliceNonce++ }),
-                await polkadotJs.tx.sudo
-                    .sudo(polkadotJs.tx.invulnerables.removeInvulnerable(charlie.address))
-                    .signAsync(context.keyring.alice, { nonce: aliceNonce++ }),
-                await polkadotJs.tx.sudo
-                    .sudo(polkadotJs.tx.invulnerables.removeInvulnerable(dave.address))
-                    .signAsync(context.keyring.alice, { nonce: aliceNonce++ }),
                 await polkadotJs.tx.pooledStaking
                     .requestDelegate(alice.address, "ManualRewards", 10000n * DANCE)
                     .signAsync(context.keyring.alice, { nonce: aliceNonce++ }),

--- a/test/suites/dev-tanssi/session-keys/test_remove_session_key_staking.ts
+++ b/test/suites/dev-tanssi/session-keys/test_remove_session_key_staking.ts
@@ -14,11 +14,13 @@ describeSuite({
         let alice: KeyringPair;
         let bob: KeyringPair;
         let charlie: KeyringPair;
+        let dave: KeyringPair;
 
         beforeAll(async () => {
             alice = context.keyring.alice;
             bob = context.keyring.bob;
             charlie = context.keyring.charlie;
+            dave = context.keyring.dave;
             polkadotJs = context.polkadotJs();
 
             let aliceNonce = (await polkadotJs.rpc.system.accountNextIndex(alice.address)).toNumber();
@@ -33,7 +35,16 @@ describeSuite({
             await context.createBlock([
                 // Remove all invulnerables, otherwise they have priority
                 await polkadotJs.tx.sudo
-                    .sudo(polkadotJs.tx.invulnerables.setInvulnerables([]))
+                    .sudo(polkadotJs.tx.invulnerables.removeInvulnerable(alice.address))
+                    .signAsync(context.keyring.alice, { nonce: aliceNonce++ }),
+                await polkadotJs.tx.sudo
+                    .sudo(polkadotJs.tx.invulnerables.removeInvulnerable(bob.address))
+                    .signAsync(context.keyring.alice, { nonce: aliceNonce++ }),
+                await polkadotJs.tx.sudo
+                    .sudo(polkadotJs.tx.invulnerables.removeInvulnerable(charlie.address))
+                    .signAsync(context.keyring.alice, { nonce: aliceNonce++ }),
+                await polkadotJs.tx.sudo
+                    .sudo(polkadotJs.tx.invulnerables.removeInvulnerable(dave.address))
                     .signAsync(context.keyring.alice, { nonce: aliceNonce++ }),
                 await polkadotJs.tx.pooledStaking
                     .requestDelegate(alice.address, "ManualRewards", 10000n * DANCE)

--- a/test/suites/dev-tanssi/staking/test_staking_rewards_balanced.ts
+++ b/test/suites/dev-tanssi/staking/test_staking_rewards_balanced.ts
@@ -19,11 +19,15 @@ describeSuite({
         let polkadotJs: ApiPromise;
         let alice: KeyringPair;
         let bob: KeyringPair;
+        let charlie: KeyringPair;
+        let dave: KeyringPair;
 
         beforeAll(async () => {
             polkadotJs = context.polkadotJs();
             alice = context.keyring.alice;
             bob = context.keyring.bob;
+            charlie = context.keyring.charlie;
+            dave = context.keyring.dave;
             let aliceNonce = (await polkadotJs.rpc.system.accountNextIndex(alice.address)).toNumber();
             let bobNonce = (await polkadotJs.rpc.system.accountNextIndex(bob.address)).toNumber();
             // We need to remove from invulnerables and add to staking
@@ -35,7 +39,16 @@ describeSuite({
             await context.createBlock([
                 // Remove all invulnerables, otherwise they have priority
                 await polkadotJs.tx.sudo
-                    .sudo(polkadotJs.tx.invulnerables.setInvulnerables([]))
+                    .sudo(polkadotJs.tx.invulnerables.removeInvulnerable(alice.address))
+                    .signAsync(context.keyring.alice, { nonce: aliceNonce++ }),
+                await polkadotJs.tx.sudo
+                    .sudo(polkadotJs.tx.invulnerables.removeInvulnerable(bob.address))
+                    .signAsync(context.keyring.alice, { nonce: aliceNonce++ }),
+                await polkadotJs.tx.sudo
+                    .sudo(polkadotJs.tx.invulnerables.removeInvulnerable(charlie.address))
+                    .signAsync(context.keyring.alice, { nonce: aliceNonce++ }),
+                await polkadotJs.tx.sudo
+                    .sudo(polkadotJs.tx.invulnerables.removeInvulnerable(dave.address))
                     .signAsync(context.keyring.alice, { nonce: aliceNonce++ }),
                 await polkadotJs.tx.pooledStaking
                     .requestDelegate(alice.address, "AutoCompounding", 10000n * DANCE)

--- a/test/suites/dev-tanssi/staking/test_staking_rewards_balanced.ts
+++ b/test/suites/dev-tanssi/staking/test_staking_rewards_balanced.ts
@@ -28,7 +28,11 @@ describeSuite({
 
             // We need to remove all the invulnerables and add to staking
             // Remove all invulnerables, otherwise they have priority
-            await createBlockAndRemoveInvulnerables(context);
+
+            await createBlockAndRemoveInvulnerables(context, alice);
+
+            const invulnerables = await polkadotJs.query.invulnerables.invulnerables();
+            expect(invulnerables.length).to.be.equal(0);
 
             // We will make each of them self-delegate the min amount, while
             // we will make each of them delegate the other with 50%

--- a/test/suites/dev-tanssi/staking/test_staking_rewards_balanced.ts
+++ b/test/suites/dev-tanssi/staking/test_staking_rewards_balanced.ts
@@ -25,11 +25,11 @@ describeSuite({
             polkadotJs = context.polkadotJs();
             alice = context.keyring.alice;
             bob = context.keyring.bob;
-            
+
             // We need to remove all the invulnerables and add to staking
             // Remove all invulnerables, otherwise they have priority
             await createBlockAndRemoveInvulnerables(context);
-            
+
             // We will make each of them self-delegate the min amount, while
             // we will make each of them delegate the other with 50%
             // Alice autocompounding, Bob will be manual

--- a/test/suites/dev-tanssi/staking/test_staking_rewards_non_balanced.ts
+++ b/test/suites/dev-tanssi/staking/test_staking_rewards_non_balanced.ts
@@ -1,5 +1,5 @@
 import "@tanssi/api-augment";
-import { describeSuite, expect, beforeAll } from "@moonwall/cli";
+import { describeSuite, expect, beforeAll, TECHNICAL_COMMITTEE_MEMBERS } from "@moonwall/cli";
 import { ApiPromise } from "@polkadot/api";
 import { KeyringPair } from "@moonwall/util";
 import {
@@ -10,6 +10,7 @@ import {
     jumpSessions,
 } from "util/block";
 import { DANCE } from "util/constants";
+import { createBlockAndRemoveInvulnerables } from "util/invulnerables";
 
 describeSuite({
     id: "DT0303",
@@ -19,37 +20,23 @@ describeSuite({
         let polkadotJs: ApiPromise;
         let alice: KeyringPair;
         let bob: KeyringPair;
-        let charlie: KeyringPair;
-        let dave: KeyringPair;
 
         beforeAll(async () => {
             polkadotJs = context.polkadotJs();
             alice = context.keyring.alice;
             bob = context.keyring.bob;
-            charlie = context.keyring.charlie;
-            dave = context.keyring.dave;
-            let aliceNonce = (await polkadotJs.rpc.system.accountNextIndex(alice.address)).toNumber();
-            let bobNonce = (await polkadotJs.rpc.system.accountNextIndex(bob.address)).toNumber();
-            // We need to remove from invulnerables and add to staking
-            // for that we need to remove Alice and Bob from invulnerables first
+            
+            // We need to remove all the invulnerables and add to staking
+            // Remove all invulnerables, otherwise they have priority
+            await createBlockAndRemoveInvulnerables(context);
+            
             // We will make each of them self-delegate the min amount, while
             // we will make each of them delegate the other with 50%
             // Alice autocompounding, Bob will be manual
+            let aliceNonce = (await polkadotJs.rpc.system.accountNextIndex(alice.address)).toNumber();
+            let bobNonce = (await polkadotJs.rpc.system.accountNextIndex(bob.address)).toNumber();
 
             await context.createBlock([
-                // Remove all invulnerables, otherwise they have priority
-                await polkadotJs.tx.sudo
-                    .sudo(polkadotJs.tx.invulnerables.removeInvulnerable(alice.address))
-                    .signAsync(context.keyring.alice, { nonce: aliceNonce++ }),
-                await polkadotJs.tx.sudo
-                    .sudo(polkadotJs.tx.invulnerables.removeInvulnerable(bob.address))
-                    .signAsync(context.keyring.alice, { nonce: aliceNonce++ }),
-                await polkadotJs.tx.sudo
-                    .sudo(polkadotJs.tx.invulnerables.removeInvulnerable(charlie.address))
-                    .signAsync(context.keyring.alice, { nonce: aliceNonce++ }),
-                await polkadotJs.tx.sudo
-                    .sudo(polkadotJs.tx.invulnerables.removeInvulnerable(dave.address))
-                    .signAsync(context.keyring.alice, { nonce: aliceNonce++ }),
                 await polkadotJs.tx.pooledStaking
                     .requestDelegate(alice.address, "AutoCompounding", 18000n * DANCE)
                     .signAsync(context.keyring.alice, { nonce: aliceNonce++ }),
@@ -76,7 +63,8 @@ describeSuite({
                 const events = await polkadotJs.query.system.events();
                 const issuance = await fetchIssuance(events).amount.toBigInt();
                 const chainRewards = (issuance * 7n) / 10n;
-                const expectedOrchestratorReward = chainRewards - (chainRewards * 2n) / 3n;
+                const rounding = chainRewards % 3n > 0 ? 1n : 0n;
+                const expectedOrchestratorReward = chainRewards - (chainRewards * 2n) / 3n - rounding;
                 const reward = await fetchRewardAuthorOrchestrator(events);
                 const stakingRewardedCollator = await filterRewardStakingCollator(events, reward.accountId.toString());
                 const stakingRewardedDelegators = await filterRewardStakingDelegators(

--- a/test/suites/dev-tanssi/staking/test_staking_rewards_non_balanced.ts
+++ b/test/suites/dev-tanssi/staking/test_staking_rewards_non_balanced.ts
@@ -19,11 +19,15 @@ describeSuite({
         let polkadotJs: ApiPromise;
         let alice: KeyringPair;
         let bob: KeyringPair;
+        let charlie: KeyringPair;
+        let dave: KeyringPair;
 
         beforeAll(async () => {
             polkadotJs = context.polkadotJs();
             alice = context.keyring.alice;
             bob = context.keyring.bob;
+            charlie = context.keyring.charlie;
+            dave = context.keyring.dave;
             let aliceNonce = (await polkadotJs.rpc.system.accountNextIndex(alice.address)).toNumber();
             let bobNonce = (await polkadotJs.rpc.system.accountNextIndex(bob.address)).toNumber();
             // We need to remove from invulnerables and add to staking
@@ -35,7 +39,16 @@ describeSuite({
             await context.createBlock([
                 // Remove all invulnerables, otherwise they have priority
                 await polkadotJs.tx.sudo
-                    .sudo(polkadotJs.tx.invulnerables.setInvulnerables([]))
+                    .sudo(polkadotJs.tx.invulnerables.removeInvulnerable(alice.address))
+                    .signAsync(context.keyring.alice, { nonce: aliceNonce++ }),
+                await polkadotJs.tx.sudo
+                    .sudo(polkadotJs.tx.invulnerables.removeInvulnerable(bob.address))
+                    .signAsync(context.keyring.alice, { nonce: aliceNonce++ }),
+                await polkadotJs.tx.sudo
+                    .sudo(polkadotJs.tx.invulnerables.removeInvulnerable(charlie.address))
+                    .signAsync(context.keyring.alice, { nonce: aliceNonce++ }),
+                await polkadotJs.tx.sudo
+                    .sudo(polkadotJs.tx.invulnerables.removeInvulnerable(dave.address))
                     .signAsync(context.keyring.alice, { nonce: aliceNonce++ }),
                 await polkadotJs.tx.pooledStaking
                     .requestDelegate(alice.address, "AutoCompounding", 18000n * DANCE)

--- a/test/suites/dev-tanssi/staking/test_staking_rewards_non_balanced.ts
+++ b/test/suites/dev-tanssi/staking/test_staking_rewards_non_balanced.ts
@@ -28,7 +28,10 @@ describeSuite({
 
             // We need to remove all the invulnerables and add to staking
             // Remove all invulnerables, otherwise they have priority
-            await createBlockAndRemoveInvulnerables(context);
+            await createBlockAndRemoveInvulnerables(context, alice);
+
+            const invulnerables = await polkadotJs.query.invulnerables.invulnerables();
+            expect(invulnerables.length).to.be.equal(0);
 
             // We will make each of them self-delegate the min amount, while
             // we will make each of them delegate the other with 50%

--- a/test/suites/dev-tanssi/staking/test_staking_rewards_non_balanced.ts
+++ b/test/suites/dev-tanssi/staking/test_staking_rewards_non_balanced.ts
@@ -25,11 +25,11 @@ describeSuite({
             polkadotJs = context.polkadotJs();
             alice = context.keyring.alice;
             bob = context.keyring.bob;
-            
+
             // We need to remove all the invulnerables and add to staking
             // Remove all invulnerables, otherwise they have priority
             await createBlockAndRemoveInvulnerables(context);
-            
+
             // We will make each of them self-delegate the min amount, while
             // we will make each of them delegate the other with 50%
             // Alice autocompounding, Bob will be manual

--- a/test/suites/dev-tanssi/staking/test_staking_rewards_non_balanced.ts
+++ b/test/suites/dev-tanssi/staking/test_staking_rewards_non_balanced.ts
@@ -1,5 +1,5 @@
 import "@tanssi/api-augment";
-import { describeSuite, expect, beforeAll, TECHNICAL_COMMITTEE_MEMBERS } from "@moonwall/cli";
+import { describeSuite, expect, beforeAll } from "@moonwall/cli";
 import { ApiPromise } from "@polkadot/api";
 import { KeyringPair } from "@moonwall/util";
 import {

--- a/test/suites/warp-sync/test_warp_sync.ts
+++ b/test/suites/warp-sync/test_warp_sync.ts
@@ -161,13 +161,11 @@ describeSuite({
                 // Deregister Collator2000-02, it should delete the db
                 const invuln = (await paraApi.query.invulnerables.invulnerables()).toJSON();
 
-                const newInvuln = invuln.filter((addr) => {
-                    return u8aToHex(decodeAddress(addr)) != getKeyringNimbusIdHex("Collator2000-02");
-                });
-                // It must have changed
-                expect(newInvuln).to.not.deep.equal(invuln);
+                const invulnerable_to_remove = invuln.filter((addr) => {
+                    return u8aToHex(decodeAddress(addr)) == getKeyringNimbusIdHex("Collator2000-02");
+                })[0];
 
-                const tx = paraApi.tx.invulnerables.setInvulnerables(newInvuln);
+                const tx = paraApi.tx.invulnerables.removeInvulnerable(invulnerable_to_remove);
                 await signAndSendAndInclude(paraApi.tx.sudo.sudo(tx), alice);
 
                 await waitSessions(context, paraApi, 2);

--- a/test/util/invulnerables.ts
+++ b/test/util/invulnerables.ts
@@ -1,0 +1,21 @@
+import { DevModeContext } from "@moonwall/cli";
+
+export async function createBlockAndRemoveInvulnerables(context: DevModeContext) {
+    
+    let nonce = (await context.polkadotJs().rpc.system.accountNextIndex(context.keyring.alice.address)).toNumber();
+
+    await context.createBlock([
+        context.polkadotJs().tx.sudo
+            .sudo(context.polkadotJs().tx.invulnerables.removeInvulnerable(context.keyring.alice.address))
+            .signAsync(context.keyring.alice, { nonce: nonce++ }),
+        context.polkadotJs().tx.sudo
+            .sudo(context.polkadotJs().tx.invulnerables.removeInvulnerable(context.keyring.bob.address))
+            .signAsync(context.keyring.alice, { nonce: nonce++ }),
+        context.polkadotJs().tx.sudo
+            .sudo(context.polkadotJs().tx.invulnerables.removeInvulnerable(context.keyring.charlie.address))
+            .signAsync(context.keyring.alice, { nonce: nonce++ }),
+        context.polkadotJs().tx.sudo
+            .sudo(context.polkadotJs().tx.invulnerables.removeInvulnerable(context.keyring.dave.address))
+            .signAsync(context.keyring.alice, { nonce: nonce++ })
+    ]);
+}

--- a/test/util/invulnerables.ts
+++ b/test/util/invulnerables.ts
@@ -5,13 +5,12 @@ export async function createBlockAndRemoveInvulnerables(context: DevModeContext,
     let nonce = (await context.polkadotJs().rpc.system.accountNextIndex(sudoKey.address)).toNumber();
     const invulnerables = await context.polkadotJs().query.invulnerables.invulnerables();
 
-    const txs = invulnerables.map((invulnerable) => {
-            context
-                .polkadotJs()
-                .tx.sudo.sudo(context.polkadotJs().tx.invulnerables.removeInvulnerable(invulnerable))
-                .signAsync(sudoKey, { nonce: nonce++ })
-        );
-    });
+    const txs = invulnerables.map((invulnerable) =>
+        context
+            .polkadotJs()
+            .tx.sudo.sudo(context.polkadotJs().tx.invulnerables.removeInvulnerable(invulnerable))
+            .signAsync(sudoKey, { nonce: nonce++ })
+    );
 
     await context.createBlock(txs);
 }

--- a/test/util/invulnerables.ts
+++ b/test/util/invulnerables.ts
@@ -1,21 +1,24 @@
 import { DevModeContext } from "@moonwall/cli";
 
 export async function createBlockAndRemoveInvulnerables(context: DevModeContext) {
-    
     let nonce = (await context.polkadotJs().rpc.system.accountNextIndex(context.keyring.alice.address)).toNumber();
 
     await context.createBlock([
-        context.polkadotJs().tx.sudo
-            .sudo(context.polkadotJs().tx.invulnerables.removeInvulnerable(context.keyring.alice.address))
+        context
+            .polkadotJs()
+            .tx.sudo.sudo(context.polkadotJs().tx.invulnerables.removeInvulnerable(context.keyring.alice.address))
             .signAsync(context.keyring.alice, { nonce: nonce++ }),
-        context.polkadotJs().tx.sudo
-            .sudo(context.polkadotJs().tx.invulnerables.removeInvulnerable(context.keyring.bob.address))
+        context
+            .polkadotJs()
+            .tx.sudo.sudo(context.polkadotJs().tx.invulnerables.removeInvulnerable(context.keyring.bob.address))
             .signAsync(context.keyring.alice, { nonce: nonce++ }),
-        context.polkadotJs().tx.sudo
-            .sudo(context.polkadotJs().tx.invulnerables.removeInvulnerable(context.keyring.charlie.address))
+        context
+            .polkadotJs()
+            .tx.sudo.sudo(context.polkadotJs().tx.invulnerables.removeInvulnerable(context.keyring.charlie.address))
             .signAsync(context.keyring.alice, { nonce: nonce++ }),
-        context.polkadotJs().tx.sudo
-            .sudo(context.polkadotJs().tx.invulnerables.removeInvulnerable(context.keyring.dave.address))
-            .signAsync(context.keyring.alice, { nonce: nonce++ })
+        context
+            .polkadotJs()
+            .tx.sudo.sudo(context.polkadotJs().tx.invulnerables.removeInvulnerable(context.keyring.dave.address))
+            .signAsync(context.keyring.alice, { nonce: nonce++ }),
     ]);
 }

--- a/test/util/invulnerables.ts
+++ b/test/util/invulnerables.ts
@@ -5,9 +5,7 @@ export async function createBlockAndRemoveInvulnerables(context: DevModeContext,
     let nonce = (await context.polkadotJs().rpc.system.accountNextIndex(sudoKey.address)).toNumber();
     const invulnerables = await context.polkadotJs().query.invulnerables.invulnerables();
 
-    const txs = [];
-    invulnerables.forEach((invulnerable) => {
-        txs.push(
+    const txs = invulnerables.map((invulnerable) => {
             context
                 .polkadotJs()
                 .tx.sudo.sudo(context.polkadotJs().tx.invulnerables.removeInvulnerable(invulnerable))

--- a/typescript-api/src/dancebox/interfaces/augment-api-tx.ts
+++ b/typescript-api/src/dancebox/interfaces/augment-api-tx.ts
@@ -1110,11 +1110,6 @@ declare module "@polkadot/api-base/types/submittable" {
                 (who: AccountId32 | string | Uint8Array) => SubmittableExtrinsic<ApiType>,
                 [AccountId32]
             >;
-            /** See [`Pallet::set_invulnerables`]. */
-            setInvulnerables: AugmentedSubmittable<
-                (updated: Vec<AccountId32> | (AccountId32 | string | Uint8Array)[]) => SubmittableExtrinsic<ApiType>,
-                [Vec<AccountId32>]
-            >;
             /** Generic tx */
             [key: string]: SubmittableExtrinsicFunction<ApiType>;
         };

--- a/typescript-api/src/dancebox/interfaces/lookup.ts
+++ b/typescript-api/src/dancebox/interfaces/lookup.ts
@@ -2697,12 +2697,6 @@ export default {
     /** Lookup294: pallet_invulnerables::pallet::Call<T> */
     PalletInvulnerablesCall: {
         _enum: {
-            set_invulnerables: {
-                _alias: {
-                    new_: "new",
-                },
-                new_: "Vec<AccountId32>",
-            },
             add_invulnerable: {
                 who: "AccountId32",
             },

--- a/typescript-api/src/dancebox/interfaces/lookup.ts
+++ b/typescript-api/src/dancebox/interfaces/lookup.ts
@@ -2697,6 +2697,7 @@ export default {
     /** Lookup294: pallet_invulnerables::pallet::Call<T> */
     PalletInvulnerablesCall: {
         _enum: {
+            __Unused0: "Null",
             add_invulnerable: {
                 who: "AccountId32",
             },

--- a/typescript-api/src/dancebox/interfaces/types-lookup.ts
+++ b/typescript-api/src/dancebox/interfaces/types-lookup.ts
@@ -3609,10 +3609,6 @@ declare module "@polkadot/types/lookup" {
 
     /** @name PalletInvulnerablesCall (294) */
     interface PalletInvulnerablesCall extends Enum {
-        readonly isSetInvulnerables: boolean;
-        readonly asSetInvulnerables: {
-            readonly new_: Vec<AccountId32>;
-        } & Struct;
         readonly isAddInvulnerable: boolean;
         readonly asAddInvulnerable: {
             readonly who: AccountId32;
@@ -3621,7 +3617,7 @@ declare module "@polkadot/types/lookup" {
         readonly asRemoveInvulnerable: {
             readonly who: AccountId32;
         } & Struct;
-        readonly type: "SetInvulnerables" | "AddInvulnerable" | "RemoveInvulnerable";
+        readonly type: "AddInvulnerable" | "RemoveInvulnerable";
     }
 
     /** @name PalletSessionCall (295) */

--- a/typescript-api/src/flashbox/interfaces/augment-api-tx.ts
+++ b/typescript-api/src/flashbox/interfaces/augment-api-tx.ts
@@ -566,11 +566,6 @@ declare module "@polkadot/api-base/types/submittable" {
                 (who: AccountId32 | string | Uint8Array) => SubmittableExtrinsic<ApiType>,
                 [AccountId32]
             >;
-            /** See [`Pallet::set_invulnerables`]. */
-            setInvulnerables: AugmentedSubmittable<
-                (updated: Vec<AccountId32> | (AccountId32 | string | Uint8Array)[]) => SubmittableExtrinsic<ApiType>,
-                [Vec<AccountId32>]
-            >;
             /** Generic tx */
             [key: string]: SubmittableExtrinsicFunction<ApiType>;
         };

--- a/typescript-api/src/flashbox/interfaces/lookup.ts
+++ b/typescript-api/src/flashbox/interfaces/lookup.ts
@@ -1601,6 +1601,7 @@ export default {
     /** Lookup229: pallet_invulnerables::pallet::Call<T> */
     PalletInvulnerablesCall: {
         _enum: {
+            __Unused0: "Null",
             add_invulnerable: {
                 who: "AccountId32",
             },

--- a/typescript-api/src/flashbox/interfaces/lookup.ts
+++ b/typescript-api/src/flashbox/interfaces/lookup.ts
@@ -1601,12 +1601,6 @@ export default {
     /** Lookup229: pallet_invulnerables::pallet::Call<T> */
     PalletInvulnerablesCall: {
         _enum: {
-            set_invulnerables: {
-                _alias: {
-                    new_: "new",
-                },
-                new_: "Vec<AccountId32>",
-            },
             add_invulnerable: {
                 who: "AccountId32",
             },

--- a/typescript-api/src/flashbox/interfaces/types-lookup.ts
+++ b/typescript-api/src/flashbox/interfaces/types-lookup.ts
@@ -2095,10 +2095,6 @@ declare module "@polkadot/types/lookup" {
 
     /** @name PalletInvulnerablesCall (229) */
     interface PalletInvulnerablesCall extends Enum {
-        readonly isSetInvulnerables: boolean;
-        readonly asSetInvulnerables: {
-            readonly new_: Vec<AccountId32>;
-        } & Struct;
         readonly isAddInvulnerable: boolean;
         readonly asAddInvulnerable: {
             readonly who: AccountId32;
@@ -2107,7 +2103,7 @@ declare module "@polkadot/types/lookup" {
         readonly asRemoveInvulnerable: {
             readonly who: AccountId32;
         } & Struct;
-        readonly type: "SetInvulnerables" | "AddInvulnerable" | "RemoveInvulnerable";
+        readonly type: "AddInvulnerable" | "RemoveInvulnerable";
     }
 
     /** @name PalletSessionCall (230) */


### PR DESCRIPTION
This PR solves 2 tickets:
MD326
- Removes set_invulnerables extrinsic
- Rewrites rust integration tests to use add_invulnerable instead of set_invulnerables
- Rewrites moonwall tests to use add_invulnerable instead of set_invulnerables
- Removes benchmark and weights related to set_invulnerables
MD325
- Changes the remove_invulnerable return type to charge the fees depending on the actual weight consumed in the execution
- Changes the benchmarking function to remove the last element, thus causing to have to read every element in the list and covering the worst-case scenario for the call
