### PR TITLE
Store tanssi slot number in author noting pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7718,6 +7718,7 @@ dependencies = [
  "hex",
  "hex-literal 0.3.4",
  "log",
+ "nimbus-primitives",
  "parity-scale-codec",
  "polkadot-parachain-primitives",
  "polkadot-primitives",

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -905,13 +905,10 @@ fn start_consensus_orchestrator(
             let relay_chain_interface = relay_chain_interace_for_cidp.clone();
             let client_set_aside_for_cidp = client_set_aside_for_cidp.clone();
             async move {
-                // Create a storage proof of paras->heads for all registered para ids, and also for
-                // self para id.
-                // TODO: this should be only container chains with assigned collators?
-                let mut para_ids = client_set_aside_for_cidp
+                let para_ids = client_set_aside_for_cidp
                     .runtime_api()
                     .registered_paras(block_hash)?;
-                para_ids.push(para_id);
+                let para_ids: Vec<_> = para_ids.into_iter().collect();
                 let author_noting_inherent =
                     tp_author_noting_inherent::OwnParachainInherentData::create_at(
                         relay_parent,

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -905,10 +905,13 @@ fn start_consensus_orchestrator(
             let relay_chain_interface = relay_chain_interace_for_cidp.clone();
             let client_set_aside_for_cidp = client_set_aside_for_cidp.clone();
             async move {
-                let para_ids = client_set_aside_for_cidp
+                // Create a storage proof of paras->heads for all registered para ids, and also for
+                // self para id.
+                // TODO: this should be only container chains with assigned collators?
+                let mut para_ids = client_set_aside_for_cidp
                     .runtime_api()
                     .registered_paras(block_hash)?;
-                let para_ids: Vec<_> = para_ids.into_iter().collect();
+                para_ids.push(para_id);
                 let author_noting_inherent =
                     tp_author_noting_inherent::OwnParachainInherentData::create_at(
                         relay_parent,

--- a/pallets/author-noting/Cargo.toml
+++ b/pallets/author-noting/Cargo.toml
@@ -33,6 +33,7 @@ cumulus-pallet-parachain-system = { workspace = true }
 cumulus-primitives-core = { workspace = true }
 dp-chain-state-snapshot = { workspace = true }
 dp-core = { workspace = true }
+nimbus-primitives = { workspace = true}
 tp-author-noting-inherent = { workspace = true }
 tp-traits = { workspace = true }
 

--- a/pallets/author-noting/Cargo.toml
+++ b/pallets/author-noting/Cargo.toml
@@ -33,7 +33,7 @@ cumulus-pallet-parachain-system = { workspace = true }
 cumulus-primitives-core = { workspace = true }
 dp-chain-state-snapshot = { workspace = true }
 dp-core = { workspace = true }
-nimbus-primitives = { workspace = true}
+nimbus-primitives = { workspace = true }
 tp-author-noting-inherent = { workspace = true }
 tp-traits = { workspace = true }
 
@@ -63,6 +63,7 @@ std = [
 	"hex",
 	"hex?/std",
 	"log/std",
+	"nimbus-primitives/std",
 	"parity-scale-codec/std",
 	"polkadot-parachain-primitives/std",
 	"polkadot-primitives/std",
@@ -91,6 +92,7 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"hex",
+	"nimbus-primitives/runtime-benchmarks",
 	"polkadot-parachain-primitives/runtime-benchmarks",
 	"polkadot-primitives/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
@@ -100,5 +102,6 @@ try-runtime = [
 	"cumulus-pallet-parachain-system/try-runtime",
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
+	"nimbus-primitives/try-runtime",
 	"sp-runtime/try-runtime",
 ]

--- a/pallets/author-noting/src/lib.rs
+++ b/pallets/author-noting/src/lib.rs
@@ -388,7 +388,9 @@ impl<T: Config> Pallet<T> {
             Ok(ContainerChainBlockInfo {
                 block_number: author_header.number,
                 author,
-                latest_slot_number: slot,
+                // TODO: this needs to be the tanssi slot, not the container chain slot,
+                // unimplemented for now, will always be 0
+                latest_slot_number: 0.into(),
             })
         } else {
             Err(Error::<T>::NonAuraDigest)

--- a/pallets/author-noting/src/mock.rs
+++ b/pallets/author-noting/src/mock.rs
@@ -141,6 +141,15 @@ impl tp_traits::GetContainerChainAuthor<AccountId> for MockAuthorFetcher {
     fn set_authors_for_para_id(_para_id: ParaId, _authors: Vec<AccountId>) {}
 }
 
+pub struct DummyBeacon {}
+impl nimbus_primitives::SlotBeacon for DummyBeacon {
+    fn slot() -> u32 {
+        let block_number = System::block_number();
+
+        block_number as u32
+    }
+}
+
 pub struct MockContainerChainGetter;
 
 impl tp_traits::GetCurrentContainerChains for MockContainerChainGetter {
@@ -179,12 +188,12 @@ impl RelaychainStateProvider for MockRelayStateProvider {
     }
 }
 
-// Implement the sudo module's `Config` on the Test runtime.
 impl Config for Test {
     type WeightInfo = ();
     type RuntimeEvent = RuntimeEvent;
     type ContainerChainAuthor = MockAuthorFetcher;
     type SelfParaId = ParachainId;
+    type SlotBeacon = DummyBeacon;
     type ContainerChains = MockContainerChainGetter;
     type AuthorNotingHook = ();
     type RelayChainStateProvider = MockRelayStateProvider;

--- a/pallets/author-noting/src/tests.rs
+++ b/pallets/author-noting/src/tests.rs
@@ -68,7 +68,7 @@ fn test_author_id_insertion() {
                 Some(ContainerChainBlockInfo {
                     block_number: 1,
                     author: 13u64,
-                    latest_slot_number: 13u64.into(),
+                    latest_slot_number: 0u64.into(),
                 })
             );
         });
@@ -108,7 +108,7 @@ fn test_author_id_insertion_real_data() {
                 Some(ContainerChainBlockInfo {
                     block_number: 3511063,
                     author: 140006956,
-                    latest_slot_number: 140006956u64.into()
+                    latest_slot_number: 0u64.into()
                 })
             );
         });
@@ -189,7 +189,7 @@ fn test_author_id_insertion_many_paras() {
                 Some(ContainerChainBlockInfo {
                     block_number: 1,
                     author: 10u64,
-                    latest_slot_number: 10u64.into()
+                    latest_slot_number: 0u64.into()
                 })
             );
             assert_eq!(AuthorNoting::latest_author(ParaId::from(1002)), None);
@@ -200,7 +200,7 @@ fn test_author_id_insertion_many_paras() {
                 Some(ContainerChainBlockInfo {
                     block_number: 2,
                     author: 13u64,
-                    latest_slot_number: 13u64.into()
+                    latest_slot_number: 0u64.into()
                 })
             );
             assert_eq!(
@@ -208,7 +208,7 @@ fn test_author_id_insertion_many_paras() {
                 Some(ContainerChainBlockInfo {
                     block_number: 1,
                     author: 14u64,
-                    latest_slot_number: 14u64.into()
+                    latest_slot_number: 0u64.into()
                 })
             );
         });
@@ -248,7 +248,7 @@ fn test_should_panic_with_invalid_proof_root() {
                 Some(ContainerChainBlockInfo {
                     block_number: 1,
                     author: 13u64,
-                    latest_slot_number: 13u64.into()
+                    latest_slot_number: 0u64.into()
                 })
             );
         });
@@ -291,7 +291,7 @@ fn test_should_panic_with_invalid_proof_state() {
                 Some(ContainerChainBlockInfo {
                     block_number: 1,
                     author: 13u64,
-                    latest_slot_number: 13u64.into()
+                    latest_slot_number: 0u64.into()
                 })
             );
         });
@@ -512,7 +512,7 @@ fn test_set_author() {
                 Some(ContainerChainBlockInfo {
                     block_number: 1,
                     author: 13u64,
-                    latest_slot_number: 13u64.into()
+                    latest_slot_number: 0u64.into()
                 })
             );
             assert_ok!(AuthorNoting::set_author(
@@ -665,7 +665,7 @@ fn weights_assigned_to_extrinsics_are_correct() {
                 para_id: 1.into(),
                 block_number: 1,
                 author: 1u64,
-                latest_slot_number: 1u64.into()
+                latest_slot_number: 0u64.into()
             }
             .get_dispatch_info()
             .weight,
@@ -732,7 +732,7 @@ fn test_kill_author_data() {
                 Some(ContainerChainBlockInfo {
                     block_number: 1,
                     author: 13u64,
-                    latest_slot_number: 13u64.into()
+                    latest_slot_number: 0u64.into()
                 })
             );
             assert_ok!(AuthorNoting::kill_author_data(
@@ -784,7 +784,7 @@ fn test_author_id_insertion_not_first_log() {
                 Some(ContainerChainBlockInfo {
                     block_number: 1,
                     author: 13u64,
-                    latest_slot_number: 13u64.into()
+                    latest_slot_number: 0u64.into()
                 })
             );
         });

--- a/pallets/author-noting/src/tests.rs
+++ b/pallets/author-noting/src/tests.rs
@@ -68,7 +68,7 @@ fn test_author_id_insertion() {
                 Some(ContainerChainBlockInfo {
                     block_number: 1,
                     author: 13u64,
-                    latest_slot_number: 0u64.into(),
+                    latest_slot_number: 1u64.into(),
                 })
             );
         });
@@ -108,7 +108,7 @@ fn test_author_id_insertion_real_data() {
                 Some(ContainerChainBlockInfo {
                     block_number: 3511063,
                     author: 140006956,
-                    latest_slot_number: 0u64.into()
+                    latest_slot_number: 1u64.into()
                 })
             );
         });
@@ -189,7 +189,7 @@ fn test_author_id_insertion_many_paras() {
                 Some(ContainerChainBlockInfo {
                     block_number: 1,
                     author: 10u64,
-                    latest_slot_number: 0u64.into()
+                    latest_slot_number: 1u64.into()
                 })
             );
             assert_eq!(AuthorNoting::latest_author(ParaId::from(1002)), None);
@@ -200,7 +200,7 @@ fn test_author_id_insertion_many_paras() {
                 Some(ContainerChainBlockInfo {
                     block_number: 2,
                     author: 13u64,
-                    latest_slot_number: 0u64.into()
+                    latest_slot_number: 2u64.into()
                 })
             );
             assert_eq!(
@@ -208,7 +208,7 @@ fn test_author_id_insertion_many_paras() {
                 Some(ContainerChainBlockInfo {
                     block_number: 1,
                     author: 14u64,
-                    latest_slot_number: 0u64.into()
+                    latest_slot_number: 2u64.into()
                 })
             );
         });
@@ -512,7 +512,7 @@ fn test_set_author() {
                 Some(ContainerChainBlockInfo {
                     block_number: 1,
                     author: 13u64,
-                    latest_slot_number: 0u64.into()
+                    latest_slot_number: 1u64.into()
                 })
             );
             assert_ok!(AuthorNoting::set_author(
@@ -732,7 +732,7 @@ fn test_kill_author_data() {
                 Some(ContainerChainBlockInfo {
                     block_number: 1,
                     author: 13u64,
-                    latest_slot_number: 0u64.into()
+                    latest_slot_number: 1u64.into()
                 })
             );
             assert_ok!(AuthorNoting::kill_author_data(
@@ -784,7 +784,7 @@ fn test_author_id_insertion_not_first_log() {
                 Some(ContainerChainBlockInfo {
                     block_number: 1,
                     author: 13u64,
-                    latest_slot_number: 0u64.into()
+                    latest_slot_number: 1u64.into()
                 })
             );
         });

--- a/runtime/dancebox/src/lib.rs
+++ b/runtime/dancebox/src/lib.rs
@@ -938,6 +938,7 @@ impl pallet_author_noting::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type ContainerChains = Registrar;
     type SelfParaId = parachain_info::Pallet<Runtime>;
+    type SlotBeacon = dp_consensus::AuraDigestSlotBeacon<Runtime>;
     type ContainerChainAuthor = CollatorAssignment;
     type RelayChainStateProvider = cumulus_pallet_parachain_system::RelaychainDataProvider<Self>;
     type AuthorNotingHook = (InflationRewards, ServicesPayment);

--- a/runtime/dancebox/tests/integration_test.rs
+++ b/runtime/dancebox/tests/integration_test.rs
@@ -1791,7 +1791,7 @@ fn test_author_noting_not_self_para() {
                 Some(ContainerChainBlockInfo {
                     block_number: 1,
                     author: AccountId::from(DAVE),
-                    latest_slot_number: 5.into(),
+                    latest_slot_number: 0.into(),
                 })
             );
         });
@@ -1940,7 +1940,7 @@ fn test_author_noting_runtime_api() {
                 Some(ContainerChainBlockInfo {
                     block_number: 1,
                     author: AccountId::from(DAVE),
-                    latest_slot_number: 5.into(),
+                    latest_slot_number: 0.into(),
                 })
             );
 

--- a/runtime/flashbox/src/lib.rs
+++ b/runtime/flashbox/src/lib.rs
@@ -788,6 +788,7 @@ impl pallet_author_noting::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type ContainerChains = Registrar;
     type SelfParaId = parachain_info::Pallet<Runtime>;
+    type SlotBeacon = dp_consensus::AuraDigestSlotBeacon<Runtime>;
     type ContainerChainAuthor = CollatorAssignment;
     type RelayChainStateProvider = cumulus_pallet_parachain_system::RelaychainDataProvider<Self>;
     type AuthorNotingHook = (InflationRewards, ServicesPayment);

--- a/runtime/flashbox/tests/integration_test.rs
+++ b/runtime/flashbox/tests/integration_test.rs
@@ -1780,7 +1780,7 @@ fn test_author_noting_not_self_para() {
                 Some(ContainerChainBlockInfo {
                     block_number: 1,
                     author: AccountId::from(DAVE),
-                    latest_slot_number: 5.into(),
+                    latest_slot_number: 0.into(),
                 })
             );
         });
@@ -1929,7 +1929,7 @@ fn test_author_noting_runtime_api() {
                 Some(ContainerChainBlockInfo {
                     block_number: 1,
                     author: AccountId::from(DAVE),
-                    latest_slot_number: 5.into(),
+                    latest_slot_number: 0.into(),
                 })
             );
 


### PR DESCRIPTION
We want this slot number to be the tanssi slot number, not the container chain slot number. Doesn't need a migration because this is not yet deployed.