### PR TITLE
Fix S09C02 and S08C03

### DIFF
--- a/test/suites/smoke-test-common/test-inflation-rewards.ts
+++ b/test/suites/smoke-test-common/test-inflation-rewards.ts
@@ -93,8 +93,9 @@ describeSuite({
 
                 const supplyAfter = (await apiAtIssuanceAfter.query.balances.totalIssuance()).toBigInt();
 
-                // expected issuance block increment in prod is: 19n/1_000_000_000n
-                const expectedIssuanceIncrement = (supplyBefore * 19n) / 1_000_000_000n;
+                // expected issuance block increment in prod
+                const expectedIssuanceIncrement =
+                    runtimeVersion > 500 ? (supplyBefore * 9n) / 1_000_000_000n : (supplyBefore * 19n) / 1_000_000_000n;
 
                 // we know there might be rounding errors, so we always check it is in the range +-1
                 expect(

--- a/test/suites/smoke-test-dancebox/test-randomness-consistency.ts
+++ b/test/suites/smoke-test-dancebox/test-randomness-consistency.ts
@@ -42,7 +42,8 @@ describeSuite({
                 if (runtimeVersion < 300) {
                     return;
                 }
-                const sessionLength = 300;
+                const sessionLength = runtimeVersion > 500 ? 600 : 300;
+
                 const currentBlock = (await api.rpc.chain.getBlock()).block.header.number.toNumber();
 
                 const blockToCheck = Math.trunc(currentBlock / sessionLength) * sessionLength;


### PR DESCRIPTION
## Description
This PR fixes `S09C02` and `S08C03` typescript test by conditionally changing `sessionLength` and `inflationIncrement` depending upon whether runtime is > 500 or not. 