### PR TITLE
Set AllowMultipleBlocksPerSlot = true in flashbox

### DIFF
--- a/runtime/flashbox/src/lib.rs
+++ b/runtime/flashbox/src/lib.rs
@@ -505,7 +505,7 @@ parameter_types! {
 }
 
 impl pallet_async_backing::Config for Runtime {
-    type AllowMultipleBlocksPerSlot = ConstBool<false>;
+    type AllowMultipleBlocksPerSlot = ConstBool<true>;
     type GetAndVerifySlot =
         pallet_async_backing::ParaSlot<RELAY_CHAIN_SLOT_DURATION_MILLIS, ParaSlotProvider>;
     type ExpectedBlockTime = ExpectedBlockTime;


### PR DESCRIPTION
This enables a setting that was missing in flashbox, to allow collators to create multiple blocks after a delay in block production. Enabling this will improve the average block time. Dancebox has already enabled it, and we have tested it using zombienet.