### PR TITLE
forbid teleports and fix command in templates

### DIFF
--- a/container-chains/nodes/frontier/src/command.rs
+++ b/container-chains/nodes/frontier/src/command.rs
@@ -53,7 +53,7 @@ fn load_spec(id: &str, para_id: ParaId) -> std::result::Result<Box<dyn ChainSpec
 
 impl SubstrateCli for Cli {
     fn impl_name() -> String {
-        "Container Chain Simple Node".into()
+        "Container Chain Frontier Node".into()
     }
 
     fn impl_version() -> String {
@@ -62,7 +62,7 @@ impl SubstrateCli for Cli {
 
     fn description() -> String {
         format!(
-            "Container Chain Simple Node\n\nThe command-line arguments provided first will be \
+            "Container Chain Frontier Node\n\nThe command-line arguments provided first will be \
 		passed to the parachain node, while the arguments provided after -- will be passed \
 		to the relay chain node.\n\n\
 		{} <parachain-args> -- <relay-chain-args>",
@@ -89,7 +89,7 @@ impl SubstrateCli for Cli {
 
 impl SubstrateCli for RelayChainCli {
     fn impl_name() -> String {
-        "Container Chain Simple Node".into()
+        "Container Chain Frontier Node".into()
     }
 
     fn impl_version() -> String {
@@ -98,7 +98,7 @@ impl SubstrateCli for RelayChainCli {
 
     fn description() -> String {
         format!(
-            "Container Chain Simple Node\n\nThe command-line arguments provided first will be \
+            "Container Chain Frontier Node\n\nThe command-line arguments provided first will be \
 		passed to the parachain node, while the arguments provided after -- will be passed \
 		to the relay chain node.\n\n\
 		{} <parachain-args> -- <relay-chain-args>",

--- a/container-chains/runtime-templates/frontier/src/xcm_config.rs
+++ b/container-chains/runtime-templates/frontier/src/xcm_config.rs
@@ -447,13 +447,15 @@ impl pallet_asset_rate::Config for Runtime {
 parameter_types! {
     pub const TrustPolicyMaxAssets: u32 = 1000;
     pub const AllNativeTrustPolicy: DefaultTrustPolicy = DefaultTrustPolicy::AllNative;
+    pub const AllNeverTrustPolicy: DefaultTrustPolicy = DefaultTrustPolicy::Never;
+
 }
 impl pallet_xcm_executor_utils::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type TrustPolicyMaxAssets = TrustPolicyMaxAssets;
     type ReserveDefaultTrustPolicy = AllNativeTrustPolicy;
     type SetReserveTrustOrigin = EnsureRoot<AccountId>;
-    type TeleportDefaultTrustPolicy = AllNativeTrustPolicy;
+    type TeleportDefaultTrustPolicy = AllNeverTrustPolicy;
     type SetTeleportTrustOrigin = EnsureRoot<AccountId>;
     type WeightInfo = weights::pallet_xcm_executor_utils::SubstrateWeight<Runtime>;
 }

--- a/container-chains/runtime-templates/frontier/src/xcm_config.rs
+++ b/container-chains/runtime-templates/frontier/src/xcm_config.rs
@@ -448,7 +448,6 @@ parameter_types! {
     pub const TrustPolicyMaxAssets: u32 = 1000;
     pub const AllNativeTrustPolicy: DefaultTrustPolicy = DefaultTrustPolicy::AllNative;
     pub const AllNeverTrustPolicy: DefaultTrustPolicy = DefaultTrustPolicy::Never;
-
 }
 impl pallet_xcm_executor_utils::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;

--- a/container-chains/runtime-templates/simple/src/xcm_config.rs
+++ b/container-chains/runtime-templates/simple/src/xcm_config.rs
@@ -412,13 +412,14 @@ pub type AssetRateAsMultiplier =
 parameter_types! {
     pub const TrustPolicyMaxAssets: u32 = 1000;
     pub const AllNativeTrustPolicy: DefaultTrustPolicy = DefaultTrustPolicy::AllNative;
+    pub const AllNeverTrustPolicy: DefaultTrustPolicy = DefaultTrustPolicy::Never;
 }
 impl pallet_xcm_executor_utils::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type TrustPolicyMaxAssets = TrustPolicyMaxAssets;
     type ReserveDefaultTrustPolicy = AllNativeTrustPolicy;
     type SetReserveTrustOrigin = EnsureRoot<AccountId>;
-    type TeleportDefaultTrustPolicy = AllNativeTrustPolicy;
+    type TeleportDefaultTrustPolicy = AllNeverTrustPolicy;
     type SetTeleportTrustOrigin = EnsureRoot<AccountId>;
     type WeightInfo = weights::pallet_xcm_executor_utils::SubstrateWeight<Runtime>;
 }

--- a/test/suites/common-xcm/xcm-token-reception/test_dmp_token_reception_teleport.ts
+++ b/test/suites/common-xcm/xcm-token-reception/test_dmp_token_reception_teleport.ts
@@ -1,0 +1,96 @@
+import { beforeAll, describeSuite, expect } from "@moonwall/cli";
+import { KeyringPair, alith } from "@moonwall/util";
+import { ApiPromise, Keyring } from "@polkadot/api";
+import { u8aToHex } from "@polkadot/util";
+
+import { RawXcmMessage, XcmFragment, injectDmpMessageAndSeal } from "../../../util/xcm.ts";
+import { RELAY_SOURCE_LOCATION, RELAY_SOURCE_LOCATION_2 } from "../../../util/constants.ts";
+
+describeSuite({
+    id: "TX0107",
+    title: "Mock XCM - Succeeds receiving tokens DMP",
+    foundationMethods: "dev",
+    testCases: ({ context, it }) => {
+        let polkadotJs: ApiPromise;
+        let transferredBalance;
+        let alice: KeyringPair;
+        let chain;
+
+        beforeAll(async function () {
+            polkadotJs = context.polkadotJs();
+            chain = polkadotJs.consts.system.version.specName.toString();
+            // since in the future is likely that we are going to add this to containers, I leave it here
+            alice =
+                chain == "frontier-template"
+                    ? alith
+                    : new Keyring({ type: "sr25519" }).addFromUri("//Alice", {
+                          name: "Alice default",
+                      });
+
+            transferredBalance = context.isEthereumChain ? 10_000_000_000_000_000_000n : 10_000_000_000_000n;
+
+            // We register the token
+            const txSigned = polkadotJs.tx.sudo.sudo(
+                polkadotJs.tx.utility.batch([
+                    polkadotJs.tx.foreignAssetsCreator.createForeignAsset(
+                        RELAY_SOURCE_LOCATION,
+                        1,
+                        alice.address,
+                        true,
+                        1
+                    ),
+                    polkadotJs.tx.assetRate.create(
+                        1,
+                        // this defines how much the asset costs with respect to the
+                        // new asset
+                        // in this case, asset*2=native
+                        // that means that we will charge 0.5 of the native balance
+                        2000000000000000000n
+                    ),
+                ])
+            );
+
+            await context.createBlock(await txSigned.signAsync(alice), {
+                allowFailures: false,
+            });
+        });
+
+        it({
+            id: "T01",
+            title: "Should fail receiving tokens",
+            test: async function () {
+                // Send an XCM and create block to execute it
+                const xcmMessage = new XcmFragment({
+                    assets: [
+                        {
+                            multilocation: {
+                                parents: 1,
+                                interior: { Here: null },
+                            },
+                            fungible: transferredBalance,
+                        },
+                    ],
+                    beneficiary: u8aToHex(alice.addressRaw),
+                })
+                    .teleported_assets_received()
+                    .clear_origin()
+                    .buy_execution()
+                    .deposit_asset()
+                    .as_v3();
+
+                // Send an XCM and create block to execute it
+                await injectDmpMessageAndSeal(context, {
+                    type: "XcmVersionedXcm",
+                    payload: xcmMessage,
+                } as RawXcmMessage);
+
+                // Create a block in which the XCM will be executed
+                await context.createBlock();
+
+                // Make sure the state does not have ALITH's DOT tokens
+                const alice_dot_balance = await context.polkadotJs().query.foreignAssets.account(1, alice.address);
+                expect(alice_dot_balance.isNone).to.be.true;
+            },
+        });
+    },
+});

--- a/test/suites/common-xcm/xcm-token-reception/test_dmp_token_reception_teleport.ts
+++ b/test/suites/common-xcm/xcm-token-reception/test_dmp_token_reception_teleport.ts
@@ -4,7 +4,7 @@ import { ApiPromise, Keyring } from "@polkadot/api";
 import { u8aToHex } from "@polkadot/util";
 
 import { RawXcmMessage, XcmFragment, injectDmpMessageAndSeal } from "../../../util/xcm.ts";
-import { RELAY_SOURCE_LOCATION, RELAY_SOURCE_LOCATION_2 } from "../../../util/constants.ts";
+import { RELAY_SOURCE_LOCATION } from "../../../util/constants.ts";
 
 describeSuite({
     id: "TX0107",

--- a/test/util/xcm.ts
+++ b/test/util/xcm.ts
@@ -298,6 +298,21 @@ export class XcmFragment {
         return this;
     }
 
+    // Add a `ReceiveTeleportedAsset` instruction
+    teleported_assets_received(): this {
+        this.instructions.push({
+            ReceiveTeleportedAsset: this.config.assets.map(({ multilocation, fungible }) => {
+                return {
+                    id: {
+                        Concrete: multilocation,
+                    },
+                    fun: { Fungible: fungible },
+                };
+            }, this),
+        });
+        return this;
+    }
+
     // Add a `WithdrawAsset` instruction
     withdraw_asset(): this {
         this.instructions.push({


### PR DESCRIPTION
Fixes the teleport policy as well as the command yield in the frontier template