### PR TITLE
Add rimraf to devDependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,15 @@ settings:
 
 importers:
 
+  .:
+    dependencies:
+      api-augment:0.400.0:
+        specifier: link:@tanssi/api-augment:0.400.0
+        version: link:@tanssi/api-augment:0.400.0
+      api-augment:latest:
+        specifier: link:@tanssi/api-augment:latest
+        version: link:@tanssi/api-augment:latest
+
   test:
     dependencies:
       '@zombienet/orchestrator':
@@ -184,6 +193,9 @@ importers:
       prettier-plugin-jsdoc:
         specifier: ^0.3.38
         version: 0.3.38(prettier@2.8.8)
+      rimraf:
+        specifier: ^5.0.5
+        version: 5.0.5
       tsx:
         specifier: ^4.7.0
         version: 4.7.0
@@ -4709,6 +4721,7 @@ packages:
       chalk: 3.0.0
       diff-match-patch: 1.0.5
     dev: true
+    bundledDependencies: []
 
   /jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
@@ -6067,6 +6080,14 @@ packages:
       glob: 7.2.3
     dev: true
 
+  /rimraf@5.0.5:
+    resolution: {integrity: sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dependencies:
+      glob: 10.3.10
+    dev: true
+
   /rlp@3.0.0:
     resolution: {integrity: sha512-PD6U2PGk6Vq2spfgiWZdomLvRGDreBLxi5jv5M8EpRo3pU6VEm31KO+HFxE18Q3vgqfDrQ9pZA3FP95rkijNKw==}
     hasBin: true
@@ -6385,6 +6406,9 @@ packages:
   /sqlite3@5.1.7:
     resolution: {integrity: sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==}
     requiresBuild: true
+    peerDependenciesMeta:
+      node-gyp:
+        optional: true
     dependencies:
       bindings: 1.5.0
       node-addon-api: 7.1.0

--- a/typescript-api/package.json
+++ b/typescript-api/package.json
@@ -96,6 +96,7 @@
         "@polkadot/typegen": "^10.11.2",
         "prettier": "^2.8.8",
         "prettier-plugin-jsdoc": "^0.3.38",
+        "rimraf": "^5.0.5",
         "tsx": "^4.7.0",
         "typescript": "^5.3.3"
     }


### PR DESCRIPTION
Fixes error when generating typescript-api with pnpm v9 instead of v8.

```
sh: 1: rimraf: not found
 ELIFECYCLE  Command failed.
Error: Command failed: pnpm run build
```