### PR TITLE
Remove `expect` which was checking `supplyAfter == supplyBefore + issuance`

### DIFF
--- a/test/suites/smoke-test-common/test-inflation-rewards.ts
+++ b/test/suites/smoke-test-common/test-inflation-rewards.ts
@@ -102,7 +102,6 @@ describeSuite({
                     issuance >= expectedIssuanceIncrement - 1n && issuance <= expectedIssuanceIncrement + 1n,
                     `Issuance not in the range, Actual: ${issuance}, Expected:  ${expectedIssuanceIncrement}`
                 ).to.be.true;
-                expect(supplyAfter).to.equal(supplyBefore + issuance);
             },
         });
 


### PR DESCRIPTION
## Description
This PR removes an  `expect` which was checking `supplyAfter == supplyBefore + issuance`; since this cannot hold in scenarios where users burn their token or if protocol burn part of the payment it received.