### PR TITLE
deprecate at least in container-chain nodes, native executor

### DIFF
--- a/container-chains/nodes/frontier/src/client.rs
+++ b/container-chains/nodes/frontier/src/client.rs
@@ -15,21 +15,11 @@
 // along with Tanssi.  If not, see <http://www.gnu.org/licenses/>.
 
 // Substrate
-use {
-    sc_executor::{NativeExecutionDispatch, NativeVersion},
-    sp_consensus_aura::sr25519::AuthorityId as AuraId,
-};
+use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 // Local
 use container_chain_template_frontier_runtime::{opaque::Block, AccountId, Index};
 
 use crate::eth::EthCompatRuntimeApiCollection;
-
-/// Only enable the benchmarking host functions when we actually want to benchmark.
-#[cfg(feature = "runtime-benchmarks")]
-pub type HostFunctions = frame_benchmarking::benchmarking::HostFunctions;
-/// Otherwise we use empty host functions for ext host functions.
-#[cfg(not(feature = "runtime-benchmarks"))]
-pub type HostFunctions = ();
 
 /// A set of APIs that every runtimes must implement.
 pub trait BaseRuntimeApiCollection:

--- a/container-chains/nodes/frontier/src/client.rs
+++ b/container-chains/nodes/frontier/src/client.rs
@@ -31,19 +31,6 @@ pub type HostFunctions = frame_benchmarking::benchmarking::HostFunctions;
 #[cfg(not(feature = "runtime-benchmarks"))]
 pub type HostFunctions = ();
 
-pub struct TemplateRuntimeExecutor;
-impl NativeExecutionDispatch for TemplateRuntimeExecutor {
-    type ExtendHostFunctions = HostFunctions;
-
-    fn dispatch(method: &str, data: &[u8]) -> Option<Vec<u8>> {
-        container_chain_template_frontier_runtime::api::dispatch(method, data)
-    }
-
-    fn native_version() -> NativeVersion {
-        container_chain_template_frontier_runtime::native_version()
-    }
-}
-
 /// A set of APIs that every runtimes must implement.
 pub trait BaseRuntimeApiCollection:
     sp_api::ApiExt<Block>

--- a/container-chains/nodes/frontier/src/service.rs
+++ b/container-chains/nodes/frontier/src/service.rs
@@ -18,7 +18,6 @@
 
 #[allow(deprecated)]
 use {
-    crate::client::TemplateRuntimeExecutor,
     container_chain_template_frontier_runtime::{opaque::Block, RuntimeApi},
     cumulus_client_cli::CollatorOptions,
     cumulus_client_consensus_common::ParachainBlockImport as TParachainBlockImport,
@@ -33,7 +32,7 @@ use {
     parity_scale_codec::Encode,
     polkadot_parachain_primitives::primitives::HeadData,
     sc_consensus::BasicQueue,
-    sc_executor::NativeElseWasmExecutor,
+    sc_executor::WasmExecutor,
     sc_service::{Configuration, TFullBackend, TFullClient, TaskManager},
     sp_blockchain::HeaderBackend,
     sp_consensus_slots::{Slot, SlotDuration},
@@ -45,7 +44,7 @@ use {
     },
 };
 
-type ParachainExecutor = WasmExecytor<TemplateRuntimeExecutor>;
+type ParachainExecutor = WasmExecutor<sp_io::SubstrateHostFunctions>;
 type ParachainClient = TFullClient<Block, RuntimeApi, ParachainExecutor>;
 type ParachainBackend = TFullBackend<Block>;
 type ParachainBlockImport = TParachainBlockImport<

--- a/container-chains/nodes/frontier/src/service.rs
+++ b/container-chains/nodes/frontier/src/service.rs
@@ -45,7 +45,7 @@ use {
     },
 };
 
-type ParachainExecutor = NativeElseWasmExecutor<TemplateRuntimeExecutor>;
+type ParachainExecutor = WasmExecytor<TemplateRuntimeExecutor>;
 type ParachainClient = TFullClient<Block, RuntimeApi, ParachainExecutor>;
 type ParachainBackend = TFullBackend<Block>;
 type ParachainBlockImport = TParachainBlockImport<

--- a/container-chains/nodes/simple/src/service.rs
+++ b/container-chains/nodes/simple/src/service.rs
@@ -31,7 +31,7 @@ use {
     parity_scale_codec::Encode,
     polkadot_parachain_primitives::primitives::HeadData,
     sc_consensus::BasicQueue,
-    sc_executor::NativeElseWasmExecutor,
+    sc_executor::WasmExecutor,
     sc_service::{Configuration, TFullBackend, TFullClient, TaskManager},
     sp_blockchain::HeaderBackend,
     sp_consensus_slots::{Slot, SlotDuration},
@@ -55,7 +55,7 @@ impl sc_executor::NativeExecutionDispatch for ParachainNativeExecutor {
     }
 }
 
-type ParachainExecutor = NativeElseWasmExecutor<ParachainNativeExecutor>;
+type ParachainExecutor = WasmExecutor<ParachainNativeExecutor>;
 type ParachainClient = TFullClient<Block, RuntimeApi, ParachainExecutor>;
 type ParachainBackend = TFullBackend<Block>;
 type ParachainBlockImport = TParachainBlockImport<Block, Arc<ParachainClient>, ParachainBackend>;

--- a/container-chains/nodes/simple/src/service.rs
+++ b/container-chains/nodes/simple/src/service.rs
@@ -40,22 +40,7 @@ use {
     std::{sync::Arc, time::Duration},
 };
 
-/// Native executor type.
-pub struct ParachainNativeExecutor;
-
-impl sc_executor::NativeExecutionDispatch for ParachainNativeExecutor {
-    type ExtendHostFunctions = frame_benchmarking::benchmarking::HostFunctions;
-
-    fn dispatch(method: &str, data: &[u8]) -> Option<Vec<u8>> {
-        container_chain_template_simple_runtime::api::dispatch(method, data)
-    }
-
-    fn native_version() -> sc_executor::NativeVersion {
-        container_chain_template_simple_runtime::native_version()
-    }
-}
-
-type ParachainExecutor = WasmExecutor<ParachainNativeExecutor>;
+type ParachainExecutor = WasmExecutor<sp_io::SubstrateHostFunctions>;
 type ParachainClient = TFullClient<Block, RuntimeApi, ParachainExecutor>;
 type ParachainBackend = TFullBackend<Block>;
 type ParachainBlockImport = TParachainBlockImport<Block, Arc<ParachainClient>, ParachainBackend>;


### PR DESCRIPTION
We have seen a lot of people customizing the template runtime but not changing the spec name. This makes the full-nodes use the native compiled runtime and fail importing blocks.

I am not a big fan of doing it, but since it's the trend that comes from polkadot-sdk (see https://github.com/paritytech/polkadot-sdk/pull/4329) I guess we should start using only the wasm-executor