### PR TITLE
Services payment RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3051,6 +3051,7 @@ dependencies = [
  "pallet-relay-storage-roots",
  "pallet-root-testing",
  "pallet-services-payment",
+ "pallet-services-payment-runtime-api",
  "pallet-session",
  "pallet-staking",
  "pallet-stream-payment",
@@ -4310,6 +4311,7 @@ dependencies = [
  "pallet-relay-storage-roots",
  "pallet-root-testing",
  "pallet-services-payment",
+ "pallet-services-payment-runtime-api",
  "pallet-session",
  "pallet-stream-payment",
  "pallet-stream-payment-runtime-api",
@@ -9134,6 +9136,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-services-payment-runtime-api"
+version = "0.1.0"
+dependencies = [
+ "parity-scale-codec",
+ "sp-api",
+]
+
+[[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
 source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-v1.6.0#7b16c9ecbe06c53affbbb32991875b0c1e5f59f6"
@@ -13635,6 +13645,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "services-payment-rpc"
+version = "0.1.0"
+dependencies = [
+ "futures 0.3.30",
+ "jsonrpsee",
+ "pallet-services-payment-runtime-api",
+ "parity-scale-codec",
+ "sc-client-api",
+ "sp-api",
+ "sp-runtime",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15428,6 +15451,7 @@ dependencies = [
  "sc-transaction-pool-api",
  "serde",
  "serde_json",
+ "services-payment-rpc",
  "sp-api",
  "sp-block-builder",
  "sp-blockchain",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ pallet-pooled-staking = { path = "pallets/pooled-staking", default-features = fa
 pallet-registrar = { path = "pallets/registrar", default-features = false }
 pallet-registrar-runtime-api = { path = "pallets/registrar/rpc/runtime-api", default-features = false }
 pallet-services-payment = { path = "pallets/services-payment", default-features = false }
+pallet-services-payment-runtime-api = { path = "pallets/services-payment/rpc/runtime-api", default-features = false }
 pallet-stream-payment = { path = "pallets/stream-payment", default-features = false }
 pallet-stream-payment-runtime-api = { path = "pallets/stream-payment/rpc/runtime-api", default-features = false }
 pallet-xcm-core-buyer = { path = "pallets/xcm-core-buyer", default-features = false }
@@ -73,6 +74,7 @@ flashbox-runtime = { path = "runtime/flashbox", default-features = false }
 manual-xcm-rpc = { path = "client/manual-xcm" }
 node-common = { path = "client/node-common" }
 runtime-common = { path = "runtime/common", default-features = false }
+services-payment-rpc = { path = "client/services-payment" }
 stream-payment-rpc = { path = "client/stream-payment" }
 tanssi-relay-encoder = { path = "runtime/relay-encoder", default-features = false }
 tc-consensus = { path = "client/consensus" }

--- a/client/services-payment/Cargo.toml
+++ b/client/services-payment/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "services-payment-rpc"
+authors = { workspace = true }
+description = "RPC interface for the Services Payment pallet"
+edition = "2021"
+license = "GPL-3.0-only"
+version = "0.1.0"
+
+[package.metadata.docs.rs]
+targets = [ "x86_64-unknown-linux-gnu" ]
+
+[lints]
+workspace = true
+
+[dependencies]
+futures = { workspace = true }
+jsonrpsee = { workspace = true }
+pallet-services-payment-runtime-api = { workspace = true, features = [ "std" ] }
+parity-scale-codec = { workspace = true }
+sc-client-api = { workspace = true }
+sp-api = { workspace = true, features = [ "std" ] }
+sp-runtime = { workspace = true, features = [ "std" ] }

--- a/client/services-payment/src/lib.rs
+++ b/client/services-payment/src/lib.rs
@@ -1,0 +1,94 @@
+// Copyright (C) Moondance Labs Ltd.
+// This file is part of Tanssi.
+
+// Tanssi is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Tanssi is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Tanssi.  If not, see <http://www.gnu.org/licenses/>
+
+//! RPC client for Services Payment pallet
+
+pub use pallet_services_payment_runtime_api::ServicesPaymentApi as ServicesPaymentRuntimeApi;
+use {
+    core::marker::PhantomData,
+    jsonrpsee::{
+        core::{async_trait, RpcResult},
+        proc_macros::rpc,
+    },
+    sc_client_api::UsageProvider,
+    sp_api::ProvideRuntimeApi,
+    sp_runtime::traits::Block as BlockT,
+    std::sync::Arc,
+};
+
+#[rpc(server)]
+pub trait ServicesPaymentApi<Balance, ParaId> {
+    #[method(name = "tanssi_servicesPaymentBlockCost")]
+    async fn block_cost(&self, para_id: ParaId) -> RpcResult<Balance>;
+
+    #[method(name = "tanssi_servicesPaymentCollatorAssignmentCost")]
+    async fn collator_assignment_cost(&self, para_id: ParaId) -> RpcResult<Balance>;
+}
+
+pub struct ServicesPayment<Client, Block> {
+    client: Arc<Client>,
+    _phantom: PhantomData<Block>,
+}
+
+impl<Client, Block> ServicesPayment<Client, Block> {
+    pub fn new(client: Arc<Client>) -> Self {
+        Self {
+            client,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+#[async_trait]
+impl<Client, Hash, Block, Balance, ParaId> ServicesPaymentApiServer<Balance, ParaId>
+    for ServicesPayment<Client, Block>
+where
+    Hash: Send + 'static,
+    Block: BlockT<Hash = Hash>,
+    Client: ProvideRuntimeApi<Block> + Sync + Send + UsageProvider<Block> + 'static,
+    Client::Api: ServicesPaymentRuntimeApi<Block, Balance, ParaId>,
+    Balance: parity_scale_codec::Codec + Send + 'static,
+    ParaId: parity_scale_codec::Codec + Send + 'static,
+{
+    async fn block_cost(&self, para_id: ParaId) -> RpcResult<Balance> {
+        let cost = self
+            .client
+            .runtime_api()
+            .block_cost(self.client.usage_info().chain.best_hash, para_id)
+            .map_err(|e| internal_err(e))?;
+        Ok(cost)
+    }
+
+    async fn collator_assignment_cost(&self, para_id: ParaId) -> RpcResult<Balance> {
+        let cost = self
+            .client
+            .runtime_api()
+            .collator_assignment_cost(self.client.usage_info().chain.best_hash, para_id)
+            .map_err(|e| internal_err(e))?;
+        Ok(cost)
+    }
+}
+
+pub fn internal_err<T: ToString>(error: T) -> jsonrpsee::core::Error {
+    jsonrpsee::core::Error::Call(jsonrpsee::types::error::CallError::Custom(
+        jsonrpsee::types::error::ErrorObject::borrowed(
+            jsonrpsee::types::error::INTERNAL_ERROR_CODE,
+            &error.to_string(),
+            None,
+        )
+        .into_owned(),
+    ))
+}

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -36,6 +36,7 @@ pallet-author-noting-runtime-api = { workspace = true, features = [ "std" ] }
 pallet-collator-assignment-runtime-api = { workspace = true, features = [ "std" ] }
 pallet-configuration = { workspace = true, features = [ "std" ] }
 pallet-registrar-runtime-api = { workspace = true, features = [ "std" ] }
+services-payment-rpc = { workspace = true }
 stream-payment-rpc = { workspace = true }
 tp-author-noting-inherent = { workspace = true, features = [ "std" ] }
 tp-container-chain-genesis-data = { workspace = true, features = [ "json", "std" ] }

--- a/pallets/services-payment/rpc/runtime-api/Cargo.toml
+++ b/pallets/services-payment/rpc/runtime-api/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "pallet-services-payment-runtime-api"
+authors = { workspace = true }
+description = "Runtime API definition of pallet-services-payment"
+edition = "2021"
+license = "GPL-3.0-only"
+version = "0.1.0"
+
+[package.metadata.docs.rs]
+targets = [ "x86_64-unknown-linux-gnu" ]
+
+[lints]
+workspace = true
+
+[dependencies]
+parity-scale-codec = { workspace = true }
+sp-api = { workspace = true }
+
+[features]
+default = [ "std" ]
+std = [
+	"parity-scale-codec/std",
+	"sp-api/std",
+]

--- a/pallets/services-payment/rpc/runtime-api/src/lib.rs
+++ b/pallets/services-payment/rpc/runtime-api/src/lib.rs
@@ -1,0 +1,30 @@
+// Copyright (C) Moondance Labs Ltd.
+// This file is part of Tanssi.
+
+// Tanssi is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Tanssi is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Tanssi.  If not, see <http://www.gnu.org/licenses/>
+
+//! Runtime API for Services Payment pallet
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+sp_api::decl_runtime_apis! {
+    pub trait ServicesPaymentApi<Balance, ParaId>
+    where
+        Balance: parity_scale_codec::Codec,
+        ParaId: parity_scale_codec::Codec,
+    {
+        fn block_cost(para_id: ParaId) -> Balance;
+        fn collator_assignment_cost(para_id: ParaId) -> Balance;
+    }
+}

--- a/runtime/dancebox/Cargo.toml
+++ b/runtime/dancebox/Cargo.toml
@@ -40,6 +40,7 @@ pallet-registrar = { workspace = true }
 pallet-registrar-runtime-api = { workspace = true }
 pallet-relay-storage-roots = { workspace = true }
 pallet-services-payment = { workspace = true }
+pallet-services-payment-runtime-api = { workspace = true }
 pallet-stream-payment = { workspace = true }
 pallet-stream-payment-runtime-api = { workspace = true }
 pallet-xcm-core-buyer = { workspace = true }
@@ -209,6 +210,7 @@ std = [
 	"pallet-registrar/std",
 	"pallet-relay-storage-roots/std",
 	"pallet-root-testing/std",
+	"pallet-services-payment-runtime-api/std",
 	"pallet-services-payment/std",
 	"pallet-session/std",
 	"pallet-staking/std",

--- a/runtime/dancebox/src/lib.rs
+++ b/runtime/dancebox/src/lib.rs
@@ -2342,6 +2342,18 @@ impl_runtime_apis! {
             SLOT_DURATION
         }
     }
+
+    impl pallet_services_payment_runtime_api::ServicesPaymentApi<Block, Balance, ParaId> for Runtime {
+        fn block_cost(para_id: ParaId) -> Balance {
+            let (block_production_costs, _) = <Runtime as pallet_services_payment::Config>::ProvideBlockProductionCost::block_cost(&para_id);
+            block_production_costs
+        }
+
+        fn collator_assignment_cost(para_id: ParaId) -> Balance {
+            let (collator_assignment_costs, _) = <Runtime as pallet_services_payment::Config>::ProvideCollatorAssignmentCost::collator_assignment_cost(&para_id);
+            collator_assignment_costs
+        }
+    }
 }
 
 struct CheckInherents;

--- a/runtime/flashbox/Cargo.toml
+++ b/runtime/flashbox/Cargo.toml
@@ -38,6 +38,7 @@ pallet-registrar = { workspace = true }
 pallet-registrar-runtime-api = { workspace = true }
 pallet-relay-storage-roots = { workspace = true }
 pallet-services-payment = { workspace = true }
+pallet-services-payment-runtime-api = { workspace = true }
 pallet-stream-payment = { workspace = true }
 pallet-stream-payment-runtime-api = { workspace = true }
 runtime-common = { workspace = true }
@@ -167,6 +168,7 @@ std = [
 	"pallet-registrar/std",
 	"pallet-relay-storage-roots/std",
 	"pallet-root-testing/std",
+	"pallet-services-payment-runtime-api/std",
 	"pallet-services-payment/std",
 	"pallet-session/std",
 	"pallet-stream-payment-runtime-api/std",

--- a/runtime/flashbox/src/lib.rs
+++ b/runtime/flashbox/src/lib.rs
@@ -1907,6 +1907,18 @@ impl_runtime_apis! {
             SLOT_DURATION
         }
     }
+
+    impl pallet_services_payment_runtime_api::ServicesPaymentApi<Block, Balance, ParaId> for Runtime {
+        fn block_cost(para_id: ParaId) -> Balance {
+            let (block_production_costs, _) = <Runtime as pallet_services_payment::Config>::ProvideBlockProductionCost::block_cost(&para_id);
+            block_production_costs
+        }
+
+        fn collator_assignment_cost(para_id: ParaId) -> Balance {
+            let (collator_assignment_costs, _) = <Runtime as pallet_services_payment::Config>::ProvideCollatorAssignmentCost::collator_assignment_cost(&para_id);
+            collator_assignment_costs
+        }
+    }
 }
 
 struct CheckInherents;

--- a/test/suites/common-tanssi/services-payment/test_services_payment_rpc.ts
+++ b/test/suites/common-tanssi/services-payment/test_services_payment_rpc.ts
@@ -1,13 +1,11 @@
 import "@tanssi/api-augment";
-import { describeSuite, beforeAll, expect, customDevRpcRequest } from "@moonwall/cli";
-import { KeyringPair } from "@moonwall/util";
-import { ApiPromise } from "@polkadot/api";
+import { describeSuite, expect, customDevRpcRequest } from "@moonwall/cli";
 
 describeSuite({
     id: "CT0609",
     title: "Stream payment RPC",
     foundationMethods: "dev",
-    testCases: ({ it, context }) => {
+    testCases: ({ it }) => {
         it({
             id: "E01",
             title: "Stream payment RPC",

--- a/test/suites/common-tanssi/services-payment/test_services_payment_rpc.ts
+++ b/test/suites/common-tanssi/services-payment/test_services_payment_rpc.ts
@@ -1,0 +1,27 @@
+import "@tanssi/api-augment";
+import { describeSuite, beforeAll, expect, customDevRpcRequest } from "@moonwall/cli";
+import { KeyringPair } from "@moonwall/util";
+import { ApiPromise } from "@polkadot/api";
+
+describeSuite({
+    id: "CT0609",
+    title: "Stream payment RPC",
+    foundationMethods: "dev",
+    testCases: ({ it, context }) => {
+        it({
+            id: "E01",
+            title: "Stream payment RPC",
+            test: async function () {
+                try {
+                    await customDevRpcRequest("tanssi_servicesPaymentBlockCost", []);
+                    throw { message: "Should have returned an error" };
+                } catch (e: any) {
+                    expect(e.message.toString()).to.eq("No more params");
+                }
+
+                expect(await customDevRpcRequest("tanssi_servicesPaymentBlockCost", [1000])).eq(1000000);
+                expect(await customDevRpcRequest("tanssi_servicesPaymentCollatorAssignmentCost", [1000])).eq(100000000);
+            },
+        });
+    },
+});

--- a/test/suites/common-tanssi/services-payment/test_services_payment_rpc.ts
+++ b/test/suites/common-tanssi/services-payment/test_services_payment_rpc.ts
@@ -3,12 +3,12 @@ import { describeSuite, expect, customDevRpcRequest } from "@moonwall/cli";
 
 describeSuite({
     id: "CT0609",
-    title: "Stream payment RPC",
+    title: "Services payment RPC",
     foundationMethods: "dev",
     testCases: ({ it }) => {
         it({
             id: "E01",
-            title: "Stream payment RPC",
+            title: "Services payment RPC",
             test: async function () {
                 try {
                     await customDevRpcRequest("tanssi_servicesPaymentBlockCost", []);


### PR DESCRIPTION
Adds a runtime API and node RPC methods for getting the block production and collator assignment cost for `ServicesPayment`