### PR TITLE
Remove runtime-benchmark cargo check on CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,8 +264,6 @@ jobs:
               with:
                   name: binaries
                   path: binaries
-            - name: Check runtime benchmarks
-              run: cargo check --features=runtime-benchmarks --release --all
 
     rust-test:
         runs-on: self-hosted


### PR DESCRIPTION
The Clippy workflow already runs with `runtime-benchmark` feature, making the `cargo check` in the CI workflow redundant.