### PR TITLE
Make some smoke tests more consistent

### DIFF
--- a/test/suites/smoke-test-common/test-inflation-rewards.ts
+++ b/test/suites/smoke-test-common/test-inflation-rewards.ts
@@ -3,7 +3,7 @@ import { ApiPromise } from "@polkadot/api";
 
 import { ApiDecoration } from "@polkadot/api/types";
 import { getAuthorFromDigest } from "util/author";
-import { fetchIssuance, filterRewardFromOrchestrator, fetchRewardAuthorContainers } from "util/block";
+import { fetchIssuance, filterRewardFromOrchestratorWithFailure, fetchRewardAuthorContainers } from "util/block";
 import { PARACHAIN_BOND } from "util/constants";
 
 describeSuite({
@@ -47,7 +47,7 @@ describeSuite({
                 const chainRewards = (issuance * 7n) / 10n;
                 const numberOfChains = await apiAt.query.registrar.registeredParaIds();
                 const expectedOrchestratorReward = chainRewards / BigInt(numberOfChains.length + 1);
-                const reward = await filterRewardFromOrchestrator(events, account);
+                const reward = await filterRewardFromOrchestratorWithFailure(events, account);
                 // we know there might be rounding errors, so we always check it is in the range +-1
                 expect(
                     reward >= expectedOrchestratorReward - 1n && reward <= expectedOrchestratorReward + 1n,

--- a/test/suites/smoke-test-dancebox/test-invulnerables-priority.ts
+++ b/test/suites/smoke-test-dancebox/test-invulnerables-priority.ts
@@ -22,7 +22,7 @@ describeSuite({
                     return;
                 }
 
-                const sessionLength = 300;
+                const sessionLength = 600;
 
                 const currentBlock = await api.rpc.chain.getBlock();
                 const currentBlockNumber = currentBlock.block.header.number.toNumber();

--- a/test/suites/smoke-test-dancebox/test-randomness-consistency.ts
+++ b/test/suites/smoke-test-dancebox/test-randomness-consistency.ts
@@ -22,7 +22,7 @@ describeSuite({
                 if (runtimeVersion < 300) {
                     return;
                 }
-                const sessionLength = 300;
+                const sessionLength = 600;
                 const currentBlock = (await api.rpc.chain.getBlock()).block.header.number.toNumber();
                 const randomness = await api.query.collatorAssignment.randomness();
 

--- a/test/util/block.ts
+++ b/test/util/block.ts
@@ -200,7 +200,7 @@ export function fetchCollatorAssignmentTip(events: EventRecord[] = []) {
     return filtered[0];
 }
 
-export function filterRewardFromOrchestrator(events: EventRecord[] = [], author: string) {
+export function filterRewardFromOrchestratorWithFailure(events: EventRecord[] = [], author: string) {
     const reward = fetchRewardAuthorOrchestrator(events);
     expect(reward, `orchestrator rewards event not found`).not.toBe(undefined);
     expect(
@@ -208,6 +208,15 @@ export function filterRewardFromOrchestrator(events: EventRecord[] = [], author:
         `orchestrator author  ${reward.accountId.toString()} does not match expected author  ${author}`
     ).to.be.true;
     return reward.balance.toBigInt();
+}
+
+export function filterRewardFromOrchestrator(events: EventRecord[] = [], author: string) {
+    const reward = fetchRewardAuthorOrchestrator(events);
+    if (reward === undefined || reward.accountId.toString() !== author) {
+        return 0n;
+    } else {
+        return reward.balance.toBigInt();
+    }
 }
 
 export function filterRewardFromContainer(events: EventRecord[] = [], feePayer: string, paraId: ParaId) {

--- a/test/util/block.ts
+++ b/test/util/block.ts
@@ -202,11 +202,12 @@ export function fetchCollatorAssignmentTip(events: EventRecord[] = []) {
 
 export function filterRewardFromOrchestrator(events: EventRecord[] = [], author: string) {
     const reward = fetchRewardAuthorOrchestrator(events);
-    if (reward === undefined || reward.accountId.toString() !== author) {
-        return 0n;
-    } else {
-        return reward.balance.toBigInt();
-    }
+    expect(reward, `orchestrator rewards event not found`).not.toBe(undefined);
+    expect(
+        reward.accountId.toString() === author,
+        `orchestrator author  ${reward.accountId.toString()} does not match expected author  ${author}`
+    ).to.be.true;
+    return reward.balance.toBigInt();
 }
 
 export function filterRewardFromContainer(events: EventRecord[] = [], feePayer: string, paraId: ParaId) {


### PR DESCRIPTION
Fixes some smoke tests with respet to:

- left over session lenghts at 300.
- inflation-rewards sometimes failing because we are probably not using the same api to fetch author events and author digest log