### PR TITLE
Fix: do not shuffle collators before applying priority

### DIFF
--- a/pallets/collator-assignment/src/lib.rs
+++ b/pallets/collator-assignment/src/lib.rs
@@ -161,7 +161,7 @@ pub mod pallet {
         pub fn assign_collators(
             current_session_index: &T::SessionIndex,
             random_seed: [u8; 32],
-            mut collators: Vec<T::AccountId>,
+            collators: Vec<T::AccountId>,
         ) -> SessionChangeOutcome<T> {
             // We work with one session delay to calculate assignments
             let session_delay = T::SessionIndex::one();
@@ -201,7 +201,6 @@ pub mod pallet {
             // This should only happen in tests, and in the genesis block.
             if random_seed != [0; 32] {
                 let mut rng: ChaCha20Rng = SeedableRng::from_seed(random_seed);
-                collators.shuffle(&mut rng);
                 container_chain_ids.shuffle(&mut rng);
                 parathreads.shuffle(&mut rng);
                 shuffle_collators = Some(move |collators: &mut Vec<T::AccountId>| {


### PR DESCRIPTION
The implementation of collator priority in #471 has a bug that renders it useless: collators are being shuffled twice. This resulted in the priority being applied to a shuffled list of collators, so it was equivalent to having no priority.

This PR fixes that by removing one line: `collators.shuffle(&mut rng);`, and fixing all the tests that break because we changed the way we use the randomness. Also adds a new test `assign_collators_truncates_before_shuffling` to check that collator priority works as expected.