### PR TITLE
Wait for lock file in container chain restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15415,6 +15415,7 @@ dependencies = [
  "flume 0.10.14",
  "frame-benchmarking",
  "frame-benchmarking-cli",
+ "fs2",
  "futures 0.3.30",
  "jsonrpsee",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -311,6 +311,7 @@ clap = { version = "4.1.6", default-features = false, features = [ "derive" ] }
 core_extensions = "1.5.3"
 exit-future = { version = "0.2.0" }
 flume = "0.10.9"
+fs2 = "0.4.3"
 futures = { version = "0.3.1" }
 futures-timer = "3.0.1"
 hex = { version = "0.4.3", default-features = false }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -16,6 +16,7 @@ async-trait = { workspace = true }
 clap = { workspace = true, features = [ "derive" ] }
 exit-future = { workspace = true }
 flume = { workspace = true }
+fs2 = { workspace = true }
 futures = { workspace = true }
 jsonrpsee = { workspace = true, features = [ "server" ] }
 log = { workspace = true }

--- a/node/src/container_chain_spawner.rs
+++ b/node/src/container_chain_spawner.rs
@@ -862,6 +862,7 @@ fn check_paritydb_lock_held(db_path: &Path) -> Result<bool, std::io::Error> {
         .create(true)
         .read(true)
         .write(true)
+        .truncate(true)
         .open(lock_path.as_path())?;
     // Check if the lock file is busy by trying to lock it.
     // Returns err if failed to adquire the lock.


### PR DESCRIPTION
Improves the hack we use to wait for the database to close when restarting a container chain. Now instead of a `sleep(10)`, we wait until the database lock file is released (with a 60 second timeout).

Fix #554