### PR TITLE
Add tanssi full node to zombienet tests

### DIFF
--- a/test/configs/zombieTanssi.json
+++ b/test/configs/zombieTanssi.json
@@ -49,8 +49,14 @@
             "COMMENT": "Important: these collators will not be injected to pallet-invulnerables because zombienet does not support that. When changing the collators list, make sure to update `scripts/build-spec.sh`",
             "collators": [
                 {
+                    "name": "FullNode-1000",
+                    "validator": false,
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"],
+                    "ws_port": 9948
+                },
+                {
                     "name": "Collator1000-01",
-                    "ws_port": "9948",
                     "command": "../target/release/tanssi-node",
                     "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },

--- a/test/configs/zombieTanssiKeepDb.json
+++ b/test/configs/zombieTanssiKeepDb.json
@@ -49,8 +49,14 @@
             "COMMENT": "Important: these collators will not be injected to pallet-invulnerables because zombienet does not support that. When changing the collators list, make sure to update `scripts/build-spec-warp-sync.sh`",
             "collators": [
                 {
+                    "name": "FullNode-1000",
+                    "validator": false,
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"],
+                    "ws_port": 9948
+                },
+                {
                     "name": "Collator1000-01",
-                    "ws_port": "9948",
                     "command": "../target/release/tanssi-node",
                     "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },

--- a/test/configs/zombieTanssiMetrics.json
+++ b/test/configs/zombieTanssiMetrics.json
@@ -49,8 +49,14 @@
             "COMMENT": "Important: these collators will not be injected to pallet-invulnerables because zombienet does not support that. When changing the collators list, make sure to update `scripts/build-spec-warp-sync.sh`",
             "collators": [
                 {
+                    "name": "FullNode-1000",
+                    "validator": false,
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"],
+                    "ws_port": 9948
+                },
+                {
                     "name": "Collator1000-01",
-                    "ws_port": "9948",
                     "command": "../target/release/tanssi-node",
                     "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },

--- a/test/configs/zombieTanssiOneNode.json
+++ b/test/configs/zombieTanssiOneNode.json
@@ -41,8 +41,14 @@
             "COMMENT": "Important: these collators will not be injected to pallet-invulnerables because zombienet does not support that. When changing the collators list, make sure to update `scripts/build-spec-one-node.sh`",
             "collators": [
                 {
+                    "name": "FullNode-1000",
+                    "validator": false,
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"],
+                    "ws_port": 9948
+                },
+                {
                     "name": "Collator-01",
-                    "ws_port": "9948",
                     "command": "../target/release/tanssi-node",
                     "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },

--- a/test/configs/zombieTanssiParathreads.json
+++ b/test/configs/zombieTanssiParathreads.json
@@ -45,8 +45,14 @@
             "COMMENT": "Important: these collators will not be injected to pallet-invulnerables because zombienet does not support that. When changing the collators list, make sure to update `scripts/build-spec-parathreads.sh`",
             "collators": [
                 {
+                    "name": "FullNode-1000",
+                    "validator": false,
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"],
+                    "ws_port": 9948
+                },
+                {
                     "name": "Collator-01",
-                    "ws_port": "9948",
                     "command": "../target/release/tanssi-node",
                     "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },

--- a/test/configs/zombieTanssiRotation.json
+++ b/test/configs/zombieTanssiRotation.json
@@ -45,8 +45,14 @@
             "COMMENT": "Important: these collators will not be injected to pallet-invulnerables because zombienet does not support that. When changing the collators list, make sure to update `scripts/build-spec.sh`",
             "collators": [
                 {
+                    "name": "FullNode-1000",
+                    "validator": false,
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"],
+                    "ws_port": 9948
+                },
+                {
                     "name": "Collator1000-01",
-                    "ws_port": "9948",
                     "command": "../target/release/tanssi-node",
                     "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },

--- a/test/configs/zombieTanssiWarpSync.json
+++ b/test/configs/zombieTanssiWarpSync.json
@@ -41,8 +41,14 @@
             "COMMENT": "Important: these collators will not be injected to pallet-invulnerables because zombienet does not support that. When changing the collators list, make sure to update `scripts/build-spec-warp-sync.sh`",
             "collators": [
                 {
+                    "name": "FullNode-1000",
+                    "validator": false,
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"],
+                    "ws_port": 9948
+                },
+                {
                     "name": "Collator1000-01",
-                    "ws_port": "9948",
                     "command": "../target/release/tanssi-node",
                     "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
                 },


### PR DESCRIPTION
Follow-up to #568 

The solution was just to use a full node as RPC, instead of using a tanssi collators as RPC. This works around the bug: https://github.com/paritytech/polkadot-sdk/issues/1202