### PR TITLE
Stream payment: Prevent making a request with a past deadline

### DIFF
--- a/pallets/stream-payment/src/lib.rs
+++ b/pallets/stream-payment/src/lib.rs
@@ -353,6 +353,7 @@ pub mod pallet {
         TargetCantChangeDeposit,
         ImmediateDepositChangeRequiresSameAssetId,
         DeadlineCantBeInPast,
+        CantFetchStatusBeforeLastTimeUpdated,
     }
 
     #[pallet::event]
@@ -818,7 +819,8 @@ pub mod pallet {
         /// The stream is considered stalled if no funds are left or if the provided
         /// time is past a mandatory request deadline. If the provided `now` is `None`
         /// then the current time will be fetched. Being able to provide a custom `now`
-        /// allows to check the status in the future.
+        /// allows to check the status in the future. It is invalid to provide a `now` that is
+        /// before `last_time_updated`.
         pub fn stream_payment_status(
             stream_id: T::StreamId,
             now: Option<T::Balance>,
@@ -831,6 +833,12 @@ pub mod pallet {
             };
 
             let last_time_updated = stream.last_time_updated;
+
+            ensure!(
+                now >= last_time_updated,
+                Error::<T>::CantFetchStatusBeforeLastTimeUpdated
+            );
+
             Self::stream_payment_status_by_ref(&stream, last_time_updated, now)
         }
 
@@ -839,6 +847,8 @@ pub mod pallet {
             last_time_updated: T::Balance,
             mut now: T::Balance,
         ) -> Result<StreamPaymentStatus<T::Balance>, Error<T>> {
+            let mut stalled_by_deadline = false;
+
             // Take into account mandatory change request deadline. Note that
             // while it'll perform payment up to deadline,
             // `stream.last_time_updated` is still the "real now" to avoid
@@ -849,6 +859,10 @@ pub mod pallet {
             }) = &stream.pending_request
             {
                 now = min(now, *deadline);
+
+                if now == *deadline {
+                    stalled_by_deadline = true;
+                }
             }
 
             // If deposit is zero the stream is fully drained and there is nothing to transfer.
@@ -882,7 +896,7 @@ pub mod pallet {
             // we pay all that is left.
             let (deposit_left, stalled) = match stream.deposit.checked_sub(&payment) {
                 Some(v) if v.is_zero() => (v, true),
-                Some(v) => (v, false),
+                Some(v) => (v, stalled_by_deadline),
                 None => {
                     payment = stream.deposit;
                     (Zero::zero(), true)

--- a/pallets/stream-payment/src/tests.rs
+++ b/pallets/stream-payment/src/tests.rs
@@ -1130,60 +1130,26 @@ mod request_change {
     }
 
     #[test]
-    fn deadline_in_past_is_fine() {
+    fn cant_set_past_deadline() {
         ExtBuilder::default().build().execute_with(|| {
             let open_stream = OpenStream::default();
             assert_ok!(open_stream.call());
 
-            // Target requets a change.
+            roll_to(12);
+
             let change1 = StreamConfig {
                 rate: 101,
                 ..open_stream.config
             };
-            assert_ok!(StreamPayment::request_change(
-                RuntimeOrigin::signed(BOB),
-                0,
-                ChangeKind::Mandatory { deadline: 10 },
-                change1,
-                None,
-            ));
-
-            // Roll to block after deadline, payment should stop at deadline.
-            let delta = u128::from(roll_to(11));
-            let payment = (delta - 1) * open_stream.config.rate;
-
-            assert_ok!(StreamPayment::perform_payment(
-                RuntimeOrigin::signed(CHARLIE),
-                0
-            ));
-            assert_event_emitted!(PaymentEvent {
-                amount: payment,
-                ..default()
-            });
-
-            // Target requets a new change that moves the deadline in the future.
-            let change1 = StreamConfig {
-                rate: 102,
-                ..open_stream.config
-            };
-            assert_ok!(StreamPayment::request_change(
-                RuntimeOrigin::signed(BOB),
-                0,
-                ChangeKind::Mandatory { deadline: 5 },
-                change1,
-                None,
-            ));
-
-            let deposit_before = Streams::<Runtime>::get(0).unwrap().deposit;
-            assert_ok!(StreamPayment::perform_payment(
-                RuntimeOrigin::signed(CHARLIE),
-                0
-            ));
-            let deposit_after = Streams::<Runtime>::get(0).unwrap().deposit;
-
-            assert_eq!(
-                deposit_before, deposit_after,
-                "no payment should be performed"
+            assert_err!(
+                StreamPayment::request_change(
+                    RuntimeOrigin::signed(BOB),
+                    0,
+                    ChangeKind::Mandatory { deadline: 10 },
+                    change1,
+                    None,
+                ),
+                Error::DeadlineCantBeInPast
             );
         })
     }

--- a/pallets/stream-payment/src/tests.rs
+++ b/pallets/stream-payment/src/tests.rs
@@ -1099,6 +1099,7 @@ mod request_change {
             ));
             assert_event_emitted!(PaymentEvent {
                 amount: payment,
+                stalled: true,
                 ..default()
             });
 
@@ -1543,6 +1544,7 @@ mod accept_requested_change {
             ));
             assert_event_emitted!(PaymentEvent {
                 amount: payment,
+                stalled: true,
                 ..default()
             });
 

--- a/test/suites/common-tanssi/stream-payment/test_stream_payment.ts
+++ b/test/suites/common-tanssi/stream-payment/test_stream_payment.ts
@@ -53,12 +53,13 @@ describeSuite({
                     .performPayment(0)
                     .signAsync(alice, { nonce: aliceNonce++ });
 
+                const blockNumber = (await polkadotJs.rpc.chain.getHeader()).number.toNumber();
                 const txRequestChange = await polkadotJs.tx.streamPayment
                     .requestChange(
                         0,
                         {
                             Mandatory: {
-                                deadline: 0,
+                                deadline: blockNumber + 5,
                             },
                         },
                         {

--- a/typescript-api/src/dancebox/interfaces/augment-api-errors.ts
+++ b/typescript-api/src/dancebox/interfaces/augment-api-errors.ts
@@ -477,6 +477,7 @@ declare module "@polkadot/api-base/types/errors" {
             CantFetchCurrentTime: AugmentedError<ApiType>;
             CantOverrideMandatoryChange: AugmentedError<ApiType>;
             ChangingAssetRequiresAbsoluteDepositChange: AugmentedError<ApiType>;
+            DeadlineCantBeInPast: AugmentedError<ApiType>;
             ImmediateDepositChangeRequiresSameAssetId: AugmentedError<ApiType>;
             NoPendingRequest: AugmentedError<ApiType>;
             SourceCantDecreaseRate: AugmentedError<ApiType>;

--- a/typescript-api/src/dancebox/interfaces/augment-api-errors.ts
+++ b/typescript-api/src/dancebox/interfaces/augment-api-errors.ts
@@ -475,6 +475,7 @@ declare module "@polkadot/api-base/types/errors" {
             CantAcceptOwnRequest: AugmentedError<ApiType>;
             CantBeBothSourceAndTarget: AugmentedError<ApiType>;
             CantFetchCurrentTime: AugmentedError<ApiType>;
+            CantFetchStatusBeforeLastTimeUpdated: AugmentedError<ApiType>;
             CantOverrideMandatoryChange: AugmentedError<ApiType>;
             ChangingAssetRequiresAbsoluteDepositChange: AugmentedError<ApiType>;
             DeadlineCantBeInPast: AugmentedError<ApiType>;

--- a/typescript-api/src/dancebox/interfaces/lookup.ts
+++ b/typescript-api/src/dancebox/interfaces/lookup.ts
@@ -4037,6 +4037,7 @@ export default {
             "TargetCantChangeDeposit",
             "ImmediateDepositChangeRequiresSameAssetId",
             "DeadlineCantBeInPast",
+            "CantFetchStatusBeforeLastTimeUpdated",
         ],
     },
     /** Lookup428: pallet_identity::types::Registration<Balance, MaxJudgements, pallet_identity::legacy::IdentityInfo<FieldLimit>> */

--- a/typescript-api/src/dancebox/interfaces/lookup.ts
+++ b/typescript-api/src/dancebox/interfaces/lookup.ts
@@ -4036,6 +4036,7 @@ export default {
             "ChangingAssetRequiresAbsoluteDepositChange",
             "TargetCantChangeDeposit",
             "ImmediateDepositChangeRequiresSameAssetId",
+            "DeadlineCantBeInPast",
         ],
     },
     /** Lookup428: pallet_identity::types::Registration<Balance, MaxJudgements, pallet_identity::legacy::IdentityInfo<FieldLimit>> */

--- a/typescript-api/src/dancebox/interfaces/types-lookup.ts
+++ b/typescript-api/src/dancebox/interfaces/types-lookup.ts
@@ -5444,6 +5444,7 @@ declare module "@polkadot/types/lookup" {
         readonly isTargetCantChangeDeposit: boolean;
         readonly isImmediateDepositChangeRequiresSameAssetId: boolean;
         readonly isDeadlineCantBeInPast: boolean;
+        readonly isCantFetchStatusBeforeLastTimeUpdated: boolean;
         readonly type:
             | "UnknownStreamId"
             | "StreamIdOverflow"
@@ -5460,7 +5461,8 @@ declare module "@polkadot/types/lookup" {
             | "ChangingAssetRequiresAbsoluteDepositChange"
             | "TargetCantChangeDeposit"
             | "ImmediateDepositChangeRequiresSameAssetId"
-            | "DeadlineCantBeInPast";
+            | "DeadlineCantBeInPast"
+            | "CantFetchStatusBeforeLastTimeUpdated";
     }
 
     /** @name PalletIdentityRegistration (428) */

--- a/typescript-api/src/dancebox/interfaces/types-lookup.ts
+++ b/typescript-api/src/dancebox/interfaces/types-lookup.ts
@@ -5443,6 +5443,7 @@ declare module "@polkadot/types/lookup" {
         readonly isChangingAssetRequiresAbsoluteDepositChange: boolean;
         readonly isTargetCantChangeDeposit: boolean;
         readonly isImmediateDepositChangeRequiresSameAssetId: boolean;
+        readonly isDeadlineCantBeInPast: boolean;
         readonly type:
             | "UnknownStreamId"
             | "StreamIdOverflow"
@@ -5458,7 +5459,8 @@ declare module "@polkadot/types/lookup" {
             | "WrongRequestNonce"
             | "ChangingAssetRequiresAbsoluteDepositChange"
             | "TargetCantChangeDeposit"
-            | "ImmediateDepositChangeRequiresSameAssetId";
+            | "ImmediateDepositChangeRequiresSameAssetId"
+            | "DeadlineCantBeInPast";
     }
 
     /** @name PalletIdentityRegistration (428) */

--- a/typescript-api/src/flashbox/interfaces/augment-api-errors.ts
+++ b/typescript-api/src/flashbox/interfaces/augment-api-errors.ts
@@ -307,6 +307,7 @@ declare module "@polkadot/api-base/types/errors" {
             CantFetchCurrentTime: AugmentedError<ApiType>;
             CantOverrideMandatoryChange: AugmentedError<ApiType>;
             ChangingAssetRequiresAbsoluteDepositChange: AugmentedError<ApiType>;
+            DeadlineCantBeInPast: AugmentedError<ApiType>;
             ImmediateDepositChangeRequiresSameAssetId: AugmentedError<ApiType>;
             NoPendingRequest: AugmentedError<ApiType>;
             SourceCantDecreaseRate: AugmentedError<ApiType>;

--- a/typescript-api/src/flashbox/interfaces/augment-api-errors.ts
+++ b/typescript-api/src/flashbox/interfaces/augment-api-errors.ts
@@ -305,6 +305,7 @@ declare module "@polkadot/api-base/types/errors" {
             CantAcceptOwnRequest: AugmentedError<ApiType>;
             CantBeBothSourceAndTarget: AugmentedError<ApiType>;
             CantFetchCurrentTime: AugmentedError<ApiType>;
+            CantFetchStatusBeforeLastTimeUpdated: AugmentedError<ApiType>;
             CantOverrideMandatoryChange: AugmentedError<ApiType>;
             ChangingAssetRequiresAbsoluteDepositChange: AugmentedError<ApiType>;
             DeadlineCantBeInPast: AugmentedError<ApiType>;

--- a/typescript-api/src/flashbox/interfaces/lookup.ts
+++ b/typescript-api/src/flashbox/interfaces/lookup.ts
@@ -2000,6 +2000,7 @@ export default {
             "ChangingAssetRequiresAbsoluteDepositChange",
             "TargetCantChangeDeposit",
             "ImmediateDepositChangeRequiresSameAssetId",
+            "DeadlineCantBeInPast",
         ],
     },
     /** Lookup283: pallet_identity::types::Registration<Balance, MaxJudgements, pallet_identity::legacy::IdentityInfo<FieldLimit>> */

--- a/typescript-api/src/flashbox/interfaces/lookup.ts
+++ b/typescript-api/src/flashbox/interfaces/lookup.ts
@@ -2001,6 +2001,7 @@ export default {
             "TargetCantChangeDeposit",
             "ImmediateDepositChangeRequiresSameAssetId",
             "DeadlineCantBeInPast",
+            "CantFetchStatusBeforeLastTimeUpdated",
         ],
     },
     /** Lookup283: pallet_identity::types::Registration<Balance, MaxJudgements, pallet_identity::legacy::IdentityInfo<FieldLimit>> */

--- a/typescript-api/src/flashbox/interfaces/types-lookup.ts
+++ b/typescript-api/src/flashbox/interfaces/types-lookup.ts
@@ -2582,6 +2582,7 @@ declare module "@polkadot/types/lookup" {
         readonly isChangingAssetRequiresAbsoluteDepositChange: boolean;
         readonly isTargetCantChangeDeposit: boolean;
         readonly isImmediateDepositChangeRequiresSameAssetId: boolean;
+        readonly isDeadlineCantBeInPast: boolean;
         readonly type:
             | "UnknownStreamId"
             | "StreamIdOverflow"
@@ -2597,7 +2598,8 @@ declare module "@polkadot/types/lookup" {
             | "WrongRequestNonce"
             | "ChangingAssetRequiresAbsoluteDepositChange"
             | "TargetCantChangeDeposit"
-            | "ImmediateDepositChangeRequiresSameAssetId";
+            | "ImmediateDepositChangeRequiresSameAssetId"
+            | "DeadlineCantBeInPast";
     }
 
     /** @name PalletIdentityRegistration (283) */

--- a/typescript-api/src/flashbox/interfaces/types-lookup.ts
+++ b/typescript-api/src/flashbox/interfaces/types-lookup.ts
@@ -2583,6 +2583,7 @@ declare module "@polkadot/types/lookup" {
         readonly isTargetCantChangeDeposit: boolean;
         readonly isImmediateDepositChangeRequiresSameAssetId: boolean;
         readonly isDeadlineCantBeInPast: boolean;
+        readonly isCantFetchStatusBeforeLastTimeUpdated: boolean;
         readonly type:
             | "UnknownStreamId"
             | "StreamIdOverflow"
@@ -2599,7 +2600,8 @@ declare module "@polkadot/types/lookup" {
             | "ChangingAssetRequiresAbsoluteDepositChange"
             | "TargetCantChangeDeposit"
             | "ImmediateDepositChangeRequiresSameAssetId"
-            | "DeadlineCantBeInPast";
+            | "DeadlineCantBeInPast"
+            | "CantFetchStatusBeforeLastTimeUpdated";
     }
 
     /** @name PalletIdentityRegistration (283) */


### PR DESCRIPTION
Prevents making a request with a mandatory change having a deadline in the past.
Also fix the `stream_payment_status` function to return `stalled = true` when deadline is reached.