### PR TITLE
Add dev starlight moonwall test suite to CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -497,6 +497,43 @@ jobs:
                   pnpm install
                   pnpm moonwall test dev_dancebox_specs
 
+    typescript-tests-relay:
+      runs-on: ubuntu-latest
+      needs: ["set-tags", "build"]
+      steps:
+          - name: Checkout
+            uses: actions/checkout@v4
+            with:
+                ref: ${{ needs.set-tags.outputs.git_ref }}
+          - name: Pnpm
+            uses: pnpm/action-setup@v3.0.0
+            with:
+                version: 8
+          - name: "Download binaries"
+            uses: actions/download-artifact@v4
+            with:
+                name: binaries
+                path: target/release
+          - name: "Setup Node"
+            uses: actions/setup-node@v4
+            with:
+                node-version: 20.x
+                cache: "pnpm"
+          - name: "Generate typescript api"
+            run: |
+                chmod uog+x target/release/tanssi-node
+                cd typescript-api
+                pnpm install
+                pnpm create-local-interfaces
+          - name: "Run Dev tests"
+            run: |
+                chmod uog+x target/release/tanssi-node
+                chmod uog+x target/release/tanssi-relay
+                chmod uog+x target/release/tanssi-relay-execute-worker
+                chmod uog+x target/release/tanssi-relay-prepare-worker
+                cd test
+                pnpm moonwall test dev_tanssi_relay
+
     zombienet-tests:
         runs-on: self-hosted
         needs: ["set-tags", "build"]


### PR DESCRIPTION
Run the moonwall dev test suite for `starlight` in CI.