### PR TITLE
fix bench script

### DIFF
--- a/tools/benchmarking.sh
+++ b/tools/benchmarking.sh
@@ -92,11 +92,13 @@ function bench {
         echo "[+] Benchmarking ${#ALL_PALLETS[@]} pallets"
         for PALLET in "${ALL_PALLETS[@]}"; do
             TEMPLATE_TO_USE=$TEMPLATE_PATH
+            OUTPUT="${OUTPUT_PATH}/$PALLET.rs"
             if [[ "$PALLET" == *"pallet_xcm_benchmarks"* ]]; then
                 echo "Using pallet xcm benchmarks for $PALLET"
                 TEMPLATE_TO_USE="./benchmarking/frame-weight-runtime-template-xcm.hbs"
+                MODIFIED_PALLET_FILE=${PALLET/::/_}
+                OUTPUT="${OUTPUT_PATH}/$MODIFIED_PALLET_FILE.rs"
             fi
-            OUTPUT="${OUTPUT_PATH}/$PALLET.rs"
             WASMTIME_BACKTRACE_DETAILS=1 ${BINARY} benchmark pallet \
             --execution=wasm \
             --wasm-execution=compiled \
@@ -111,8 +113,11 @@ function bench {
         done
     else
         TEMPLATE_TO_USE=$TEMPLATE_PATH
+        OUTPUT="${OUTPUT_PATH}/${1}.rs"
         if [[ "${1}" == *"pallet_xcm_benchmarks"* ]]; then
             TEMPLATE_TO_USE="./benchmarking/frame-weight-runtime-template-xcm.hbs"
+            MODIFIED_PALLET_FILE=${1/::/_}
+            OUTPUT="${OUTPUT_PATH}/$MODIFIED_PALLET_FILE.rs"
         fi
         WASMTIME_BACKTRACE_DETAILS=1 ${BINARY} benchmark pallet \
             --execution=wasm \

--- a/tools/benchmarking.sh
+++ b/tools/benchmarking.sh
@@ -91,8 +91,10 @@ function bench {
         ))
         echo "[+] Benchmarking ${#ALL_PALLETS[@]} pallets"
         for PALLET in "${ALL_PALLETS[@]}"; do
+            TEMPLATE_TO_USE=$TEMPLATE_PATH
             if [[ "$PALLET" == *"pallet_xcm_benchmarks"* ]]; then
-                TEMPLATE_PATH="./benchmarking/frame-weight-runtime-template-xcm.hbs"
+                echo "Using pallet xcm benchmarks for $PALLET"
+                TEMPLATE_TO_USE="./benchmarking/frame-weight-runtime-template-xcm.hbs"
             fi
             OUTPUT="${OUTPUT_PATH}/$PALLET.rs"
             WASMTIME_BACKTRACE_DETAILS=1 ${BINARY} benchmark pallet \
@@ -103,13 +105,14 @@ function bench {
             --chain="${CHAIN}" \
             --steps "${STEPS}" \
             --repeat "${REPEAT}" \
-            --template="${TEMPLATE_PATH}" \
+            --template="${TEMPLATE_TO_USE}" \
             --json-file raw.json \
             --output "${OUTPUT}"
         done
     else
+        TEMPLATE_TO_USE=$TEMPLATE_PATH
         if [[ "${1}" == *"pallet_xcm_benchmarks"* ]]; then
-            TEMPLATE_PATH="./benchmarking/frame-weight-runtime-template-xcm.hbs"
+            TEMPLATE_TO_USE="./benchmarking/frame-weight-runtime-template-xcm.hbs"
         fi
         WASMTIME_BACKTRACE_DETAILS=1 ${BINARY} benchmark pallet \
             --execution=wasm \
@@ -119,7 +122,7 @@ function bench {
             --chain="${CHAIN}" \
             --steps "${STEPS}" \
             --repeat "${REPEAT}" \
-            --template="${TEMPLATE_PATH}" \
+            --template="${TEMPLATE_TO_USE}" \
             --json-file raw.json \
             --output "${OUTPUT}"
     fi


### PR DESCRIPTION
Before the bench script had two issues:
- when it reached benchamrks of `pallet_xcm_benchmarks`, the `TEMPLATE` was set to the one for XCM and it was not modified for the next benchmarks that run.

- the output file of  `pallet_xcm_benchmarks` by default was `pallet_xcm_benchmarks::generic.rs` and after this PR is `pallet_xcm_benchmarks_generic.rs`