### PR TITLE
Remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,21 +439,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "assert_cmd"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed72493ac66d5804837f480ab3766c72bdfab91a65e565fc54fa9e42db0073a8"
-dependencies = [
- "anstyle",
- "bstr 1.9.1",
- "doc-comment",
- "predicates 3.1.0",
- "predicates-core",
- "predicates-tree",
- "wait-timeout",
-]
-
-[[package]]
 name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,17 +1230,6 @@ dependencies = [
  "lazy_static",
  "memchr",
  "regex-automata 0.1.10",
-]
-
-[[package]]
-name = "bstr"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
-dependencies = [
- "memchr",
- "regex-automata 0.4.5",
- "serde",
 ]
 
 [[package]]
@@ -3506,12 +3480,6 @@ dependencies = [
  "quote",
  "syn 2.0.66",
 ]
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "docify"
@@ -7058,12 +7026,10 @@ version = "0.1.0"
 dependencies = [
  "cumulus-primitives-core",
  "flume 0.10.14",
- "futures 0.3.30",
  "hex-literal 0.3.4",
  "jsonrpsee",
  "parity-scale-codec",
  "staging-xcm",
- "tokio",
 ]
 
 [[package]]
@@ -7134,15 +7100,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -7288,7 +7245,7 @@ dependencies = [
  "fragile",
  "lazy_static",
  "mockall_derive",
- "predicates 2.1.5",
+ "predicates",
  "predicates-tree",
 ]
 
@@ -7677,8 +7634,6 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset 0.7.1",
- "pin-utils",
 ]
 
 [[package]]
@@ -9182,7 +9137,6 @@ dependencies = [
  "frame-support",
  "frame-system",
  "log",
- "nimbus-primitives",
  "num-traits",
  "pallet-balances",
  "parity-scale-codec",
@@ -9472,7 +9426,6 @@ dependencies = [
  "frame-support",
  "frame-system",
  "log",
- "nimbus-primitives",
  "num-traits",
  "pallet-balances",
  "parity-scale-codec",
@@ -12065,17 +12018,6 @@ dependencies = [
  "normalize-line-endings",
  "predicates-core",
  "regex",
-]
-
-[[package]]
-name = "predicates"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
-dependencies = [
- "anstyle",
- "difflib",
- "predicates-core",
 ]
 
 [[package]]
@@ -15008,7 +14950,7 @@ version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32fea41aca09ee824cc9724996433064c89f7777e60762749a4170a14abbfa21"
 dependencies = [
- "bstr 0.2.17",
+ "bstr",
  "unicode-segmentation",
 ]
 
@@ -16381,7 +16323,6 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-weights",
- "staging-xcm",
  "staging-xcm-builder",
 ]
 
@@ -16443,7 +16384,6 @@ dependencies = [
 name = "stream-payment-rpc"
 version = "0.1.0"
 dependencies = [
- "futures 0.3.30",
  "jsonrpsee",
  "pallet-stream-payment-runtime-api",
  "parity-scale-codec",
@@ -16928,9 +16868,7 @@ dependencies = [
 name = "tanssi-relay"
 version = "0.1.0"
 dependencies = [
- "assert_cmd",
  "color-eyre",
- "nix 0.26.4",
  "polkadot-core-primitives",
  "polkadot-node-core-pvf",
  "polkadot-node-core-pvf-common",
@@ -16949,7 +16887,6 @@ dependencies = [
 name = "tanssi-relay-cli"
 version = "0.1.0"
 dependencies = [
- "cfg-if",
  "clap 4.5.4",
  "frame-benchmarking-cli",
  "futures 0.3.30",
@@ -16980,19 +16917,10 @@ name = "tanssi-relay-encoder"
 version = "0.1.0"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support",
- "frame-system",
- "frame-try-runtime",
- "hex-literal 0.3.4",
- "pallet-balances",
  "parity-scale-codec",
  "polkadot-runtime-parachains",
  "rococo-runtime",
  "rococo-runtime-constants",
- "scale-info",
- "sp-core",
- "sp-runtime",
- "sp-std",
 ]
 
 [[package]]
@@ -17693,23 +17621,17 @@ dependencies = [
  "cumulus-primitives-parachain-inherent",
  "cumulus-relay-chain-interface",
  "dp-core",
- "frame-support",
  "futures 0.3.30",
  "hex-literal 0.3.4",
- "log",
  "parity-scale-codec",
  "polkadot-primitives",
  "sc-client-api",
  "scale-info",
- "sp-api",
  "sp-consensus-aura",
  "sp-core",
  "sp-inherents",
- "sp-io",
  "sp-runtime",
  "sp-state-machine",
- "sp-std",
- "sp-storage",
  "sp-trie",
  "test-relay-sproof-builder",
 ]
@@ -17729,10 +17651,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-core",
- "sp-runtime",
- "sp-state-machine",
  "sp-std",
- "sp-trie",
  "tp-traits",
 ]
 
@@ -18223,15 +18142,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wait-timeout"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "waker-fn"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18630,7 +18540,7 @@ dependencies = [
  "log",
  "mach",
  "memfd",
- "memoffset 0.8.0",
+ "memoffset",
  "paste",
  "rand 0.8.5",
  "rustix 0.36.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -463,7 +463,6 @@ service = { package = "sc-service", git = "https://github.com/moondance-labs/pol
 telemetry = { package = "sc-telemetry", git = "https://github.com/moondance-labs/polkadot-sdk", branch = "tanssi-polkadot-v1.11.0", default-features = false }
 
 # Tanssi Relay Chain CLI
-cfg-if = "1.0"
 pyro = { package = "pyroscope", version = "0.5.3" }
 pyroscope_pprofrs = { version = "0.2" }
 
@@ -472,9 +471,7 @@ sc-storage-monitor = { git = "https://github.com/moondance-labs/polkadot-sdk", b
 sp-maybe-compressed-blob = { git = "https://github.com/moondance-labs/polkadot-sdk", branch = "tanssi-polkadot-v1.11.0", default-features = false }
 
 # Tanssi Relay Chain
-assert_cmd = "2.0.4"
 color-eyre = { version = "0.6.1", default-features = false }
-nix = { version = "0.26.1", features = [ "signal" ] }
 tikv-jemallocator = { version = "0.5.0", features = [ "unprefixed_malloc_on_supported_platforms" ] }
 
 polkadot-node-core-pvf-common = { git = "https://github.com/moondance-labs/polkadot-sdk", branch = "tanssi-polkadot-v1.11.0", default-features = false }

--- a/client/manual-xcm/Cargo.toml
+++ b/client/manual-xcm/Cargo.toml
@@ -11,11 +11,9 @@ workspace = true
 
 [dependencies]
 flume = { workspace = true }
-futures = { workspace = true, features = [ "compat" ] }
 hex-literal = { workspace = true }
 jsonrpsee = { workspace = true, features = [ "macros", "server" ] }
 parity-scale-codec = { workspace = true, features = [ "std" ] }
 staging-xcm = { workspace = true }
-tokio = { workspace = true, features = [ "sync", "time" ] }
 
 cumulus-primitives-core = { workspace = true, features = [ "std" ] }

--- a/client/stream-payment/Cargo.toml
+++ b/client/stream-payment/Cargo.toml
@@ -13,7 +13,6 @@ targets = [ "x86_64-unknown-linux-gnu" ]
 workspace = true
 
 [dependencies]
-futures = { workspace = true }
 jsonrpsee = { workspace = true }
 pallet-stream-payment-runtime-api = { workspace = true, features = [ "std" ] }
 parity-scale-codec = { workspace = true }

--- a/pallets/inflation-rewards/Cargo.toml
+++ b/pallets/inflation-rewards/Cargo.toml
@@ -25,7 +25,6 @@ frame-support = { workspace = true }
 frame-system = { workspace = true }
 
 # Nimbus
-nimbus-primitives = { workspace = true }
 parity-scale-codec = { workspace = true }
 scale-info = { workspace = true }
 sp-core = { workspace = true }
@@ -48,7 +47,6 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 	"log/std",
-	"nimbus-primitives/std",
 	"pallet-balances/std",
 	"parity-scale-codec/std",
 	"scale-info/std",
@@ -64,7 +62,6 @@ runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
-	"nimbus-primitives/runtime-benchmarks",
 	"pallet-balances/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	"tp-traits/runtime-benchmarks",
@@ -72,7 +69,6 @@ runtime-benchmarks = [
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
-	"nimbus-primitives/try-runtime",
 	"pallet-balances/try-runtime",
 	"sp-runtime/try-runtime",
 ]

--- a/pallets/pooled-staking/Cargo.toml
+++ b/pallets/pooled-staking/Cargo.toml
@@ -25,7 +25,6 @@ frame-support = { workspace = true }
 frame-system = { workspace = true }
 
 # Nimbus
-nimbus-primitives = { workspace = true }
 parity-scale-codec = { workspace = true }
 scale-info = { workspace = true }
 sp-core = { workspace = true }
@@ -46,7 +45,6 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 	"log/std",
-	"nimbus-primitives/std",
 	"pallet-balances/std",
 	"parity-scale-codec/std",
 	"scale-info/std",
@@ -63,7 +61,6 @@ runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
-	"nimbus-primitives/runtime-benchmarks",
 	"pallet-balances/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	"tp-maths/runtime-benchmarks",
@@ -72,7 +69,6 @@ runtime-benchmarks = [
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
-	"nimbus-primitives/try-runtime",
 	"pallet-balances/try-runtime",
 	"sp-runtime/try-runtime",
 ]

--- a/primitives/author-noting-inherent/Cargo.toml
+++ b/primitives/author-noting-inherent/Cargo.toml
@@ -11,8 +11,6 @@ workspace = true
 
 [dependencies]
 async-trait = { workspace = true, optional = true }
-hex-literal = { workspace = true }
-log = { workspace = true }
 parity-scale-codec = { workspace = true, features = [ "derive", "max-encoded-len" ] }
 scale-info = { workspace = true }
 
@@ -20,60 +18,47 @@ dp-core = { workspace = true, optional = true }
 test-relay-sproof-builder = { workspace = true, optional = true }
 
 # Substrate
-frame-support = { workspace = true, optional = true }
-sc-client-api = { workspace = true, optional = true }
-sp-api = { workspace = true, optional = true }
 sp-consensus-aura = { workspace = true, optional = true }
 sp-core = { workspace = true }
 sp-inherents = { workspace = true }
-sp-io = { workspace = true }
 sp-runtime = { workspace = true, optional = true }
 sp-state-machine = { workspace = true, optional = true }
-sp-std = { workspace = true }
-sp-storage = { workspace = true, optional = true }
 sp-trie = { workspace = true }
 
 # Cumulus
-cumulus-pallet-parachain-system = { workspace = true }
-cumulus-primitives-core = { workspace = true }
-cumulus-primitives-parachain-inherent = { workspace = true }
+cumulus-primitives-core = { workspace = true, optional = true }
+cumulus-primitives-parachain-inherent = { workspace = true, optional = true }
 cumulus-relay-chain-interface = { workspace = true, optional = true }
-polkadot-primitives = { workspace = true, optional = true }
 
 [dev-dependencies]
+hex-literal = { workspace = true }
+cumulus-pallet-parachain-system = { workspace = true }
 futures = { workspace = true }
+sc-client-api = { workspace = true }
+polkadot-primitives = { workspace = true }
 
 [features]
 default = [ "std" ]
 std = [
+	"cumulus-primitives-core",
+	"cumulus-primitives-parachain-inherent",
 	"async-trait",
-	"cumulus-pallet-parachain-system/std",
-	"cumulus-primitives-core/std",
-	"cumulus-primitives-parachain-inherent/std",
 	"cumulus-relay-chain-interface",
 	"cumulus-relay-chain-interface",
 	"dp-core/std",
-	"frame-support",
-	"frame-support?/std",
-	"log/std",
 	"parity-scale-codec/std",
-	"polkadot-primitives",
-	"polkadot-primitives?/std",
-	"sc-client-api",
 	"scale-info/std",
 	"scale-info/std",
-	"sp-api",
-	"sp-api?/std",
 	"sp-consensus-aura",
 	"sp-consensus-aura/std",
 	"sp-core/std",
 	"sp-inherents/std",
-	"sp-io/std",
 	"sp-runtime/std",
 	"sp-state-machine/std",
-	"sp-std/std",
-	"sp-storage",
-	"sp-storage?/std",
 	"sp-trie/std",
 	"test-relay-sproof-builder/std",
+	"cumulus-primitives-core?/std",
+	"cumulus-primitives-parachain-inherent?/std",
+	"cumulus-pallet-parachain-system/std",
+	"polkadot-primitives/std"
 ]

--- a/primitives/author-noting-inherent/Cargo.toml
+++ b/primitives/author-noting-inherent/Cargo.toml
@@ -31,22 +31,26 @@ cumulus-primitives-parachain-inherent = { workspace = true, optional = true }
 cumulus-relay-chain-interface = { workspace = true, optional = true }
 
 [dev-dependencies]
-hex-literal = { workspace = true }
 cumulus-pallet-parachain-system = { workspace = true }
 futures = { workspace = true }
-sc-client-api = { workspace = true }
+hex-literal = { workspace = true }
 polkadot-primitives = { workspace = true }
+sc-client-api = { workspace = true }
 
 [features]
 default = [ "std" ]
 std = [
-	"cumulus-primitives-core",
-	"cumulus-primitives-parachain-inherent",
 	"async-trait",
+	"cumulus-pallet-parachain-system/std",
+	"cumulus-primitives-core",
+	"cumulus-primitives-core?/std",
+	"cumulus-primitives-parachain-inherent",
+	"cumulus-primitives-parachain-inherent?/std",
 	"cumulus-relay-chain-interface",
 	"cumulus-relay-chain-interface",
 	"dp-core/std",
 	"parity-scale-codec/std",
+	"polkadot-primitives/std",
 	"scale-info/std",
 	"scale-info/std",
 	"sp-consensus-aura",
@@ -57,8 +61,4 @@ std = [
 	"sp-state-machine/std",
 	"sp-trie/std",
 	"test-relay-sproof-builder/std",
-	"cumulus-primitives-core?/std",
-	"cumulus-primitives-parachain-inherent?/std",
-	"cumulus-pallet-parachain-system/std",
-	"polkadot-primitives/std"
 ]

--- a/primitives/container-chain-genesis-data/Cargo.toml
+++ b/primitives/container-chain-genesis-data/Cargo.toml
@@ -26,10 +26,7 @@ frame-support = { workspace = true }
 parity-scale-codec = { workspace = true }
 scale-info = { workspace = true }
 sp-core = { workspace = true }
-sp-runtime = { workspace = true, optional = true }
-sp-state-machine = { workspace = true, optional = true }
 sp-std = { workspace = true }
-sp-trie = { workspace = true, optional = true }
 
 # Cumulus
 cumulus-primitives-core = { workspace = true, optional = true }
@@ -52,10 +49,7 @@ std = [
 	"serde/std",
 	"serde_json?/std",
 	"sp-core/std",
-	"sp-runtime/std",
-	"sp-state-machine/std",
 	"sp-std/std",
-	"sp-trie/std",
 	"tp-traits/std",
 ]
 json = [ "hex", "serde_json" ]

--- a/runtime/relay-encoder/Cargo.toml
+++ b/runtime/relay-encoder/Cargo.toml
@@ -13,22 +13,8 @@ targets = [ "x86_64-unknown-linux-gnu" ]
 workspace = true
 
 [dependencies]
-hex-literal = { workspace = true }
-parity-scale-codec = { workspace = true, features = [ "derive" ] }
-scale-info = { workspace = true, features = [ "derive" ] }
-
-# Substrate
-frame-support = { workspace = true }
-frame-system = { workspace = true }
-frame-try-runtime = { workspace = true, optional = true }
-pallet-balances = { workspace = true }
-
-# Cumulus
-sp-core = { workspace = true }
-sp-runtime = { workspace = true }
-sp-std = { workspace = true }
-
 cumulus-primitives-core = { workspace = true }
+parity-scale-codec = { workspace = true, features = [ "derive" ] }
 
 [dev-dependencies]
 polkadot-runtime-parachains = { workspace = true }
@@ -41,16 +27,8 @@ default = [
 ]
 std = [
 	"cumulus-primitives-core/std",
-	"frame-support/std",
-	"frame-system/std",
-	"frame-try-runtime?/std",
-	"pallet-balances/std",
 	"parity-scale-codec/std",
 	"polkadot-runtime-parachains/std",
 	"rococo-runtime-constants/std",
-	"rococo-runtime/std",
-	"scale-info/std",
-	"sp-core/std",
-	"sp-runtime/std",
-	"sp-std/std",
+	"rococo-runtime/std"
 ]

--- a/runtime/relay-encoder/Cargo.toml
+++ b/runtime/relay-encoder/Cargo.toml
@@ -30,5 +30,5 @@ std = [
 	"parity-scale-codec/std",
 	"polkadot-runtime-parachains/std",
 	"rococo-runtime-constants/std",
-	"rococo-runtime/std"
+	"rococo-runtime/std",
 ]

--- a/solo-chains/client/cli/Cargo.toml
+++ b/solo-chains/client/cli/Cargo.toml
@@ -17,7 +17,6 @@ crate-type = [ "cdylib", "rlib" ]
 workspace = true
 
 [dependencies]
-cfg-if = { workspace = true }
 clap = { workspace = true, optional = true }
 futures = { workspace = true }
 log = { workspace = true }

--- a/solo-chains/node/tanssi-relay/Cargo.toml
+++ b/solo-chains/node/tanssi-relay/Cargo.toml
@@ -36,8 +36,6 @@ polkadot-overseer = { workspace = true }
 tanssi-relay-cli = { workspace = true, features = [ "starlight-native" ] }
 
 [dev-dependencies]
-assert_cmd = { workspace = true }
-nix = { workspace = true, features = [ "signal" ] }
 polkadot-core-primitives = { workspace = true }
 substrate-rpc-client = { workspace = true }
 tempfile = { workspace = true }
@@ -48,12 +46,6 @@ substrate-build-script-utils = { workspace = true }
 
 [features]
 fast-runtime = [ "tanssi-relay-cli/fast-runtime" ]
-jemalloc-allocator = [
-	"dep:tikv-jemallocator",
-	"polkadot-node-core-pvf-prepare-worker/jemalloc-allocator",
-	"polkadot-node-core-pvf/jemalloc-allocator",
-	"polkadot-overseer/jemalloc-allocator",
-]
 pyroscope = [ "tanssi-relay-cli/pyroscope" ]
 runtime-benchmarks = [ "tanssi-relay-cli/runtime-benchmarks" ]
 runtime-metrics = [ "tanssi-relay-cli/runtime-metrics" ]

--- a/solo-chains/runtime/starlight/constants/Cargo.toml
+++ b/solo-chains/runtime/starlight/constants/Cargo.toml
@@ -18,7 +18,6 @@ sp-core = { workspace = true }
 sp-runtime = { workspace = true }
 sp-weights = { workspace = true }
 
-xcm = { workspace = true }
 xcm-builder = { workspace = true }
 
 [features]
@@ -31,7 +30,6 @@ std = [
 	"sp-runtime/std",
 	"sp-weights/std",
 	"xcm-builder/std",
-	"xcm/std",
 ]
 
 # Set timing constants (e.g. session period) to faster versions to speed up testing.


### PR DESCRIPTION
Remove some unused dependencies from our crates. Unused dependencies can be easily found by adding this to `Cargo.toml`:

```toml
[workspace.lints.rust]
unused-crate-dependencies = { level = "deny", priority = 1 }
```

But that has many false positives related to features and it suggests to remove some dependencies that are not unused, so it is not enabled in CI.