### PR TITLE
Increase error margin in parathead slot diff check

### DIFF
--- a/test/suites/parathreads/test_tanssi_parathreads.ts
+++ b/test/suites/parathreads/test_tanssi_parathreads.ts
@@ -450,7 +450,7 @@ async function assertSlotFrequency(blockData, expectedSlotDiff) {
     expect(
         Math.abs(avgSlotDiff - expectedSlotDiff),
         `Average slot time is different from expected: average ${avgSlotDiff}, expected ${expectedSlotDiff}`
-    ).to.be.lessThan(3);
+    ).to.be.lessThan(5);
 }
 
 /// Create a map of collator key "5C5p..." to collator name "Collator1000-01".


### PR DESCRIPTION
Parathreads are still a bit unstable so this is expected