### PR TITLE
Add zombie_flashbox moonwall suite, not enabled in CI

### DIFF
--- a/test/configs/zombieFlashbox.json
+++ b/test/configs/zombieFlashbox.json
@@ -1,0 +1,152 @@
+{
+    "settings": {
+        "timeout": 1000,
+        "provider": "native"
+    },
+    "relaychain": {
+        "chain": "rococo-local",
+        "default_command": "tmp/polkadot",
+        "default_args": ["--no-hardware-benchmarks", "-lparachain=debug", "--database=paritydb", "--no-beefy"],
+        "genesis": {
+            "runtimeGenesis": {
+                "patch": {
+                    "configuration": {
+                        "config": {
+                            "async_backing_params": {
+                                "allowed_ancestry_len": 2,
+                                "max_candidate_depth": 3
+                            },
+                            "scheduler_params": {
+                                "scheduling_lookahead": 2
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "nodes": [
+            {
+                "name": "alice",
+                "ws_port": "9947",
+                "validator": true
+            },
+            {
+                "name": "bob",
+                "validator": true
+            },
+            {
+                "name": "charlie",
+                "validator": true
+            },
+            {
+                "name": "dave",
+                "validator": true
+            }
+        ]
+    },
+    "parachains": [
+        {
+            "id": 1000,
+            "chain_spec_path": "specs/flashbox-1000.json",
+            "COMMENT": "Important: these collators will not be injected to pallet-invulnerables because zombienet does not support that. When changing the collators list, make sure to update `scripts/build-spec-flashbox.sh`",
+            "collators": [
+                {
+                    "name": "FullNode-1000",
+                    "validator": false,
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"],
+                    "ws_port": 9948
+                },
+                {
+                    "name": "Collator1000-01",
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
+                },
+                {
+                    "name": "Collator1000-02",
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
+                },
+                {
+                    "name": "Collator2000-01",
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
+                },
+                {
+                    "name": "Collator2000-02",
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
+                },
+                {
+                    "name": "Collator2001-01",
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
+                },
+                {
+                    "name": "Collator2001-02",
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
+                },
+                {
+                    "name": "Collator2002-01",
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
+                },
+                {
+                    "name": "Collator2002-02",
+                    "command": "../target/release/tanssi-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"]
+                }
+            ]
+        },
+        {
+            "id": 2000,
+            "chain_spec_path": "specs/template-container-2000.json",
+            "collators": [
+                {
+                    "name": "FullNode-2000",
+                    "validator": false,
+                    "command": "../target/release/container-chain-simple-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"],
+                    "ws_port": 9949,
+                    "p2p_port": 33049
+                }
+            ]
+        },
+        {
+            "id": 2001,
+            "chain_spec_path": "specs/template-container-2001.json",
+            "collators": [
+                {
+                    "name": "FullNode-2001",
+                    "validator": false,
+                    "command": "../target/release/container-chain-frontier-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"],
+                    "ws_port": 9950,
+                    "p2p_port": 33050
+                }
+            ]
+        },
+        {
+            "id": 2002,
+            "chain_spec_path": "specs/template-container-2002.json",
+            "collators": [
+                {
+                    "name": "FullNode-2002",
+                    "validator": false,
+                    "command": "../target/release/container-chain-simple-node",
+                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"],
+                    "ws_port": 9951,
+                    "p2p_port": 33051
+                }
+            ]
+        }
+    ],
+    "types": {
+        "Header": {
+            "number": "u64",
+            "parent_hash": "Hash",
+            "post_state": "Hash"
+        }
+    }
+}

--- a/test/moonwall.config.json
+++ b/test/moonwall.config.json
@@ -169,6 +169,62 @@
             }
         },
         {
+            "name": "zombie_flashbox",
+            "timeout": 600000,
+            "testFileDir": ["suites/para"],
+            "runScripts": [
+                "build-spec-flashbox.sh",
+                "download-polkadot.sh",
+                "compile-wasm.ts compile -b ../target/release/tanssi-node -o wasm -c specs/tanssi-1000.json",
+                "compile-wasm.ts compile -b ../target/release/container-chain-simple-node -o wasm -c specs/template-container-2000.json",
+                "compile-wasm.ts compile -b ../target/release/container-chain-frontier-node -o wasm -c specs/template-container-2001.json"
+            ],
+            "foundation": {
+                "type": "zombie",
+                "zombieSpec": {
+                    "configPath": "./configs/zombieFlashbox.json",
+                    "skipBlockCheck": ["Container2002"]
+                }
+            },
+            "connections": [
+                {
+                    "name": "Relay",
+                    "type": "polkadotJs",
+                    "endpoints": ["ws://127.0.0.1:9947"]
+                },
+                {
+                    "name": "Tanssi",
+                    "type": "polkadotJs",
+                    "endpoints": ["ws://127.0.0.1:9948"]
+                },
+                {
+                    "name": "Container2000",
+                    "type": "polkadotJs",
+                    "endpoints": ["ws://127.0.0.1:9949"]
+                },
+                {
+                    "name": "Container2001",
+                    "type": "polkadotJs",
+                    "endpoints": ["ws://127.0.0.1:9950"]
+                },
+                {
+                    "name": "Container2002",
+                    "type": "polkadotJs",
+                    "endpoints": ["ws://127.0.0.1:9951"]
+                },
+                {
+                    "name": "ethers",
+                    "type": "ethers",
+                    "endpoints": ["ws://127.0.0.1:9950"]
+                },
+                {
+                    "name": "w3",
+                    "type": "web3",
+                    "endpoints": ["ws://127.0.0.1:9950"]
+                }
+            ]
+        },
+        {
             "name": "zombie_tanssi",
             "timeout": 600000,
             "testFileDir": ["suites/para"],

--- a/test/scripts/build-spec-flashbox.sh
+++ b/test/scripts/build-spec-flashbox.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Exit on any error
+set -e
+
+# Always run the commands from the "test" dir
+cd $(dirname $0)/..
+
+mkdir -p specs
+../target/release/container-chain-simple-node build-spec --disable-default-bootnode --add-bootnode "/ip4/127.0.0.1/tcp/33049/ws/p2p/12D3KooWHVMhQDHBpj9vQmssgyfspYecgV6e3hH1dQVDUkUbCYC9" --parachain-id 2000 --raw > specs/template-container-2000.json
+../target/release/container-chain-frontier-node build-spec --disable-default-bootnode --add-bootnode "/ip4/127.0.0.1/tcp/33050/ws/p2p/12D3KooWFGaw1rxB6MSuN3ucuBm7hMq5pBFJbEoqTyth4cG483Cc" --parachain-id 2001 --raw > specs/template-container-2001.json
+../target/release/container-chain-simple-node build-spec --disable-default-bootnode --parachain-id 2002 --raw > specs/template-container-2002.json
+../target/release/tanssi-node build-spec --chain flashbox-local --parachain-id 1000 --add-container-chain specs/template-container-2000.json --add-container-chain specs/template-container-2001.json --invulnerable "Collator1000-01" --invulnerable "Collator1000-02" --invulnerable "Collator2002-01" --invulnerable "Collator2002-02" --invulnerable "Collator2000-01" --invulnerable "Collator2000-02" --invulnerable "Collator2001-01" --invulnerable "Collator2001-02" > specs/flashbox-1000.json

--- a/test/suites/para/test_tanssi_containers.ts
+++ b/test/suites/para/test_tanssi_containers.ts
@@ -36,10 +36,12 @@ describeSuite({
             const relayNetwork = relayApi.consts.system.version.specName.toString();
             expect(relayNetwork, "Relay API incorrect").to.contain("rococo");
 
-            const paraNetwork = paraApi.consts.system.version.specName.toString();
             const paraId1000 = (await paraApi.query.parachainInfo.parachainId()).toString();
-            expect(paraNetwork, "Para API incorrect").to.contain("dancebox");
             expect(paraId1000, "Para API incorrect").to.be.equal("1000");
+            const paraNetwork = paraApi.consts.system.version.specName.toString();
+            expect(paraNetwork, "Para API incorrect").to.satisfy(
+                (network) => network.includes("dancebox") || network.includes("flashbox")
+            );
 
             const container2000Network = container2000Api.consts.system.version.specName.toString();
             const paraId2000 = (await container2000Api.query.parachainInfo.parachainId()).toString();


### PR DESCRIPTION
Identical to the dancebox suite zombie_tanssi, the only difference is in `test/scripts/build-spec-flashbox.sh`, which has `--chain flashbox-local` instead of dancebox-local.