### PR TITLE
Increase authoring duration to 2s and block weight limit x4

### DIFF
--- a/client/service-container-chain/src/service.rs
+++ b/client/service-container-chain/src/service.rs
@@ -474,8 +474,7 @@ fn start_consensus_container(
         relay_chain_slot_duration,
         proposer,
         collator_service,
-        // Very limited proposal time.
-        authoring_duration: Duration::from_millis(500),
+        authoring_duration: Duration::from_millis(2000),
         para_backend: backend,
         code_hash_provider,
         // This cancellation token is no-op as it is not shared outside.

--- a/container-chains/runtime-templates/frontier/src/lib.rs
+++ b/container-chains/runtime-templates/frontier/src/lib.rs
@@ -842,13 +842,6 @@ parameter_types! {
         = U256::from(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT.ref_time() / WEIGHT_PER_GAS);
     pub PrecompilesValue: TemplatePrecompiles<Runtime> = TemplatePrecompiles::<_>::new();
     pub WeightPerGas: Weight = Weight::from_parts(WEIGHT_PER_GAS, 0);
-    /// The amount of gas per pov. A ratio of 4 if we convert ref_time to gas and we compare
-    /// it with the pov_size for a block. E.g.
-    /// ceil(
-    ///     (max_extrinsic.ref_time() / max_extrinsic.proof_size()) / WEIGHT_PER_GAS
-    /// )
-    /// We should re-check `xcm_config::Erc20XcmBridgeTransferGasLimit` when changing this value
-    pub const GasLimitPovSizeRatio: u64 = 8;
     pub SuicideQuickClearLimit: u32 = 0;
 }
 
@@ -877,7 +870,8 @@ impl pallet_evm::Config for Runtime {
     type OnChargeTransaction = OnChargeEVMTransaction<()>;
     type OnCreate = ();
     type FindAuthor = FindAuthorAdapter;
-    type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
+    // TODO: update in the future
+    type GasLimitPovSizeRatio = ();
     type SuicideQuickClearLimit = SuicideQuickClearLimit;
     type Timestamp = Timestamp;
     type WeightInfo = ();

--- a/container-chains/runtime-templates/frontier/src/lib.rs
+++ b/container-chains/runtime-templates/frontier/src/lib.rs
@@ -372,14 +372,14 @@ const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(5);
 /// `Operational` extrinsics.
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 
-/// We allow for 0.5 of a second of compute with a 12 second average block time.
+/// We allow for 2 seconds of compute with a 6 second average block time
 const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::from_parts(
-    WEIGHT_REF_TIME_PER_SECOND.saturating_div(2),
+    WEIGHT_REF_TIME_PER_SECOND.saturating_mul(2),
     cumulus_primitives_core::relay_chain::MAX_POV_SIZE as u64,
 );
 
-/// We allow for 500ms of compute with a 12 second average block time.
-pub const WEIGHT_MILLISECS_PER_BLOCK: u64 = 500;
+/// We allow for 2 seconds of compute with a 6 second average block time
+pub const WEIGHT_MILLISECS_PER_BLOCK: u64 = 2000;
 
 /// The version information used to identify this runtime when compiled natively.
 #[cfg(feature = "std")]

--- a/container-chains/runtime-templates/simple/src/lib.rs
+++ b/container-chains/runtime-templates/simple/src/lib.rs
@@ -272,9 +272,9 @@ const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(5);
 /// `Operational` extrinsics.
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 
-/// We allow for 0.5 of a second of compute with a 12 second average block time.
+/// We allow for 2 seconds of compute with a 6 second average block time
 const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::from_parts(
-    WEIGHT_REF_TIME_PER_SECOND.saturating_div(2),
+    WEIGHT_REF_TIME_PER_SECOND.saturating_mul(2),
     cumulus_primitives_core::relay_chain::MAX_POV_SIZE as u64,
 );
 

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -638,8 +638,7 @@ fn start_consensus_orchestrator(
         force_authoring,
         proposer,
         collator_service,
-        // Very limited proposal time.
-        authoring_duration: Duration::from_millis(500),
+        authoring_duration: Duration::from_millis(2000),
         code_hash_provider,
         para_backend: backend,
         cancellation_token: cancellation_token.clone(),

--- a/runtime/dancebox/src/lib.rs
+++ b/runtime/dancebox/src/lib.rs
@@ -288,9 +288,9 @@ const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(5);
 /// `Operational` extrinsics.
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 
-/// We allow for 0.5 of a second of compute with a 12 second average block time.
+/// We allow for 2 seconds of compute with a 6 second average block time
 const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::from_parts(
-    WEIGHT_REF_TIME_PER_SECOND.saturating_div(2),
+    WEIGHT_REF_TIME_PER_SECOND.saturating_mul(2),
     cumulus_primitives_core::relay_chain::MAX_POV_SIZE as u64,
 );
 

--- a/runtime/flashbox/src/lib.rs
+++ b/runtime/flashbox/src/lib.rs
@@ -263,9 +263,9 @@ const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(5);
 /// `Operational` extrinsics.
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 
-/// We allow for 0.5 of a second of compute with a 12 second average block time.
+/// We allow for 2 seconds of compute with a 6 second average block time
 const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::from_parts(
-    WEIGHT_REF_TIME_PER_SECOND.saturating_div(2),
+    WEIGHT_REF_TIME_PER_SECOND.saturating_mul(2),
     cumulus_primitives_core::relay_chain::MAX_POV_SIZE as u64,
 );
 


### PR DESCRIPTION
Block authoring duration: 0.5s -> 2s
Frontier template gas limit: 15M -> 60M
Substrate block weight limit: 0.5e12 -> 2e12

https://github.com/paritytech/polkadot-sdk/pull/5195