### PR TITLE
ServicesPayment in Starlight runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16278,6 +16278,8 @@ dependencies = [
  "pallet-registrar-runtime-api",
  "pallet-root-testing",
  "pallet-scheduler",
+ "pallet-services-payment",
+ "pallet-services-payment-runtime-api",
  "pallet-session",
  "pallet-staking",
  "pallet-sudo",

--- a/solo-chains/runtime/starlight/Cargo.toml
+++ b/solo-chains/runtime/starlight/Cargo.toml
@@ -130,6 +130,8 @@ pallet-author-noting-runtime-api = { workspace = true }
 pallet-configuration = { workspace = true }
 pallet-registrar = { workspace = true }
 pallet-registrar-runtime-api = { workspace = true }
+pallet-services-payment = { workspace = true }
+pallet-services-payment-runtime-api = { workspace = true }
 tanssi-runtime-common = { workspace = true }
 
 # Moonkit
@@ -214,6 +216,8 @@ std = [
 	"pallet-registrar/std",
 	"pallet-root-testing/std",
 	"pallet-scheduler/std",
+	"pallet-services-payment-runtime-api/std",
+	"pallet-services-payment/std",
 	"pallet-session/std",
 	"pallet-staking/std",
 	"pallet-sudo/std",
@@ -303,6 +307,7 @@ runtime-benchmarks = [
 	"pallet-referenda/runtime-benchmarks",
 	"pallet-registrar/runtime-benchmarks",
 	"pallet-scheduler/runtime-benchmarks",
+	"pallet-services-payment/runtime-benchmarks",
 	"pallet-staking/runtime-benchmarks",
 	"pallet-sudo/runtime-benchmarks",
 	"pallet-timestamp/runtime-benchmarks",
@@ -369,6 +374,7 @@ try-runtime = [
 	"pallet-registrar/try-runtime",
 	"pallet-root-testing/try-runtime",
 	"pallet-scheduler/try-runtime",
+	"pallet-services-payment/try-runtime",
 	"pallet-session/try-runtime",
 	"pallet-staking/try-runtime",
 	"pallet-sudo/try-runtime",

--- a/solo-chains/runtime/starlight/README.md
+++ b/solo-chains/runtime/starlight/README.md
@@ -3,10 +3,9 @@
 Starlight is a testnet runtime with no stability guarantees.
 
 ## How to build `starlight` runtime
-`EpochDurationInBlocks` parameter is configurable via `STARLIGHT_EPOCH_DURATION` environment variable. To build wasm
-runtime blob with customized epoch duration the following command shall be executed:
+To build wasm runtime blob with customized epoch duration the following command shall be executed:
 ```bash
-STARLIGHT_EPOCH_DURATION=10 ./polkadot/scripts/build-only-wasm.sh starlight-runtime /path/to/output/directory/
+./polkadot/scripts/build-only-wasm.sh starlight-runtime /path/to/output/directory/
 ```
 
 ## How to run `starlight-local`

--- a/solo-chains/runtime/starlight/constants/src/lib.rs
+++ b/solo-chains/runtime/starlight/constants/src/lib.rs
@@ -45,8 +45,7 @@ pub mod time {
     pub const SLOT_DURATION: Moment = MILLISECS_PER_BLOCK;
 
     frame_support::parameter_types! {
-        pub EpochDurationInBlocks: BlockNumber =
-            prod_or_fast!(1 * HOURS, 1 * MINUTES, "STARLIGHT_EPOCH_DURATION");
+        pub const EpochDurationInBlocks: BlockNumber = prod_or_fast!(1 * HOURS, 1 * MINUTES);
     }
 
     // These time units are defined in number of blocks.

--- a/solo-chains/runtime/starlight/constants/src/lib.rs
+++ b/solo-chains/runtime/starlight/constants/src/lib.rs
@@ -29,6 +29,7 @@ pub mod currency {
     pub const CENTS: Balance = UNITS / 30_000;
     pub const GRAND: Balance = CENTS * 100_000;
     pub const MILLICENTS: Balance = CENTS / 1_000;
+    pub const MICROUNITS: Balance = 1_000_000;
 
     pub const fn deposit(items: u32, bytes: u32) -> Balance {
         items as Balance * 2_000 * CENTS + (bytes as Balance) * 100 * MILLICENTS

--- a/solo-chains/runtime/starlight/src/genesis_config_presets.rs
+++ b/solo-chains/runtime/starlight/src/genesis_config_presets.rs
@@ -242,6 +242,13 @@ fn starlight_testnet_genesis(
         .map(|(para_id, genesis_data, _boot_nodes)| (para_id, genesis_data, None))
         .collect();
 
+    // Assign 1000 block credits to all container chains registered in genesis
+    // Assign 100 collator assignment credits to all container chains registered in genesis
+    let para_id_credits: Vec<_> = para_ids
+        .iter()
+        .map(|(para_id, _genesis_data, _boot_nodes)| (*para_id, 1000, 100).into())
+        .collect();
+
     const ENDOWMENT: u128 = 1_000_000 * STAR;
 
     serde_json::json!({
@@ -289,6 +296,7 @@ fn starlight_testnet_genesis(
             invulnerables: invulnerables.iter().cloned().map(|x| x.stash.clone()).collect(),
         },
         "containerRegistrar": crate::ContainerRegistrarConfig { para_ids, ..Default::default() },
+        "servicesPayment": crate::ServicesPaymentConfig { para_id_credits },
     })
 }
 

--- a/solo-chains/runtime/starlight/src/lib.rs
+++ b/solo-chains/runtime/starlight/src/lib.rs
@@ -29,12 +29,13 @@ use {
     frame_support::{
         dispatch::DispatchResult,
         dynamic_params::{dynamic_pallet_params, dynamic_params},
-        traits::{ConstBool, FromContains},
+        traits::{fungible::Inspect, ConstBool, FromContains},
     },
     frame_system::{pallet_prelude::BlockNumberFor, EnsureNever},
     nimbus_primitives::NimbusId,
     pallet_initializer as tanssi_initializer,
     pallet_registrar_runtime_api::ContainerChainGenesisData,
+    pallet_services_payment::{ProvideBlockProductionCost, ProvideCollatorAssignmentCost},
     pallet_session::ShouldEndSession,
     parachains_scheduler::common::Assignment,
     parity_scale_codec::{Decode, Encode, MaxEncodedLen},
@@ -73,10 +74,11 @@ use {
     sp_runtime::traits::BlockNumberProvider,
     sp_std::{
         cmp::Ordering,
-        collections::{btree_map::BTreeMap, vec_deque::VecDeque},
+        collections::{btree_map::BTreeMap, btree_set::BTreeSet, vec_deque::VecDeque},
+        marker::PhantomData,
         prelude::*,
     },
-    tp_traits::{GetSessionContainerChains, Slot, SlotFrequency},
+    tp_traits::{GetSessionContainerChains, RemoveParaIdsWithNoCredits, Slot, SlotFrequency},
 };
 
 #[cfg(any(feature = "std", test))]
@@ -1263,6 +1265,51 @@ impl pallet_multiblock_migrations::Config for Runtime {
     type WeightInfo = ();
 }
 
+pub const FIXED_BLOCK_PRODUCTION_COST: u128 = 1 * MICROUNITS;
+pub const FIXED_COLLATOR_ASSIGNMENT_COST: u128 = 100 * MICROUNITS;
+
+pub struct BlockProductionCost<Runtime>(PhantomData<Runtime>);
+impl ProvideBlockProductionCost<Runtime> for BlockProductionCost<Runtime> {
+    fn block_cost(_para_id: &ParaId) -> (u128, Weight) {
+        (FIXED_BLOCK_PRODUCTION_COST, Weight::zero())
+    }
+}
+
+pub struct CollatorAssignmentCost<Runtime>(PhantomData<Runtime>);
+impl ProvideCollatorAssignmentCost<Runtime> for CollatorAssignmentCost<Runtime> {
+    fn collator_assignment_cost(_para_id: &ParaId) -> (u128, Weight) {
+        (FIXED_COLLATOR_ASSIGNMENT_COST, Weight::zero())
+    }
+}
+
+parameter_types! {
+    // 60 days worth of blocks
+    pub const FreeBlockProductionCredits: BlockNumber = 60 * DAYS;
+    // 60 days worth of blocks
+    pub const FreeCollatorAssignmentCredits: u32 = FreeBlockProductionCredits::get();
+    // pub const FreeCollatorAssignmentCredits: u32 = FreeBlockProductionCredits::get()/u32::from(EpochDurationInBlocks::get());
+}
+
+impl pallet_services_payment::Config for Runtime {
+    type RuntimeEvent = RuntimeEvent;
+    /// Handler for fees
+    type OnChargeForBlock = ();
+    type OnChargeForCollatorAssignment = ();
+    type OnChargeForCollatorAssignmentTip = ();
+    /// Currency type for fee payment
+    type Currency = Balances;
+    /// Provider of a block cost which can adjust from block to block
+    type ProvideBlockProductionCost = BlockProductionCost<Runtime>;
+    /// Provider of a block cost which can adjust from block to block
+    type ProvideCollatorAssignmentCost = CollatorAssignmentCost<Runtime>;
+    /// The maximum number of block credits that can be accumulated
+    type FreeBlockProductionCredits = FreeBlockProductionCredits;
+    /// The maximum number of session credits that can be accumulated
+    type FreeCollatorAssignmentCredits = FreeCollatorAssignmentCredits;
+    type ManagerOrigin = EnsureRoot<AccountId>;
+    type WeightInfo = ();
+}
+
 construct_runtime! {
     pub enum Runtime
     {
@@ -1375,6 +1422,7 @@ construct_runtime! {
         Migrations: pallet_migrations = 107,
         MultiBlockMigrations: pallet_multiblock_migrations = 108,
         AuthorNoting: pallet_author_noting = 109,
+        ServicesPayment: pallet_services_payment = 110,
     }
 }
 
@@ -1450,14 +1498,12 @@ impl pallet_registrar::Config for Runtime {
 pub struct StarlightRegistrarHooks;
 
 impl pallet_registrar::RegistrarHooks for StarlightRegistrarHooks {
-    fn para_marked_valid_for_collating(_para_id: ParaId) -> Weight {
+    fn para_marked_valid_for_collating(para_id: ParaId) -> Weight {
         // Give free credits but only once per para id
-        // TODO: uncomment when ServicesPayment pallet exists
-        //ServicesPayment::give_free_credits(&para_id)
-        Weight::default()
+        ServicesPayment::give_free_credits(&para_id)
     }
 
-    fn para_deregistered(_para_id: ParaId) -> Weight {
+    fn para_deregistered(para_id: ParaId) -> Weight {
         // Clear pallet_author_noting storage
         // TODO: uncomment when pallets exists
         /*
@@ -1471,10 +1517,9 @@ impl pallet_registrar::RegistrarHooks for StarlightRegistrarHooks {
         // Remove bootnodes from pallet_data_preservers
         DataPreservers::para_deregistered(para_id);
 
-        ServicesPayment::para_deregistered(para_id);
-
         XcmCoreBuyer::para_deregistered(para_id);
          */
+        ServicesPayment::para_deregistered(para_id);
 
         Weight::default()
     }
@@ -1555,7 +1600,7 @@ impl pallet_author_noting::Config for Runtime {
     #[cfg(feature = "runtime-benchmarks")]
     type AuthorNotingHook = ();
     #[cfg(not(feature = "runtime-benchmarks"))]
-    type AuthorNotingHook = ();
+    type AuthorNotingHook = ServicesPayment;
     // TODO: uncomment when pallets exist
     //type AuthorNotingHook = (InflationRewards, ServicesPayment);
     type RelayOrPara = pallet_author_noting::RelayMode;
@@ -1604,6 +1649,7 @@ mod benches {
         [pallet_utility, Utility]
         [pallet_asset_rate, AssetRate]
         [pallet_whitelist, Whitelist]
+        [pallet_services_payment, ServicesPayment]
         // XCM
         [pallet_xcm, PalletXcmExtrinsicsBenchmark::<Runtime>]
         [pallet_xcm_benchmarks::fungible, pallet_xcm_benchmarks::fungible::Pallet::<Runtime>]
@@ -2239,6 +2285,18 @@ sp_api::impl_runtime_apis! {
         }
     }
 
+    impl pallet_services_payment_runtime_api::ServicesPaymentApi<Block, Balance, ParaId> for Runtime {
+        fn block_cost(para_id: ParaId) -> Balance {
+            let (block_production_costs, _) = <Runtime as pallet_services_payment::Config>::ProvideBlockProductionCost::block_cost(&para_id);
+            block_production_costs
+        }
+
+        fn collator_assignment_cost(para_id: ParaId) -> Balance {
+            let (collator_assignment_costs, _) = <Runtime as pallet_services_payment::Config>::ProvideCollatorAssignmentCost::collator_assignment_cost(&para_id);
+            collator_assignment_costs
+        }
+    }
+
     #[cfg(feature = "runtime-benchmarks")]
     impl frame_benchmarking::Benchmark<Block> for Runtime {
         fn benchmark_metadata(extra: bool) -> (
@@ -2570,6 +2628,83 @@ impl tanssi_initializer::Config for Runtime {
     type SessionHandler = OwnApplySession;
 }
 
+pub struct RemoveParaIdsWithNoCreditsImpl;
+
+impl RemoveParaIdsWithNoCredits for RemoveParaIdsWithNoCreditsImpl {
+    fn remove_para_ids_with_no_credits(
+        para_ids: &mut Vec<ParaId>,
+        currently_assigned: &BTreeSet<ParaId>,
+    ) {
+        let blocks_per_session = EpochDurationInBlocks::get();
+
+        para_ids.retain(|para_id| {
+            // If the para has been assigned collators for this session it must have enough block credits
+            // for the current and the next session.
+            let block_credits_needed = if currently_assigned.contains(para_id) {
+                blocks_per_session * 2
+            } else {
+                blocks_per_session
+            };
+
+            // Check if the container chain has enough credits for producing blocks
+            let free_block_credits = pallet_services_payment::BlockProductionCredits::<Runtime>::get(para_id)
+                .unwrap_or_default();
+
+            // Check if the container chain has enough credits for a session assignments
+            let free_session_credits = pallet_services_payment::CollatorAssignmentCredits::<Runtime>::get(para_id)
+                .unwrap_or_default();
+
+            // If para's max tip is set it should have enough to pay for one assignment with tip
+            let max_tip = pallet_services_payment::MaxTip::<Runtime>::get(para_id).unwrap_or_default() ;
+
+            // Return if we can survive with free credits
+            if free_block_credits >= block_credits_needed && free_session_credits >= 1 {
+                // Max tip should always be checked, as it can be withdrawn even if free credits were used
+                return Balances::can_withdraw(&pallet_services_payment::Pallet::<Runtime>::parachain_tank(*para_id), max_tip).into_result(true).is_ok()
+            }
+
+            let remaining_block_credits = block_credits_needed.saturating_sub(free_block_credits);
+            let remaining_session_credits = 1u32.saturating_sub(free_session_credits);
+
+            let (block_production_costs, _) = <Runtime as pallet_services_payment::Config>::ProvideBlockProductionCost::block_cost(para_id);
+            let (collator_assignment_costs, _) = <Runtime as pallet_services_payment::Config>::ProvideCollatorAssignmentCost::collator_assignment_cost(para_id);
+            // let's check if we can withdraw
+            let remaining_block_credits_to_pay = u128::from(remaining_block_credits).saturating_mul(block_production_costs);
+            let remaining_session_credits_to_pay = u128::from(remaining_session_credits).saturating_mul(collator_assignment_costs);
+
+            let remaining_to_pay = remaining_block_credits_to_pay.saturating_add(remaining_session_credits_to_pay).saturating_add(max_tip);
+
+            // This should take into account whether we tank goes below ED
+            // The true refers to keepAlive
+            Balances::can_withdraw(&pallet_services_payment::Pallet::<Runtime>::parachain_tank(*para_id), remaining_to_pay).into_result(true).is_ok()
+        });
+    }
+
+    /// Make those para ids valid by giving them enough credits, for benchmarking.
+    #[cfg(feature = "runtime-benchmarks")]
+    fn make_valid_para_ids(para_ids: &[ParaId]) {
+        use frame_support::assert_ok;
+
+        let blocks_per_session = EpochDurationInBlocks::get();
+        // Enough credits to run any benchmark
+        let block_credits = 20 * blocks_per_session;
+        let session_credits = 20;
+
+        for para_id in para_ids {
+            assert_ok!(ServicesPayment::set_block_production_credits(
+                RuntimeOrigin::root(),
+                *para_id,
+                block_credits,
+            ));
+            assert_ok!(ServicesPayment::set_collator_assignment_credits(
+                RuntimeOrigin::root(),
+                *para_id,
+                session_credits,
+            ));
+        }
+    }
+}
+
 impl pallet_collator_assignment::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type HostConfiguration = CollatorConfiguration;
@@ -2579,9 +2714,9 @@ impl pallet_collator_assignment::Config for Runtime {
     type ShouldRotateAllCollators = ();
     type GetRandomnessForNextBlock = ();
     type RemoveInvulnerables = ();
-    type RemoveParaIdsWithNoCredits = ();
-    type CollatorAssignmentHook = ();
-    type CollatorAssignmentTip = ();
+    type RemoveParaIdsWithNoCredits = RemoveParaIdsWithNoCreditsImpl;
+    type CollatorAssignmentHook = ServicesPayment;
+    type CollatorAssignmentTip = ServicesPayment;
     type Currency = Balances;
     type ForceEmptyOrchestrator = ConstBool<true>;
     type WeightInfo = ();

--- a/solo-chains/runtime/starlight/src/lib.rs
+++ b/solo-chains/runtime/starlight/src/lib.rs
@@ -1285,9 +1285,8 @@ impl ProvideCollatorAssignmentCost<Runtime> for CollatorAssignmentCost<Runtime> 
 parameter_types! {
     // 60 days worth of blocks
     pub const FreeBlockProductionCredits: BlockNumber = 60 * DAYS;
-    // 60 days worth of blocks
-    pub const FreeCollatorAssignmentCredits: u32 = FreeBlockProductionCredits::get();
-    // pub const FreeCollatorAssignmentCredits: u32 = FreeBlockProductionCredits::get()/u32::from(EpochDurationInBlocks::get());
+    // 60 days worth of collator assignment
+    pub const FreeCollatorAssignmentCredits: u32 = FreeBlockProductionCredits::get()/EpochDurationInBlocks::get();
 }
 
 impl pallet_services_payment::Config for Runtime {

--- a/solo-chains/runtime/starlight/src/tests/collator_assignment_tests.rs
+++ b/solo-chains/runtime/starlight/src/tests/collator_assignment_tests.rs
@@ -19,10 +19,16 @@
 use {
     crate::tests::common::*,
     crate::{
-        CollatorConfiguration, ContainerRegistrar, TanssiAuthorityMapping, TanssiInvulnerables,
+        Balances, CollatorConfiguration, ContainerRegistrar, ServicesPayment,
+        TanssiAuthorityMapping, TanssiInvulnerables,
     },
+    cumulus_primitives_core::ParaId,
     frame_support::assert_ok,
+    parity_scale_codec::Encode,
+    sp_consensus_aura::AURA_ENGINE_ID,
+    sp_runtime::{traits::BlakeTwo256, DigestItem},
     sp_std::vec,
+    test_relay_sproof_builder::{HeaderAs, ParaHeaderSproofBuilder, ParaHeaderSproofBuilderItem},
 };
 
 #[test]
@@ -560,8 +566,6 @@ fn test_authors_paras_inserted_a_posteriori() {
             // Alice gets 10k extra tokens for her mapping deposit
             (AccountId::from(ALICE), 210_000 * UNIT),
             (AccountId::from(BOB), 100_000 * UNIT),
-            (AccountId::from(CHARLIE), 100_000 * UNIT),
-            (AccountId::from(DAVE), 100_000 * UNIT),
         ])
         .with_collators(vec![
             (AccountId::from(ALICE), 210 * UNIT),
@@ -600,12 +604,11 @@ fn test_authors_paras_inserted_a_posteriori() {
                 1001.into()
             ));
 
-            // TODO: uncomment when we add ServicesPayment
-            /*  assert_ok!(ServicesPayment::purchase_credits(
+            assert_ok!(ServicesPayment::purchase_credits(
                 origin_of(ALICE.into()),
                 1001.into(),
                 block_credits_to_required_balance(1000, 1001.into())
-            )); */
+            ));
 
             assert_ok!(ContainerRegistrar::register(
                 origin_of(ALICE.into()),
@@ -620,12 +623,11 @@ fn test_authors_paras_inserted_a_posteriori() {
                 1002.into()
             ));
 
-            // TODO: uncomment when we add ServicesPayment
-            /*  assert_ok!(ServicesPayment::purchase_credits(
+            assert_ok!(ServicesPayment::purchase_credits(
                 origin_of(ALICE.into()),
                 1002.into(),
                 block_credits_to_required_balance(1000, 1002.into())
-            )); */
+            ));
 
             // Assignment should happen after 2 sessions
             run_to_session(1u32);
@@ -638,6 +640,1318 @@ fn test_authors_paras_inserted_a_posteriori() {
             assert_eq!(
                 assignment.container_chains[&1001u32.into()],
                 vec![ALICE.into(), BOB.into()]
+            );
+        });
+}
+
+#[test]
+fn test_authors_paras_inserted_a_posteriori_with_collators_already_assigned() {
+    ExtBuilder::default()
+        .with_balances(vec![
+            // Alice gets 10k extra tokens for her mapping deposit
+            (AccountId::from(ALICE), 210_000 * UNIT),
+            (AccountId::from(BOB), 100_000 * UNIT),
+        ])
+        .with_collators(vec![
+            (AccountId::from(ALICE), 210 * UNIT),
+            (AccountId::from(BOB), 100 * UNIT),
+        ])
+        .with_config(pallet_configuration::HostConfiguration {
+            max_collators: 100,
+            min_orchestrator_collators: 2,
+            max_orchestrator_collators: 5,
+            collators_per_container: 2,
+            full_rotation_period: 24,
+            ..Default::default()
+        })
+        .build()
+        .execute_with(|| {
+            assert_ok!(ContainerRegistrar::register(
+                origin_of(ALICE.into()),
+                1001.into(),
+                empty_genesis_data()
+            ));
+
+            // TODO: uncomment when we add DataPreservers
+            // set_dummy_boot_node(origin_of(ALICE.into()), 1001.into());
+
+            assert_ok!(ContainerRegistrar::mark_valid_for_collating(
+                root_origin(),
+                1001.into()
+            ));
+            assert_ok!(ServicesPayment::purchase_credits(
+                origin_of(ALICE.into()),
+                1001.into(),
+                block_credits_to_required_balance(1000, 1001.into())
+            ));
+
+            // Assignment should happen after 2 sessions
+            run_to_session(1u32);
+            let assignment = TanssiCollatorAssignment::collator_container_chain();
+            assert!(assignment.container_chains.is_empty());
+            run_to_session(2u32);
+
+            // Alice and Bob are now assigned to para 1001
+            let assignment = TanssiCollatorAssignment::collator_container_chain();
+            assert_eq!(
+                assignment.container_chains[&1001u32.into()],
+                vec![ALICE.into(), BOB.into()]
+            );
+        });
+}
+
+#[test]
+fn test_paras_registered_but_zero_credits() {
+    ExtBuilder::default()
+        .with_balances(vec![
+            // Alice gets 10k extra tokens for her mapping deposit
+            (AccountId::from(ALICE), 210_000 * UNIT),
+            (AccountId::from(BOB), 100_000 * UNIT),
+        ])
+        .with_collators(vec![
+            (AccountId::from(ALICE), 210 * UNIT),
+            (AccountId::from(BOB), 100 * UNIT),
+        ])
+        .build()
+        .execute_with(|| {
+            assert_ok!(ContainerRegistrar::register(
+                origin_of(ALICE.into()),
+                1001.into(),
+                empty_genesis_data()
+            ));
+
+            // TODO: uncomment when we add DataPreservers
+            // set_dummy_boot_node(origin_of(ALICE.into()), 1001.into());
+
+            assert_ok!(ContainerRegistrar::mark_valid_for_collating(
+                root_origin(),
+                1001.into()
+            ));
+            // Need to reset credits to 0 because now parachains are given free credits on register
+            assert_ok!(ServicesPayment::set_block_production_credits(
+                root_origin(),
+                1001.into(),
+                0
+            ));
+
+            // Assignment should happen after 2 sessions
+            run_to_session(1u32);
+            let assignment = TanssiCollatorAssignment::collator_container_chain();
+            assert!(assignment.container_chains.is_empty());
+            run_to_session(2u32);
+
+            // Nobody should be assigned to para 1001
+            let assignment = TanssiCollatorAssignment::collator_container_chain();
+            assert_eq!(assignment.container_chains.get(&1001u32.into()), None,);
+        });
+}
+
+#[test]
+fn test_paras_registered_but_not_enough_credits() {
+    ExtBuilder::default()
+        .with_balances(vec![
+            // Alice gets 10k extra tokens for her mapping deposit
+            (AccountId::from(ALICE), 210_000 * UNIT),
+            (AccountId::from(BOB), 100_000 * UNIT),
+        ])
+        .with_collators(vec![
+            (AccountId::from(ALICE), 210 * UNIT),
+            (AccountId::from(BOB), 100 * UNIT),
+        ])
+        .build()
+        .execute_with(|| {
+            assert_ok!(ContainerRegistrar::register(
+                origin_of(ALICE.into()),
+                1001.into(),
+                empty_genesis_data()
+            ));
+
+            // TODO: uncomment when we add DataPreservers
+            // set_dummy_boot_node(origin_of(ALICE.into()), 1001.into());
+
+            assert_ok!(ContainerRegistrar::mark_valid_for_collating(
+                root_origin(),
+                1001.into()
+            ));
+            // Need to reset credits to 0 because now parachains are given free credits on register
+            assert_ok!(ServicesPayment::set_block_production_credits(
+                root_origin(),
+                1001.into(),
+                0
+            ));
+            // Purchase 1 credit less that what is needed
+            let credits_1001 = crate::EpochDurationInBlocks::get() - 1;
+            assert_ok!(ServicesPayment::set_block_production_credits(
+                root_origin(),
+                1001.into(),
+                credits_1001
+            ));
+
+            // Assignment should happen after 2 sessions
+            run_to_session(1u32);
+            let assignment = TanssiCollatorAssignment::collator_container_chain();
+            assert!(assignment.container_chains.is_empty());
+            run_to_session(2u32);
+            // Nobody should be assigned to para 1001
+            let assignment = TanssiCollatorAssignment::collator_container_chain();
+            assert_eq!(assignment.container_chains.get(&1001u32.into()), None);
+
+            // Now purchase the missing block credit
+            assert_ok!(ServicesPayment::set_block_production_credits(
+                root_origin(),
+                1001.into(),
+                credits_1001 + 1
+            ));
+
+            run_to_session(4u32);
+            // Alice and Bob should be assigned to para 1001
+            let assignment = TanssiCollatorAssignment::collator_container_chain();
+            assert_eq!(
+                assignment.container_chains[&1001u32.into()],
+                vec![ALICE.into(), BOB.into()]
+            );
+        });
+}
+
+#[test]
+fn test_paras_registered_but_only_credits_for_1_session() {
+    ExtBuilder::default()
+        .with_balances(vec![
+            // Alice gets 10k extra tokens for her mapping deposit
+            (AccountId::from(ALICE), 210_000 * UNIT),
+            (AccountId::from(BOB), 100_000 * UNIT),
+        ])
+        .with_collators(vec![
+            (AccountId::from(ALICE), 210 * UNIT),
+            (AccountId::from(BOB), 100 * UNIT),
+        ])
+        .build()
+        .execute_with(|| {
+            assert_ok!(ContainerRegistrar::register(
+                origin_of(ALICE.into()),
+                1001.into(),
+                empty_genesis_data()
+            ));
+
+            // TODO: uncomment when we add DataPreservers
+            // set_dummy_boot_node(origin_of(ALICE.into()), 1001.into());
+
+            assert_ok!(ContainerRegistrar::mark_valid_for_collating(
+                root_origin(),
+                1001.into()
+            ));
+            // Need to reset credits to 0 because now parachains are given free credits on register
+            assert_ok!(ServicesPayment::set_block_production_credits(
+                root_origin(),
+                1001.into(),
+                0
+            ));
+            // Purchase only enough credits for 1 session
+            let credits_1001 = crate::EpochDurationInBlocks::get();
+            assert_ok!(ServicesPayment::set_block_production_credits(
+                root_origin(),
+                1001.into(),
+                credits_1001
+            ));
+
+            // Assignment should happen after 2 sessions
+            run_to_session(1u32);
+            let assignment = TanssiCollatorAssignment::collator_container_chain();
+            assert!(assignment.container_chains.is_empty());
+            run_to_session(2u32);
+            // Charlie and Dave should be assigned to para 1001
+            let assignment = TanssiCollatorAssignment::collator_container_chain();
+            assert_eq!(
+                assignment.container_chains[&1001u32.into()],
+                vec![ALICE.into(), BOB.into()]
+            );
+
+            // No credits are consumed if the container chain is not producing blocks
+            run_block();
+            let credits =
+                pallet_services_payment::BlockProductionCredits::<Runtime>::get(ParaId::from(1001))
+                    .unwrap_or_default();
+            assert_eq!(credits, credits_1001);
+
+            // Simulate block inclusion from container chain 1001
+            let mut sproof = ParaHeaderSproofBuilder::default();
+            let slot: u64 = 5;
+            let s = ParaHeaderSproofBuilderItem {
+                para_id: 1001.into(),
+                author_id: HeaderAs::NonEncoded(sp_runtime::generic::Header::<u32, BlakeTwo256> {
+                    parent_hash: Default::default(),
+                    number: 1,
+                    state_root: Default::default(),
+                    extrinsics_root: Default::default(),
+                    digest: sp_runtime::generic::Digest {
+                        logs: vec![DigestItem::PreRuntime(AURA_ENGINE_ID, slot.encode())],
+                    },
+                }),
+            };
+            sproof.items.push(s);
+            set_author_noting_inherent_data(sproof);
+
+            run_block();
+            let credits =
+                pallet_services_payment::BlockProductionCredits::<Runtime>::get(ParaId::from(1001))
+                    .unwrap_or_default();
+            assert_eq!(credits, credits_1001 - 1);
+
+            run_to_session(4u32);
+            // Nobody should be assigned to para 1001
+            let assignment = TanssiCollatorAssignment::collator_container_chain();
+            assert_eq!(assignment.container_chains.get(&1001u32.into()), None,);
+
+            // The container chain only produced one block, so it only consumed one block credit.
+            // (it could have produced more blocks, but at most it would have consumed `Period::get()` credits)
+            let credits =
+                pallet_services_payment::BlockProductionCredits::<Runtime>::get(ParaId::from(1001))
+                    .unwrap_or_default();
+            assert_eq!(credits, credits_1001 - 1);
+        });
+}
+
+#[test]
+fn test_can_buy_credits_before_registering_para() {
+    ExtBuilder::default()
+        .with_balances(vec![
+            // Alice gets 10k extra tokens for her mapping deposit
+            (AccountId::from(ALICE), 210_000 * UNIT),
+            (AccountId::from(BOB), 100_000 * UNIT),
+        ])
+        .with_collators(vec![
+            (AccountId::from(ALICE), 210 * UNIT),
+            (AccountId::from(BOB), 100 * UNIT),
+        ])
+        .build()
+        .execute_with(|| {
+            // Try to buy the maximum amount of credits
+            let balance_before = System::account(AccountId::from(ALICE)).data.free;
+
+            assert_ok!(ServicesPayment::purchase_credits(
+                origin_of(ALICE.into()),
+                1001.into(),
+                block_credits_to_required_balance(u32::MAX, 1001.into())
+            ));
+            let balance_after = System::account(AccountId::from(ALICE)).data.free;
+
+            // Now parachain tank should have this amount
+            let balance_tank = System::account(ServicesPayment::parachain_tank(1001.into()))
+                .data
+                .free;
+
+            assert_eq!(
+                balance_tank,
+                block_credits_to_required_balance(u32::MAX, 1001.into())
+            );
+
+            let expected_cost = block_credits_to_required_balance(u32::MAX, 1001.into());
+            assert_eq!(balance_before - balance_after, expected_cost);
+        });
+}
+
+#[test]
+fn test_can_buy_credits_before_registering_para_and_receive_free_credits() {
+    ExtBuilder::default()
+        .with_balances(vec![
+            // Alice gets 10k extra tokens for her mapping deposit
+            (AccountId::from(ALICE), 210_000 * UNIT),
+            (AccountId::from(BOB), 100_000 * UNIT),
+        ])
+        .with_collators(vec![
+            (AccountId::from(ALICE), 210 * UNIT),
+            (AccountId::from(BOB), 100 * UNIT),
+        ])
+        .build()
+        .execute_with(|| {
+            run_to_block(2);
+
+            // Try to buy (MaxCreditsStored - 1) credits
+            let balance_before = System::account(AccountId::from(ALICE)).data.free;
+            assert_ok!(ServicesPayment::purchase_credits(
+                origin_of(ALICE.into()),
+                1001.into(),
+                block_credits_to_required_balance(
+                    crate::FreeBlockProductionCredits::get() - 1,
+                    1001.into()
+                )
+            ));
+            let balance_after = System::account(AccountId::from(ALICE)).data.free;
+
+            // Now parachain tank should have this amount
+            let balance_tank = System::account(ServicesPayment::parachain_tank(1001.into()))
+                .data
+                .free;
+
+            assert_eq!(
+                balance_tank,
+                block_credits_to_required_balance(
+                    crate::FreeBlockProductionCredits::get() - 1,
+                    1001.into()
+                )
+            );
+
+            let expected_cost = block_credits_to_required_balance(
+                crate::FreeBlockProductionCredits::get() - 1,
+                1001.into(),
+            );
+            assert_eq!(balance_before - balance_after, expected_cost);
+
+            // Now register para
+            assert_ok!(ContainerRegistrar::register(
+                origin_of(ALICE.into()),
+                1001.into(),
+                empty_genesis_data()
+            ));
+
+            // TODO: uncomment when we add DataPreservers
+            // set_dummy_boot_node(origin_of(ALICE.into()), 1001.into());
+
+            assert_ok!(ContainerRegistrar::mark_valid_for_collating(
+                root_origin(),
+                1001.into()
+            ));
+
+            // We received free credits, because we cannot have more than MaxCreditsStored
+            let credits =
+                pallet_services_payment::BlockProductionCredits::<Runtime>::get(ParaId::from(1001))
+                    .unwrap_or_default();
+            assert_eq!(credits, crate::FreeBlockProductionCredits::get());
+        });
+}
+
+#[test]
+fn test_ed_plus_block_credit_session_purchase_works() {
+    ExtBuilder::default()
+        .with_balances(vec![
+            // Alice gets 10k extra tokens for her mapping deposit
+            (AccountId::from(ALICE), 210_000 * UNIT),
+            (AccountId::from(BOB), 100_000 * UNIT),
+        ])
+        .with_collators(vec![
+            (AccountId::from(ALICE), 210 * UNIT),
+            (AccountId::from(BOB), 100 * UNIT),
+        ])
+        .build()
+        .execute_with(|| {
+            assert_ok!(ContainerRegistrar::register(
+                origin_of(ALICE.into()),
+                1001.into(),
+                empty_genesis_data()
+            ));
+
+            // TODO: uncomment when we add DataPreservers
+            // set_dummy_boot_node(origin_of(ALICE.into()), 1001.into());
+
+            assert_ok!(ContainerRegistrar::mark_valid_for_collating(
+                root_origin(),
+                1001.into()
+            ));
+            // Need to reset credits to 0 because now parachains are given free credits on register
+            assert_ok!(ServicesPayment::set_block_production_credits(
+                root_origin(),
+                1001.into(),
+                0
+            ));
+            let credits_1001 =
+                block_credits_to_required_balance(crate::EpochDurationInBlocks::get(), 1001.into())
+                    + crate::EXISTENTIAL_DEPOSIT;
+
+            // Fill the tank
+            assert_ok!(ServicesPayment::purchase_credits(
+                origin_of(ALICE.into()),
+                1001.into(),
+                credits_1001
+            ));
+
+            // Assignment should happen after 2 sessions
+            run_to_session(1u32);
+            let assignment = TanssiCollatorAssignment::collator_container_chain();
+            assert!(assignment.container_chains.is_empty());
+            run_to_session(2u32);
+            // Charlie and Dave should be assigned to para 1001
+            let assignment = TanssiCollatorAssignment::collator_container_chain();
+            assert_eq!(
+                assignment.container_chains[&1001u32.into()],
+                vec![ALICE.into(), BOB.into()]
+            );
+
+            // Simulate block inclusion from container chain 1001
+            let mut sproof: ParaHeaderSproofBuilder = ParaHeaderSproofBuilder::default();
+            let slot: u64 = 5;
+            let s = ParaHeaderSproofBuilderItem {
+                para_id: 1001.into(),
+                author_id: HeaderAs::NonEncoded(sp_runtime::generic::Header::<u32, BlakeTwo256> {
+                    parent_hash: Default::default(),
+                    number: 1,
+                    state_root: Default::default(),
+                    extrinsics_root: Default::default(),
+                    digest: sp_runtime::generic::Digest {
+                        logs: vec![DigestItem::PreRuntime(AURA_ENGINE_ID, slot.encode())],
+                    },
+                }),
+            };
+
+            sproof.items.push(s);
+            set_author_noting_inherent_data(sproof);
+
+            run_block();
+
+            // After this it should not be assigned anymore, since credits are not payable
+            run_to_session(3u32);
+            // Nobody should be assigned to para 1001
+            let assignment = TanssiCollatorAssignment::collator_container_chain();
+            assert_eq!(assignment.container_chains.get(&1001u32.into()), None,);
+        });
+}
+
+#[test]
+fn test_ed_plus_block_credit_session_minus_1_purchase_fails() {
+    ExtBuilder::default()
+        .with_balances(vec![
+            // Alice gets 10k extra tokens for her mapping deposit
+            (AccountId::from(ALICE), 210_000 * UNIT),
+            (AccountId::from(BOB), 100_000 * UNIT),
+        ])
+        .with_collators(vec![
+            (AccountId::from(ALICE), 210 * UNIT),
+            (AccountId::from(BOB), 100 * UNIT),
+        ])
+        .build()
+        .execute_with(|| {
+            assert_ok!(ContainerRegistrar::register(
+                origin_of(ALICE.into()),
+                1001.into(),
+                empty_genesis_data()
+            ));
+
+            // TODO: uncomment when we add DataPreservers
+            // set_dummy_boot_node(origin_of(ALICE.into()), 1001.into());
+
+            assert_ok!(ContainerRegistrar::mark_valid_for_collating(
+                root_origin(),
+                1001.into()
+            ));
+            // Need to reset credits to 0 because now parachains are given free credits on register
+            assert_ok!(ServicesPayment::set_block_production_credits(
+                root_origin(),
+                1001.into(),
+                0
+            ));
+            let credits_1001 =
+                block_credits_to_required_balance(crate::EpochDurationInBlocks::get(), 1001.into())
+                    + crate::EXISTENTIAL_DEPOSIT
+                    - 1;
+
+            // Fill the tank
+            assert_ok!(ServicesPayment::purchase_credits(
+                origin_of(ALICE.into()),
+                1001.into(),
+                credits_1001
+            ));
+
+            // Assignment should happen after 2 sessions
+            run_to_session(1u32);
+            let assignment = TanssiCollatorAssignment::collator_container_chain();
+            assert!(assignment.container_chains.is_empty());
+            run_to_session(2u32);
+            // Charlie and Dave should not be assigned to para 1001
+            let assignment = TanssiCollatorAssignment::collator_container_chain();
+            assert_eq!(assignment.container_chains.get(&1001u32.into()), None,);
+        });
+}
+
+#[test]
+fn test_reassignment_ed_plus_two_block_credit_session_purchase_works() {
+    ExtBuilder::default()
+        .with_balances(vec![
+            // Alice gets 10k extra tokens for her mapping deposit
+            (AccountId::from(ALICE), 210_000 * UNIT),
+            (AccountId::from(BOB), 100_000 * UNIT),
+        ])
+        .with_collators(vec![
+            (AccountId::from(ALICE), 210 * UNIT),
+            (AccountId::from(BOB), 100 * UNIT),
+        ])
+        .build()
+        .execute_with(|| {
+            assert_ok!(ContainerRegistrar::register(
+                origin_of(ALICE.into()),
+                1001.into(),
+                empty_genesis_data()
+            ));
+
+            // TODO: uncomment when we add DataPreservers
+            // set_dummy_boot_node(origin_of(ALICE.into()), 1001.into());
+
+            assert_ok!(ContainerRegistrar::mark_valid_for_collating(
+                root_origin(),
+                1001.into()
+            ));
+            // Need to reset credits to 0 because now parachains are given free credits on register
+            assert_ok!(ServicesPayment::set_block_production_credits(
+                root_origin(),
+                1001.into(),
+                0
+            ));
+            // On reassignment the blocks credits needed should be enough for the current session and the next one
+            let credits_1001 = block_credits_to_required_balance(
+                crate::EpochDurationInBlocks::get() * 2,
+                1001.into(),
+            ) + crate::EXISTENTIAL_DEPOSIT;
+
+            // Fill the tank
+            assert_ok!(ServicesPayment::purchase_credits(
+                origin_of(ALICE.into()),
+                1001.into(),
+                credits_1001
+            ));
+
+            // Assignment should happen after 2 sessions
+            run_to_session(1u32);
+            let assignment = TanssiCollatorAssignment::collator_container_chain();
+            assert!(assignment.container_chains.is_empty());
+
+            run_to_session(2u32);
+            // Alice and Bob should be assigned to para 1001
+            let assignment = TanssiCollatorAssignment::collator_container_chain();
+            assert_eq!(
+                assignment.container_chains[&1001u32.into()],
+                vec![ALICE.into(), BOB.into()]
+            );
+
+            // Simulate block inclusion from container chain 1001
+            let mut sproof: ParaHeaderSproofBuilder = ParaHeaderSproofBuilder::default();
+            let slot: u64 = 5;
+            let s = ParaHeaderSproofBuilderItem {
+                para_id: 1001.into(),
+                author_id: HeaderAs::NonEncoded(sp_runtime::generic::Header::<u32, BlakeTwo256> {
+                    parent_hash: Default::default(),
+                    number: 1,
+                    state_root: Default::default(),
+                    extrinsics_root: Default::default(),
+                    digest: sp_runtime::generic::Digest {
+                        logs: vec![DigestItem::PreRuntime(AURA_ENGINE_ID, slot.encode())],
+                    },
+                }),
+            };
+
+            sproof.items.push(s);
+            set_author_noting_inherent_data(sproof);
+
+            run_block();
+
+            // Session 3 should still be assigned
+            run_to_session(3u32);
+            // Alice and Bob should be assigned to para 1001
+            let assignment = TanssiCollatorAssignment::collator_container_chain();
+            assert_eq!(
+                assignment.container_chains[&1001u32.into()],
+                vec![ALICE.into(), BOB.into()]
+            );
+
+            // After this it should not be assigned anymore, since credits are not payable
+            run_to_session(4u32);
+
+            // Nobody should be assigned to para 1001
+            let assignment = TanssiCollatorAssignment::collator_container_chain();
+            assert_eq!(assignment.container_chains.get(&1001u32.into()), None,);
+        });
+}
+
+#[test]
+fn test_reassignment_ed_plus_two_block_credit_session_minus_1_purchase_fails() {
+    ExtBuilder::default()
+        .with_balances(vec![
+            // Alice gets 10k extra tokens for her mapping deposit
+            (AccountId::from(ALICE), 210_000 * UNIT),
+            (AccountId::from(BOB), 100_000 * UNIT),
+        ])
+        .with_collators(vec![
+            (AccountId::from(ALICE), 210 * UNIT),
+            (AccountId::from(BOB), 100 * UNIT),
+        ])
+        .build()
+        .execute_with(|| {
+            assert_ok!(ContainerRegistrar::register(
+                origin_of(ALICE.into()),
+                1001.into(),
+                empty_genesis_data()
+            ));
+
+            // TODO: uncomment when we add DataPreservers
+            // set_dummy_boot_node(origin_of(ALICE.into()), 1001.into());
+
+            assert_ok!(ContainerRegistrar::mark_valid_for_collating(
+                root_origin(),
+                1001.into()
+            ));
+            // Need to reset credits to 0 because now parachains are given free credits on register
+            assert_ok!(ServicesPayment::set_block_production_credits(
+                root_origin(),
+                1001.into(),
+                0
+            ));
+            let credits_1001 = block_credits_to_required_balance(
+                crate::EpochDurationInBlocks::get() * 2,
+                1001.into(),
+            ) + crate::EXISTENTIAL_DEPOSIT
+                - 1;
+
+            // Fill the tank
+            assert_ok!(ServicesPayment::purchase_credits(
+                origin_of(ALICE.into()),
+                1001.into(),
+                credits_1001
+            ));
+
+            // Assignment should happen after 2 sessions
+            run_to_session(1u32);
+            let assignment = TanssiCollatorAssignment::collator_container_chain();
+            assert!(assignment.container_chains.is_empty());
+
+            run_to_session(2u32);
+            // Charlie and Dave should be assigned to para 1001
+            let assignment = TanssiCollatorAssignment::collator_container_chain();
+            assert_eq!(
+                assignment.container_chains[&1001u32.into()],
+                vec![ALICE.into(), BOB.into()]
+            );
+
+            // Simulate block inclusion from container chain 1001
+            let mut sproof: ParaHeaderSproofBuilder = ParaHeaderSproofBuilder::default();
+            let slot: u64 = 5;
+            let s = ParaHeaderSproofBuilderItem {
+                para_id: 1001.into(),
+                author_id: HeaderAs::NonEncoded(sp_runtime::generic::Header::<u32, BlakeTwo256> {
+                    parent_hash: Default::default(),
+                    number: 1,
+                    state_root: Default::default(),
+                    extrinsics_root: Default::default(),
+                    digest: sp_runtime::generic::Digest {
+                        logs: vec![DigestItem::PreRuntime(AURA_ENGINE_ID, slot.encode())],
+                    },
+                }),
+            };
+
+            sproof.items.push(s);
+            set_author_noting_inherent_data(sproof);
+
+            run_block();
+
+            // After this it should not be assigned anymore, since credits are not payable
+            run_to_session(3u32);
+            // Nobody should be assigned to para 1001
+            let assignment = TanssiCollatorAssignment::collator_container_chain();
+            assert_eq!(assignment.container_chains.get(&1001u32.into()), None,);
+        });
+}
+
+#[test]
+fn test_credits_with_purchase_can_be_combined() {
+    ExtBuilder::default()
+        .with_balances(vec![
+            // Alice gets 10k extra tokens for her mapping deposit
+            (AccountId::from(ALICE), 210_000 * UNIT),
+            (AccountId::from(BOB), 100_000 * UNIT),
+        ])
+        .with_collators(vec![
+            (AccountId::from(ALICE), 210 * UNIT),
+            (AccountId::from(BOB), 100 * UNIT),
+        ])
+        .build()
+        .execute_with(|| {
+            assert_ok!(ContainerRegistrar::register(
+                origin_of(ALICE.into()),
+                1001.into(),
+                empty_genesis_data()
+            ));
+
+            // TODO: uncomment when we add DataPreservers
+            // set_dummy_boot_node(origin_of(ALICE.into()), 1001.into());
+
+            assert_ok!(ContainerRegistrar::mark_valid_for_collating(
+                root_origin(),
+                1001.into()
+            ));
+            // Set 1 session of free credits and purchase 1 session of credits
+            assert_ok!(ServicesPayment::set_block_production_credits(
+                root_origin(),
+                1001.into(),
+                crate::EpochDurationInBlocks::get()
+            ));
+            let credits_1001 =
+                block_credits_to_required_balance(crate::EpochDurationInBlocks::get(), 1001.into())
+                    + crate::EXISTENTIAL_DEPOSIT;
+
+            // Fill the tank
+            assert_ok!(ServicesPayment::purchase_credits(
+                origin_of(ALICE.into()),
+                1001.into(),
+                credits_1001
+            ));
+
+            // Assignment should happen after 2 sessions
+            run_to_session(1u32);
+            let assignment = TanssiCollatorAssignment::collator_container_chain();
+            assert!(assignment.container_chains.is_empty());
+            run_to_session(2u32);
+            // Alice and Bob should be assigned to para 1001
+            let assignment = TanssiCollatorAssignment::collator_container_chain();
+            assert_eq!(
+                assignment.container_chains[&1001u32.into()],
+                vec![ALICE.into(), BOB.into()]
+            );
+        });
+}
+
+#[test]
+fn test_ed_plus_collator_assignment_session_purchase_works() {
+    ExtBuilder::default()
+        .with_balances(vec![
+            // Alice gets 10k extra tokens for her mapping deposit
+            (AccountId::from(ALICE), 210_000 * UNIT),
+            (AccountId::from(BOB), 100_000 * UNIT),
+        ])
+        .with_collators(vec![
+            (AccountId::from(ALICE), 210 * UNIT),
+            (AccountId::from(BOB), 100 * UNIT),
+        ])
+        .build()
+        .execute_with(|| {
+            assert_ok!(ContainerRegistrar::register(
+                origin_of(ALICE.into()),
+                1001.into(),
+                empty_genesis_data()
+            ));
+
+            // TODO: uncomment when we add DataPreservers
+            // set_dummy_boot_node(origin_of(ALICE.into()), 1001.into());
+
+            assert_ok!(ContainerRegistrar::mark_valid_for_collating(
+                root_origin(),
+                1001.into()
+            ));
+            // Need to reset credits to 0 because now parachains are given free credits on register
+            assert_ok!(ServicesPayment::set_collator_assignment_credits(
+                root_origin(),
+                1001.into(),
+                0
+            ));
+            let credits_1001 = collator_assignment_credits_to_required_balance(1, 1001.into())
+                + crate::EXISTENTIAL_DEPOSIT;
+
+            // Fill the tank
+            assert_ok!(ServicesPayment::purchase_credits(
+                origin_of(ALICE.into()),
+                1001.into(),
+                credits_1001
+            ));
+
+            // Assignment should happen after 2 sessions
+            run_to_session(1u32);
+            let assignment = TanssiCollatorAssignment::collator_container_chain();
+            assert!(assignment.container_chains.is_empty());
+            run_to_session(2u32);
+            // Charlie and Dave should be assigned to para 1001
+            let assignment = TanssiCollatorAssignment::collator_container_chain();
+            assert_eq!(
+                assignment.container_chains[&1001u32.into()],
+                vec![ALICE.into(), BOB.into()]
+            );
+
+            // Simulate block inclusion from container chain 1001
+            let mut sproof: ParaHeaderSproofBuilder = ParaHeaderSproofBuilder::default();
+            let slot: u64 = 5;
+            let s = ParaHeaderSproofBuilderItem {
+                para_id: 1001.into(),
+                author_id: HeaderAs::NonEncoded(sp_runtime::generic::Header::<u32, BlakeTwo256> {
+                    parent_hash: Default::default(),
+                    number: 1,
+                    state_root: Default::default(),
+                    extrinsics_root: Default::default(),
+                    digest: sp_runtime::generic::Digest {
+                        logs: vec![DigestItem::PreRuntime(AURA_ENGINE_ID, slot.encode())],
+                    },
+                }),
+            };
+            sproof.items.push(s);
+            set_author_noting_inherent_data(sproof);
+
+            run_block();
+
+            // After this it should not be assigned anymore, since credits are not payable
+            run_to_session(4u32);
+            // Nobody should be assigned to para 1001
+            let assignment = TanssiCollatorAssignment::collator_container_chain();
+            assert_eq!(assignment.container_chains.get(&1001u32.into()), None,);
+        });
+}
+
+#[test]
+fn test_ed_plus_collator_assignment_credit_session_minus_1_purchase_fails() {
+    ExtBuilder::default()
+        .with_balances(vec![
+            // Alice gets 10k extra tokens for her mapping deposit
+            (AccountId::from(ALICE), 210_000 * UNIT),
+            (AccountId::from(BOB), 100_000 * UNIT),
+        ])
+        .with_collators(vec![
+            (AccountId::from(ALICE), 210 * UNIT),
+            (AccountId::from(BOB), 100 * UNIT),
+        ])
+        .build()
+        .execute_with(|| {
+            assert_ok!(ContainerRegistrar::register(
+                origin_of(ALICE.into()),
+                1001.into(),
+                empty_genesis_data()
+            ));
+
+            // TODO: uncomment when we add DataPreservers
+            // set_dummy_boot_node(origin_of(ALICE.into()), 1001.into());
+
+            assert_ok!(ContainerRegistrar::mark_valid_for_collating(
+                root_origin(),
+                1001.into()
+            ));
+            // Need to reset credits to 0 because now parachains are given free credits on register
+            assert_ok!(ServicesPayment::set_collator_assignment_credits(
+                root_origin(),
+                1001.into(),
+                0
+            ));
+            let credits_1001 = collator_assignment_credits_to_required_balance(1, 1001.into())
+                + crate::EXISTENTIAL_DEPOSIT
+                - 1;
+
+            // Fill the tank
+            assert_ok!(ServicesPayment::purchase_credits(
+                origin_of(ALICE.into()),
+                1001.into(),
+                credits_1001
+            ));
+
+            // Assignment should happen after 2 sessions
+            run_to_session(1u32);
+            let assignment = TanssiCollatorAssignment::collator_container_chain();
+            assert!(assignment.container_chains.is_empty());
+            run_to_session(2u32);
+            // Charlie and Dave should not be assigned to para 1001
+            let assignment = TanssiCollatorAssignment::collator_container_chain();
+            assert_eq!(assignment.container_chains.get(&1001u32.into()), None,);
+        });
+}
+
+#[test]
+fn test_collator_assignment_credits_with_purchase_can_be_combined() {
+    ExtBuilder::default()
+        .with_balances(vec![
+            // Alice gets 10k extra tokens for her mapping deposit
+            (AccountId::from(ALICE), 210_000 * UNIT),
+            (AccountId::from(BOB), 100_000 * UNIT),
+        ])
+        .with_collators(vec![
+            (AccountId::from(ALICE), 210 * UNIT),
+            (AccountId::from(BOB), 100 * UNIT),
+        ])
+        .build()
+        .execute_with(|| {
+            assert_ok!(ContainerRegistrar::register(
+                origin_of(ALICE.into()),
+                1001.into(),
+                empty_genesis_data()
+            ));
+
+            // TODO: uncomment when we add DataPreservers
+            // set_dummy_boot_node(origin_of(ALICE.into()), 1001.into());
+
+            assert_ok!(ContainerRegistrar::mark_valid_for_collating(
+                root_origin(),
+                1001.into()
+            ));
+
+            // We assign one session to free credits
+            assert_ok!(ServicesPayment::set_collator_assignment_credits(
+                root_origin(),
+                1001.into(),
+                1
+            ));
+            // We buy another session through the tank
+            let credits_1001 = collator_assignment_credits_to_required_balance(1, 1001.into())
+                + crate::EXISTENTIAL_DEPOSIT;
+
+            // Fill the tank
+            assert_ok!(ServicesPayment::purchase_credits(
+                origin_of(ALICE.into()),
+                1001.into(),
+                credits_1001
+            ));
+
+            // Assignment should happen after 2 sessions
+            run_to_session(1u32);
+            let assignment = TanssiCollatorAssignment::collator_container_chain();
+            assert!(assignment.container_chains.is_empty());
+            run_to_session(2u32);
+            // Alice and Bob should be assigned to para 1001
+            let assignment = TanssiCollatorAssignment::collator_container_chain();
+            assert_eq!(
+                assignment.container_chains[&1001u32.into()],
+                vec![ALICE.into(), BOB.into()]
+            );
+        });
+}
+
+#[test]
+fn test_block_credits_and_collator_assignation_credits_through_tank() {
+    ExtBuilder::default()
+        .with_balances(vec![
+            // Alice gets 10k extra tokens for her mapping deposit
+            (AccountId::from(ALICE), 210_000 * UNIT),
+            (AccountId::from(BOB), 100_000 * UNIT),
+        ])
+        .with_collators(vec![
+            (AccountId::from(ALICE), 210 * UNIT),
+            (AccountId::from(BOB), 100 * UNIT),
+        ])
+        .build()
+        .execute_with(|| {
+            assert_ok!(ContainerRegistrar::register(
+                origin_of(ALICE.into()),
+                1001.into(),
+                empty_genesis_data()
+            ));
+
+            // TODO: uncomment when we add DataPreservers
+            // set_dummy_boot_node(origin_of(ALICE.into()), 1001.into());
+            assert_ok!(ContainerRegistrar::mark_valid_for_collating(
+                root_origin(),
+                1001.into()
+            ));
+
+            // We make all free credits 0
+            assert_ok!(ServicesPayment::set_collator_assignment_credits(
+                root_origin(),
+                1001.into(),
+                0
+            ));
+            assert_ok!(ServicesPayment::set_block_production_credits(
+                root_origin(),
+                1001.into(),
+                0
+            ));
+
+            // We buy 2 sessions through tank
+            let collator_assignation_credits =
+                collator_assignment_credits_to_required_balance(2, 1001.into());
+            let block_production_credits = block_credits_to_required_balance(
+                crate::EpochDurationInBlocks::get() * 2,
+                1001.into(),
+            );
+
+            // Fill the tank
+            assert_ok!(ServicesPayment::purchase_credits(
+                origin_of(ALICE.into()),
+                1001.into(),
+                collator_assignation_credits
+                    + block_production_credits
+                    + crate::EXISTENTIAL_DEPOSIT
+            ));
+
+            // Assignment should happen after 2 sessions
+            run_to_session(1u32);
+            let assignment = TanssiCollatorAssignment::collator_container_chain();
+            assert!(assignment.container_chains.is_empty());
+            run_to_session(2u32);
+            // Alice and Bob should be assigned to para 1001
+            let assignment = TanssiCollatorAssignment::collator_container_chain();
+            assert_eq!(
+                assignment.container_chains[&1001u32.into()],
+                vec![ALICE.into(), BOB.into()]
+            );
+
+            // After this it should not be assigned anymore, since credits are not payable
+            run_to_session(4u32);
+            // Nobody should be assigned to para 1001
+            let assignment = TanssiCollatorAssignment::collator_container_chain();
+            assert_eq!(assignment.container_chains.get(&1001u32.into()), None,);
+        });
+}
+
+#[test]
+fn test_collator_assignment_tip_priority_on_congestion() {
+    ExtBuilder::default()
+        .with_balances(vec![
+            (AccountId::from(ALICE), 210_000 * UNIT),
+            (AccountId::from(BOB), 100_000 * UNIT),
+        ])
+        .with_collators(vec![
+            (AccountId::from(ALICE), 210 * UNIT),
+            (AccountId::from(BOB), 100 * UNIT),
+        ])
+        .with_empty_parachains(vec![1001, 1002, 1003])
+        .build()
+        .execute_with(|| {
+            let para_id = 1003u32;
+            let tank_funds = 100 * UNIT;
+            let max_tip = 1 * UNIT;
+
+            assert_eq!(
+                TanssiCollatorAssignment::collator_container_chain().container_chains
+                    [&1003u32.into()]
+                    .len(),
+                0
+            );
+
+            // Send funds to tank
+            assert_ok!(ServicesPayment::purchase_credits(
+                origin_of(ALICE.into()),
+                para_id.into(),
+                tank_funds,
+            ));
+
+            // Set tip for 1003
+            assert_ok!(ServicesPayment::set_max_tip(
+                root_origin(),
+                para_id.into(),
+                Some(max_tip),
+            ));
+
+            run_to_session(2);
+            assert_eq!(
+                TanssiCollatorAssignment::collator_container_chain().container_chains
+                    [&para_id.into()]
+                    .len(),
+                2,
+            );
+        });
+}
+
+#[test]
+fn test_collator_assignment_tip_charged_on_congestion() {
+    ExtBuilder::default()
+        .with_balances(vec![
+            (AccountId::from(ALICE), 210_000 * UNIT),
+            (AccountId::from(BOB), 100_000 * UNIT),
+        ])
+        .with_collators(vec![
+            (AccountId::from(ALICE), 210 * UNIT),
+            (AccountId::from(BOB), 100 * UNIT),
+        ])
+        .with_empty_parachains(vec![1001, 1002, 1003])
+        .build()
+        .execute_with(|| {
+            let tank_funds = 100 * UNIT;
+            let max_tip = 1 * UNIT;
+            let para_id = 1003u32;
+
+            // Send funds to tank
+            assert_ok!(ServicesPayment::purchase_credits(
+                origin_of(ALICE.into()),
+                para_id.into(),
+                tank_funds,
+            ));
+
+            // Set tip for para_id
+            assert_ok!(ServicesPayment::set_max_tip(
+                root_origin(),
+                para_id.into(),
+                Some(max_tip),
+            ));
+
+            run_to_session(1);
+            assert_eq!(
+                Balances::usable_balance(ServicesPayment::parachain_tank(para_id.into())),
+                tank_funds - max_tip,
+            );
+        });
+}
+
+#[test]
+fn test_collator_assignment_tip_not_assigned_on_insufficient_balance() {
+    ExtBuilder::default()
+        .with_balances(vec![
+            (AccountId::from(ALICE), 210_000 * UNIT),
+            (AccountId::from(BOB), 100_000 * UNIT),
+        ])
+        .with_collators(vec![
+            (AccountId::from(ALICE), 210 * UNIT),
+            (AccountId::from(BOB), 100 * UNIT),
+        ])
+        .with_empty_parachains(vec![1001, 1002, 1003])
+        .build()
+        .execute_with(|| {
+            let tank_funds = 1 * UNIT;
+            let max_tip = 1 * UNIT;
+            let para_id = 1003u32;
+
+            // Send insufficient funds to tank for tip for 2 sessions
+            assert_ok!(ServicesPayment::purchase_credits(
+                origin_of(ALICE.into()),
+                para_id.into(),
+                tank_funds,
+            ));
+
+            // Set tip for para_id
+            assert_ok!(ServicesPayment::set_max_tip(
+                root_origin(),
+                para_id.into(),
+                Some(max_tip),
+            ));
+
+            run_to_session(1);
+            assert_eq!(
+                TanssiCollatorAssignment::collator_container_chain().container_chains
+                    [&para_id.into()]
+                    .len(),
+                0
+            );
+        });
+}
+
+#[test]
+fn test_collator_assignment_tip_only_charge_willing_paras() {
+    ExtBuilder::default()
+        .with_balances(vec![
+            (AccountId::from(ALICE), 210_000 * UNIT),
+            (AccountId::from(BOB), 100_000 * UNIT),
+            (AccountId::from(CHARLIE), 100_000 * UNIT),
+            (AccountId::from(DAVE), 100_000 * UNIT),
+        ])
+        .with_collators(vec![
+            (AccountId::from(ALICE), 210 * UNIT),
+            (AccountId::from(BOB), 100 * UNIT),
+            (AccountId::from(CHARLIE), 100 * UNIT),
+            (AccountId::from(DAVE), 100 * UNIT),
+        ])
+        .with_empty_parachains(vec![1001, 1002, 1003])
+        .build()
+        .execute_with(|| {
+            let tank_funds = 100 * UNIT;
+            let max_tip = 1 * UNIT;
+            let para_id_with_tip = 1003u32;
+            let para_id_without_tip = 1001u32;
+
+            // Send funds to tank to both paras
+            assert_ok!(ServicesPayment::purchase_credits(
+                origin_of(ALICE.into()),
+                para_id_with_tip.into(),
+                tank_funds,
+            ));
+            assert_ok!(ServicesPayment::purchase_credits(
+                origin_of(ALICE.into()),
+                para_id_without_tip.into(),
+                tank_funds,
+            ));
+
+            assert_eq!(
+                Balances::usable_balance(ServicesPayment::parachain_tank(
+                    para_id_without_tip.into()
+                )),
+                tank_funds,
+            );
+
+            // Only set tip for 1003
+            assert_ok!(ServicesPayment::set_max_tip(
+                root_origin(),
+                para_id_with_tip.into(),
+                Some(max_tip),
+            ));
+
+            run_to_session(2);
+
+            let assignment = TanssiCollatorAssignment::collator_container_chain().container_chains;
+
+            // 2 out of the 3 paras should have collators assigned, with one paying tip to get
+            // prioritized, and the other selected at random that should not be charged any tips
+            assert_eq!(assignment[&para_id_with_tip.into()].len(), 2);
+            assert_eq!(
+                Balances::usable_balance(ServicesPayment::parachain_tank(para_id_with_tip.into())),
+                tank_funds - max_tip * 2,
+            );
+
+            assert_eq!(assignment[&para_id_without_tip.into()].len(), 2);
+            assert_eq!(
+                Balances::usable_balance(ServicesPayment::parachain_tank(
+                    para_id_without_tip.into()
+                )),
+                tank_funds,
+            );
+        });
+}
+
+#[test]
+fn test_collator_assignment_tip_withdraw_min_tip() {
+    ExtBuilder::default()
+        .with_balances(vec![
+            (AccountId::from(ALICE), 210_000 * UNIT),
+            (AccountId::from(BOB), 100_000 * UNIT),
+            (AccountId::from(CHARLIE), 100_000 * UNIT),
+            (AccountId::from(DAVE), 100_000 * UNIT),
+        ])
+        .with_collators(vec![
+            (AccountId::from(ALICE), 210 * UNIT),
+            (AccountId::from(BOB), 100 * UNIT),
+            (AccountId::from(CHARLIE), 100 * UNIT),
+            (AccountId::from(DAVE), 100 * UNIT),
+        ])
+        .with_empty_parachains(vec![1001, 1002, 1003])
+        .build()
+        .execute_with(|| {
+            let tank_funds = 100 * UNIT;
+            let max_tip_1003 = 3 * UNIT;
+            let max_tip_1002 = 2 * UNIT;
+            let para_id_1003 = 1003u32;
+            let para_id_1002 = 1002u32;
+
+            // Send funds to tank to both paras
+            assert_ok!(ServicesPayment::purchase_credits(
+                origin_of(ALICE.into()),
+                para_id_1003.into(),
+                tank_funds,
+            ));
+            assert_ok!(ServicesPayment::purchase_credits(
+                origin_of(ALICE.into()),
+                para_id_1002.into(),
+                tank_funds,
+            ));
+
+            // Set tips
+            assert_ok!(ServicesPayment::set_max_tip(
+                root_origin(),
+                para_id_1003.into(),
+                Some(max_tip_1003),
+            ));
+            assert_ok!(ServicesPayment::set_max_tip(
+                root_origin(),
+                para_id_1002.into(),
+                Some(max_tip_1002),
+            ));
+
+            run_to_session(2);
+
+            assert_eq!(
+                TanssiCollatorAssignment::collator_container_chain().container_chains
+                    [&para_id_1003.into()]
+                    .len(),
+                2
+            );
+            assert_eq!(
+                TanssiCollatorAssignment::collator_container_chain().container_chains
+                    [&para_id_1002.into()]
+                    .len(),
+                2
+            );
+
+            // Should have withdrawn the lowest tip from both paras
+            assert_eq!(
+                Balances::usable_balance(ServicesPayment::parachain_tank(para_id_1003.into())),
+                tank_funds - max_tip_1002 * 2,
+            );
+
+            assert_eq!(
+                Balances::usable_balance(ServicesPayment::parachain_tank(para_id_1002.into())),
+                tank_funds - max_tip_1002 * 2,
             );
         });
 }

--- a/solo-chains/runtime/starlight/src/tests/collator_assignment_tests.rs
+++ b/solo-chains/runtime/starlight/src/tests/collator_assignment_tests.rs
@@ -859,7 +859,7 @@ fn test_paras_registered_but_only_credits_for_1_session() {
             let assignment = TanssiCollatorAssignment::collator_container_chain();
             assert!(assignment.container_chains.is_empty());
             run_to_session(2u32);
-            // Charlie and Dave should be assigned to para 1001
+            // Alice and Bob should be assigned to para 1001
             let assignment = TanssiCollatorAssignment::collator_container_chain();
             assert_eq!(
                 assignment.container_chains[&1001u32.into()],
@@ -1069,7 +1069,7 @@ fn test_ed_plus_block_credit_session_purchase_works() {
             let assignment = TanssiCollatorAssignment::collator_container_chain();
             assert!(assignment.container_chains.is_empty());
             run_to_session(2u32);
-            // Charlie and Dave should be assigned to para 1001
+            // Alice and Bob should be assigned to para 1001
             let assignment = TanssiCollatorAssignment::collator_container_chain();
             assert_eq!(
                 assignment.container_chains[&1001u32.into()],
@@ -1155,7 +1155,7 @@ fn test_ed_plus_block_credit_session_minus_1_purchase_fails() {
             let assignment = TanssiCollatorAssignment::collator_container_chain();
             assert!(assignment.container_chains.is_empty());
             run_to_session(2u32);
-            // Charlie and Dave should not be assigned to para 1001
+            // Alice and Bob should not be assigned to para 1001
             let assignment = TanssiCollatorAssignment::collator_container_chain();
             assert_eq!(assignment.container_chains.get(&1001u32.into()), None,);
         });
@@ -1311,7 +1311,7 @@ fn test_reassignment_ed_plus_two_block_credit_session_minus_1_purchase_fails() {
             assert!(assignment.container_chains.is_empty());
 
             run_to_session(2u32);
-            // Charlie and Dave should be assigned to para 1001
+            // Alice and Bob should be assigned to para 1001
             let assignment = TanssiCollatorAssignment::collator_container_chain();
             assert_eq!(
                 assignment.container_chains[&1001u32.into()],
@@ -1453,7 +1453,7 @@ fn test_ed_plus_collator_assignment_session_purchase_works() {
             let assignment = TanssiCollatorAssignment::collator_container_chain();
             assert!(assignment.container_chains.is_empty());
             run_to_session(2u32);
-            // Charlie and Dave should be assigned to para 1001
+            // Alice and Bob should be assigned to para 1001
             let assignment = TanssiCollatorAssignment::collator_container_chain();
             assert_eq!(
                 assignment.container_chains[&1001u32.into()],
@@ -1537,7 +1537,7 @@ fn test_ed_plus_collator_assignment_credit_session_minus_1_purchase_fails() {
             let assignment = TanssiCollatorAssignment::collator_container_chain();
             assert!(assignment.container_chains.is_empty());
             run_to_session(2u32);
-            // Charlie and Dave should not be assigned to para 1001
+            // Alice and Bob should not be assigned to para 1001
             let assignment = TanssiCollatorAssignment::collator_container_chain();
             assert_eq!(assignment.container_chains.get(&1001u32.into()), None,);
         });

--- a/solo-chains/runtime/starlight/src/tests/common/mod.rs
+++ b/solo-chains/runtime/starlight/src/tests/common/mod.rs
@@ -445,24 +445,6 @@ impl ExtBuilder {
         .assimilate_storage(&mut t)
         .unwrap();
 
-        pallet_services_payment::GenesisConfig::<Runtime> {
-            para_id_credits: self
-                .para_ids
-                .clone()
-                .into_iter()
-                .map(|registered_para| {
-                    (
-                        registered_para.para_id.into(),
-                        registered_para.block_production_credits,
-                        registered_para.collator_assignment_credits,
-                    )
-                        .into()
-                })
-                .collect(),
-        }
-        .assimilate_storage(&mut t)
-        .unwrap();
-
         runtime_common::paras_registrar::GenesisConfig::<Runtime> {
             next_free_para_id: self.next_free_para_id,
             ..Default::default()

--- a/solo-chains/runtime/starlight/src/tests/common/mod.rs
+++ b/solo-chains/runtime/starlight/src/tests/common/mod.rs
@@ -395,7 +395,7 @@ impl ExtBuilder {
                     )
                 })
                 .collect(),
-            phantom: Default::default(),
+            ..Default::default()
         }
         .assimilate_storage(&mut t)
         .unwrap();

--- a/solo-chains/runtime/starlight/src/tests/mod.rs
+++ b/solo-chains/runtime/starlight/src/tests/mod.rs
@@ -27,6 +27,7 @@ mod core_scheduling_tests;
 mod integration_test;
 mod relay_configuration;
 mod relay_registrar;
+mod services_payment;
 mod session_keys;
 mod sudo;
 

--- a/solo-chains/runtime/starlight/src/tests/services_payment.rs
+++ b/solo-chains/runtime/starlight/src/tests/services_payment.rs
@@ -1,0 +1,143 @@
+// Copyright (C) Moondance Labs Ltd.
+// This file is part of Tanssi.
+
+// Tanssi is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Tanssi is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Tanssi.  If not, see <http://www.gnu.org/licenses/>
+
+#![cfg(test)]
+
+use {
+    crate::tests::common::*,
+    crate::{ContainerRegistrar, ServicesPayment},
+    cumulus_primitives_core::ParaId,
+    frame_support::assert_ok,
+    sp_std::vec,
+};
+
+#[test]
+fn test_can_buy_credits_before_registering_para() {
+    ExtBuilder::default()
+        .with_balances(vec![
+            // Alice gets 10k extra tokens for her mapping deposit
+            (AccountId::from(ALICE), 210_000 * UNIT),
+            (AccountId::from(BOB), 100_000 * UNIT),
+            (AccountId::from(CHARLIE), 100_000 * UNIT),
+            (AccountId::from(DAVE), 100_000 * UNIT),
+        ])
+        .with_collators(vec![
+            (AccountId::from(ALICE), 210 * UNIT),
+            (AccountId::from(BOB), 100 * UNIT),
+            (AccountId::from(CHARLIE), 100 * UNIT),
+            (AccountId::from(DAVE), 100 * UNIT),
+        ])
+        .build()
+        .execute_with(|| {
+            run_to_block(2);
+
+            // Try to buy the maximum amount of credits
+            let balance_before = System::account(AccountId::from(ALICE)).data.free;
+            assert_ok!(ServicesPayment::purchase_credits(
+                origin_of(ALICE.into()),
+                1001.into(),
+                block_credits_to_required_balance(u32::MAX, 1001.into())
+            ));
+            let balance_after = System::account(AccountId::from(ALICE)).data.free;
+
+            // Now parachain tank should have this amount
+            let balance_tank = System::account(ServicesPayment::parachain_tank(1001.into()))
+                .data
+                .free;
+
+            assert_eq!(
+                balance_tank,
+                block_credits_to_required_balance(u32::MAX, 1001.into())
+            );
+
+            let expected_cost = block_credits_to_required_balance(u32::MAX, 1001.into());
+            assert_eq!(balance_before - balance_after, expected_cost);
+        });
+}
+
+#[test]
+fn test_can_buy_credits_before_registering_para_and_receive_free_credits() {
+    ExtBuilder::default()
+        .with_balances(vec![
+            // Alice gets 10k extra tokens for her mapping deposit
+            (AccountId::from(ALICE), 210_000 * UNIT),
+            (AccountId::from(BOB), 100_000 * UNIT),
+            (AccountId::from(CHARLIE), 100_000 * UNIT),
+            (AccountId::from(DAVE), 100_000 * UNIT),
+        ])
+        .with_collators(vec![
+            (AccountId::from(ALICE), 210 * UNIT),
+            (AccountId::from(BOB), 100 * UNIT),
+            (AccountId::from(CHARLIE), 100 * UNIT),
+            (AccountId::from(DAVE), 100 * UNIT),
+        ])
+        .build()
+        .execute_with(|| {
+            run_to_block(2);
+
+            // Try to buy (FreeBlockProductionCredits - 1) credits
+            let balance_before = System::account(AccountId::from(ALICE)).data.free;
+            assert_ok!(ServicesPayment::purchase_credits(
+                origin_of(ALICE.into()),
+                1001.into(),
+                block_credits_to_required_balance(
+                    crate::FreeBlockProductionCredits::get() - 1,
+                    1001.into()
+                )
+            ));
+            let balance_after = System::account(AccountId::from(ALICE)).data.free;
+
+            // Now parachain tank should have this amount
+            let balance_tank = System::account(ServicesPayment::parachain_tank(1001.into()))
+                .data
+                .free;
+
+            assert_eq!(
+                balance_tank,
+                block_credits_to_required_balance(
+                    crate::FreeBlockProductionCredits::get() - 1,
+                    1001.into()
+                )
+            );
+
+            let expected_cost = block_credits_to_required_balance(
+                crate::FreeBlockProductionCredits::get() - 1,
+                1001.into(),
+            );
+            assert_eq!(balance_before - balance_after, expected_cost);
+
+            // Now register para
+            assert_ok!(ContainerRegistrar::register(
+                origin_of(ALICE.into()),
+                1001.into(),
+                empty_genesis_data()
+            ));
+
+            // TODO: uncomment when we add DataPreservers
+            // set_dummy_boot_node(origin_of(ALICE.into()), 1001.into());
+
+            assert_ok!(ContainerRegistrar::mark_valid_for_collating(
+                root_origin(),
+                1001.into()
+            ));
+
+            // We received free credits, because we cannot have more than FreeBlockProductionCredits
+            let credits =
+                pallet_services_payment::BlockProductionCredits::<Runtime>::get(ParaId::from(1001))
+                    .unwrap_or_default();
+            assert_eq!(credits, crate::FreeBlockProductionCredits::get());
+        });
+}


### PR DESCRIPTION
Adds `ServicePayment` pallet to Starlight runtime. This also enables service charging on collator assignment, free credits on registration and removal of assignment on insufficient credits.