### PR TITLE
generate the authorize upgrade hash correctly in releases

### DIFF
--- a/test/moonwall.config.json
+++ b/test/moonwall.config.json
@@ -531,7 +531,7 @@
             "testFileDir": ["suites/rt-upgrade-templates-zombienet"],
             "runScripts": [
                 "download-latest-rt-binaries.sh",
-                "build-spec-single-container.sh tmp container-chain-simple-node",
+                "build-spec-single-container.sh tmp container-chain-simple-node flashbox-local",
                 "download-polkadot.sh",
                 "compile-wasm.ts compile -b tmp/tanssi-node -o wasm -c specs/single-container-tanssi-1000.json",
                 "compile-wasm.ts compile -b tmp/container-chain-simple-node -o wasm -c specs/single-container-template-container-2000.json"

--- a/test/moonwall.config.json
+++ b/test/moonwall.config.json
@@ -569,7 +569,7 @@
             "testFileDir": ["suites/rt-upgrade-templates-zombienet"],
             "runScripts": [
                 "download-latest-rt-binaries.sh",
-                "build-spec-single-container.sh tmp container-chain-frontier-node",
+                "build-spec-single-container.sh tmp container-chain-frontier-node flashbox-local",
                 "download-polkadot.sh",
                 "compile-wasm.ts compile -b tmp/tanssi-node -o wasm -c specs/single-container-tanssi-1000.json",
                 "compile-wasm.ts compile -b tmp/container-chain-frontier-node -o wasm -c specs/single-container-template-container-2000.json"

--- a/test/scripts/build-spec-single-container.sh
+++ b/test/scripts/build-spec-single-container.sh
@@ -18,6 +18,12 @@ else
     CONTAINER_BINARY="${2}"
 fi
 
+if [[ -z "${3}" || ${3} == "undefined" ]]; then
+    TANSSI_CHAIN="dancebox-local"
+else
+    TANSSI_CHAIN="${3}"
+fi
+
 mkdir -p specs
 $BINARY_FOLDER/$CONTAINER_BINARY build-spec --disable-default-bootnode --add-bootnode "/ip4/127.0.0.1/tcp/33049/ws/p2p/12D3KooWHVMhQDHBpj9vQmssgyfspYecgV6e3hH1dQVDUkUbCYC9" --parachain-id 2000 --raw > specs/single-container-template-container-2000.json
-$BINARY_FOLDER/tanssi-node build-spec --chain dancebox-local --parachain-id 1000 --add-container-chain specs/single-container-template-container-2000.json --invulnerable "Collator1000-01" --invulnerable "Collator1000-02" --invulnerable "Collator1000-03" --invulnerable "Collator2000-01" --invulnerable "Collator2000-02" --raw > specs/single-container-tanssi-1000.json
+$BINARY_FOLDER/tanssi-node build-spec --chain $TANSSI_CHAIN --parachain-id 1000 --add-container-chain specs/single-container-template-container-2000.json --invulnerable "Collator1000-01" --invulnerable "Collator1000-02" --invulnerable "Collator1000-03" --invulnerable "Collator2000-01" --invulnerable "Collator2000-02" --raw > specs/single-container-tanssi-1000.json

--- a/tools/github/generate-runtimes-body.ts
+++ b/tools/github/generate-runtimes-body.ts
@@ -8,7 +8,7 @@ import { blake2AsHex } from "@polkadot/util-crypto";
 
 const BREAKING_CHANGES_LABEL = "D2-breaksapi";
 const RUNTIME_CHANGES_LABEL = "B7-runtimenoteworthy";
-// `System` is pallet index 1. `authorize_upgrade` is extrinsic index 9.
+// `System` is pallet index 0. `authorize_upgrade` is extrinsic index 9.
 const DANCEBOX_PREFIX_SYSTEM_AUTHORIZE_UPGRADE = "0x0009";
 
 function capitalize(s) {

--- a/tools/github/generate-runtimes-body.ts
+++ b/tools/github/generate-runtimes-body.ts
@@ -8,8 +8,8 @@ import { blake2AsHex } from "@polkadot/util-crypto";
 
 const BREAKING_CHANGES_LABEL = "D2-breaksapi";
 const RUNTIME_CHANGES_LABEL = "B7-runtimenoteworthy";
-// `ParachainSystem` is pallet index 1. `authorize_upgrade` is extrinsic index 2.
-const DANCEBOX_PREFIX_PARACHAINSYSTEM_AUTHORIZE_UPGRADE = "0x0102";
+// `System` is pallet index 1. `authorize_upgrade` is extrinsic index 9.
+const DANCEBOX_PREFIX_SYSTEM_AUTHORIZE_UPGRADE = "0x0009";
 
 function capitalize(s) {
   return s[0].toUpperCase() + s.slice(1);
@@ -46,12 +46,13 @@ function getRuntimeInfo(srtoolReportFolder: string, runtimeName: string) {
 function authorizeUpgradeHash(runtimeName: string, srtool: any): string {
   if (runtimeName == "dancebox") {
     return blake2AsHex(
-      DANCEBOX_PREFIX_PARACHAINSYSTEM_AUTHORIZE_UPGRADE +
+      DANCEBOX_PREFIX_SYSTEM_AUTHORIZE_UPGRADE +
         srtool.runtimes.compressed.blake2_256.substr(2) // remove "0x" prefix
     );
   } else {
+    // it's same index in all of thenm for now
     return blake2AsHex(
-      DANCEBOX_PREFIX_PARACHAINSYSTEM_AUTHORIZE_UPGRADE +
+      DANCEBOX_PREFIX_SYSTEM_AUTHORIZE_UPGRADE +
         srtool.runtimes.compressed.blake2_256.substr(2) // remove "0x" prefix
     );
   }


### PR DESCRIPTION
With the change from ParachainSystem to System for the authorized upgrade extrinsic, we are incorrectly generating the call hash for the extrinsic in the release. this pr fixes it