### PR TITLE
increase timeout for container zombie upgrade tests

### DIFF
--- a/test/moonwall.config.json
+++ b/test/moonwall.config.json
@@ -537,7 +537,7 @@
                 "compile-wasm.ts compile -b tmp/container-chain-simple-node -o wasm -c specs/single-container-template-container-2000.json"
             ],
 
-            "timeout": 600000,
+            "timeout": 900000,
             "foundation": {
                 "rtUpgradePath": "../target/release/wbuild/container-chain-template-simple-runtime/container_chain_template_simple_runtime.compact.compressed.wasm",
                 "type": "zombie",
@@ -575,7 +575,7 @@
                 "compile-wasm.ts compile -b tmp/container-chain-frontier-node -o wasm -c specs/single-container-template-container-2000.json"
             ],
 
-            "timeout": 600000,
+            "timeout": 900000,
             "foundation": {
                 "rtUpgradePath": "../target/release/wbuild/container-chain-template-frontier-runtime/container_chain_template_frontier_runtime.compact.compressed.wasm",
                 "type": "zombie",


### PR DESCRIPTION
Since we are using flashbox as the tanssi chain now, this is a a bit slower than fast-runtime dancebox, but it provides better guarantees with respect to the images we publish in docker.

However we need to increase the timeout as we are seeing the jobs sometime taking a bit longer