### PR TITLE
Update dancekit to change ref to vec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,7 +1375,7 @@ dependencies = [
 [[package]]
 name = "ccp-authorities-noting-inherent"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/dancekit?branch=tanssi-polkadot-stable2407#83c5af140bffb06af6111f5cac7f3075315fa453"
+source = "git+https://github.com/moondance-labs/dancekit?branch=tanssi-polkadot-stable2407#cf501fc2ad446b06256084b75a39bdb3c276eae4"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1403,7 +1403,7 @@ dependencies = [
 [[package]]
 name = "ccp-xcm"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/dancekit?branch=tanssi-polkadot-stable2407#83c5af140bffb06af6111f5cac7f3075315fa453"
+source = "git+https://github.com/moondance-labs/dancekit?branch=tanssi-polkadot-stable2407#cf501fc2ad446b06256084b75a39bdb3c276eae4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3241,7 +3241,7 @@ dependencies = [
 [[package]]
 name = "dc-orchestrator-chain-interface"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/dancekit?branch=tanssi-polkadot-stable2407#83c5af140bffb06af6111f5cac7f3075315fa453"
+source = "git+https://github.com/moondance-labs/dancekit?branch=tanssi-polkadot-stable2407#cf501fc2ad446b06256084b75a39bdb3c276eae4"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3486,7 +3486,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 [[package]]
 name = "dp-chain-state-snapshot"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/dancekit?branch=tanssi-polkadot-stable2407#83c5af140bffb06af6111f5cac7f3075315fa453"
+source = "git+https://github.com/moondance-labs/dancekit?branch=tanssi-polkadot-stable2407#cf501fc2ad446b06256084b75a39bdb3c276eae4"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -3498,7 +3498,7 @@ dependencies = [
 [[package]]
 name = "dp-collator-assignment"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/dancekit?branch=tanssi-polkadot-stable2407#83c5af140bffb06af6111f5cac7f3075315fa453"
+source = "git+https://github.com/moondance-labs/dancekit?branch=tanssi-polkadot-stable2407#cf501fc2ad446b06256084b75a39bdb3c276eae4"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -3518,7 +3518,7 @@ dependencies = [
 [[package]]
 name = "dp-consensus"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/dancekit?branch=tanssi-polkadot-stable2407#83c5af140bffb06af6111f5cac7f3075315fa453"
+source = "git+https://github.com/moondance-labs/dancekit?branch=tanssi-polkadot-stable2407#cf501fc2ad446b06256084b75a39bdb3c276eae4"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -3535,7 +3535,7 @@ dependencies = [
 [[package]]
 name = "dp-container-chain-genesis-data"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/dancekit?branch=tanssi-polkadot-stable2407#83c5af140bffb06af6111f5cac7f3075315fa453"
+source = "git+https://github.com/moondance-labs/dancekit?branch=tanssi-polkadot-stable2407#cf501fc2ad446b06256084b75a39bdb3c276eae4"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -3557,7 +3557,7 @@ dependencies = [
 [[package]]
 name = "dp-core"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/dancekit?branch=tanssi-polkadot-stable2407#83c5af140bffb06af6111f5cac7f3075315fa453"
+source = "git+https://github.com/moondance-labs/dancekit?branch=tanssi-polkadot-stable2407#cf501fc2ad446b06256084b75a39bdb3c276eae4"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -3572,7 +3572,7 @@ dependencies = [
 [[package]]
 name = "dp-impl-tanssi-pallets-config"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/dancekit?branch=tanssi-polkadot-stable2407#83c5af140bffb06af6111f5cac7f3075315fa453"
+source = "git+https://github.com/moondance-labs/dancekit?branch=tanssi-polkadot-stable2407#cf501fc2ad446b06256084b75a39bdb3c276eae4"
 dependencies = [
  "dp-consensus",
  "frame-support",
@@ -3587,7 +3587,7 @@ dependencies = [
 [[package]]
 name = "dp-slot-duration-runtime-api"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/dancekit?branch=tanssi-polkadot-stable2407#83c5af140bffb06af6111f5cac7f3075315fa453"
+source = "git+https://github.com/moondance-labs/dancekit?branch=tanssi-polkadot-stable2407#cf501fc2ad446b06256084b75a39bdb3c276eae4"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -8692,7 +8692,7 @@ dependencies = [
 [[package]]
 name = "pallet-cc-authorities-noting"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/dancekit?branch=tanssi-polkadot-stable2407#83c5af140bffb06af6111f5cac7f3075315fa453"
+source = "git+https://github.com/moondance-labs/dancekit?branch=tanssi-polkadot-stable2407#cf501fc2ad446b06256084b75a39bdb3c276eae4"
 dependencies = [
  "ccp-authorities-noting-inherent",
  "cumulus-pallet-parachain-system",
@@ -10253,7 +10253,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-executor-utils"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/dancekit?branch=tanssi-polkadot-stable2407#83c5af140bffb06af6111f5cac7f3075315fa453"
+source = "git+https://github.com/moondance-labs/dancekit?branch=tanssi-polkadot-stable2407#cf501fc2ad446b06256084b75a39bdb3c276eae4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -17575,7 +17575,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 [[package]]
 name = "test-relay-sproof-builder"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/dancekit?branch=tanssi-polkadot-stable2407#83c5af140bffb06af6111f5cac7f3075315fa453"
+source = "git+https://github.com/moondance-labs/dancekit?branch=tanssi-polkadot-stable2407#cf501fc2ad446b06256084b75a39bdb3c276eae4"
 dependencies = [
  "cumulus-primitives-core",
  "dp-collator-assignment",

--- a/client/orchestrator-chain-rpc-interface/src/lib.rs
+++ b/client/orchestrator-chain-rpc-interface/src/lib.rs
@@ -244,7 +244,7 @@ impl OrchestratorChainInterface for OrchestratorChainRpcClient {
     async fn prove_read(
         &self,
         orchestrator_parent: PHash,
-        relevant_keys: &[Vec<u8>],
+        relevant_keys: &Vec<Vec<u8>>,
     ) -> OrchestratorChainResult<StorageProof> {
         let mut cloned = Vec::new();
         cloned.extend_from_slice(relevant_keys);

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -954,7 +954,7 @@ where
     async fn prove_read(
         &self,
         orchestrator_parent: PHash,
-        relevant_keys: &[Vec<u8>],
+        relevant_keys: &Vec<Vec<u8>>,
     ) -> OrchestratorChainResult<StorageProof> {
         let state_backend = self.backend.state_at(orchestrator_parent)?;
 


### PR DESCRIPTION
https://github.com/moondance-labs/dancekit/pull/31

> I need this to be able to use RelayChainInterface::prove_read to implement OrchestratorChainInterface::prove_read. Using &Vec as input argument is never correct, but we are forced to do it here.
