### PR TITLE
Add force-debug feature to starlight

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16543,6 +16543,7 @@ dependencies = [
  "sp-consensus-beefy",
  "sp-consensus-grandpa",
  "sp-core",
+ "sp-debug-derive",
  "sp-genesis-builder",
  "sp-inherents",
  "sp-io",

--- a/solo-chains/runtime/starlight/Cargo.toml
+++ b/solo-chains/runtime/starlight/Cargo.toml
@@ -35,6 +35,7 @@ sp-api = { workspace = true }
 sp-arithmetic = { workspace = true }
 sp-consensus-aura = { workspace = true }
 sp-core = { workspace = true }
+sp-debug-derive = { workspace = true }
 sp-genesis-builder = { workspace = true }
 sp-io = { workspace = true }
 sp-keystore = { workspace = true }
@@ -266,6 +267,7 @@ std = [
 	"xcm-executor/std",
 	"xcm-runtime-apis/std",
 	"xcm/std",
+	"sp-debug-derive/std"
 ]
 no_std = []
 runtime-benchmarks = [
@@ -393,6 +395,9 @@ try-runtime = [
 
 # Set timing constants (e.g. session period) to faster versions to speed up testing.
 fast-runtime = [ "starlight-runtime-constants/fast-runtime" ]
+
+# Allow to print logs details (no wasm:stripped)
+force-debug = [ "sp-debug-derive/force-debug" ]
 
 runtime-metrics = [ "runtime-parachains/runtime-metrics", "sp-io/with-tracing" ]
 

--- a/solo-chains/runtime/starlight/Cargo.toml
+++ b/solo-chains/runtime/starlight/Cargo.toml
@@ -244,6 +244,7 @@ std = [
 	"sp-arithmetic/std",
 	"sp-consensus-aura/std",
 	"sp-core/std",
+	"sp-debug-derive/std",
 	"sp-genesis-builder/std",
 	"sp-io/std",
 	"sp-keystore/std",
@@ -267,7 +268,6 @@ std = [
 	"xcm-executor/std",
 	"xcm-runtime-apis/std",
 	"xcm/std",
-	"sp-debug-derive/std"
 ]
 no_std = []
 runtime-benchmarks = [


### PR DESCRIPTION
So we won't see `wasm:stripped` in zombienet logs if compiled with `--features force-debug`