### PR TITLE
Always use warp sync for container chains

### DIFF
--- a/client/service-container-chain/src/spawner.rs
+++ b/client/service-container-chain/src/spawner.rs
@@ -69,21 +69,11 @@ const MAX_DB_RESTART_TIMEOUT: Duration = Duration::from_secs(60);
 /// Assuming a syncing speed of 100 blocks per second, this will take 5 minutes to sync.
 const MAX_BLOCK_DIFF_FOR_FULL_SYNC: u32 = 30_000;
 
-pub trait TSelectSyncMode:
-    Send + Sync + Clone + 'static + (Fn(bool, ParaId) -> sc_service::error::Result<SyncMode>)
-{
-}
-impl<
-        T: Send + Sync + Clone + 'static + (Fn(bool, ParaId) -> sc_service::error::Result<SyncMode>),
-    > TSelectSyncMode for T
-{
-}
-
 /// Task that handles spawning a stopping container chains based on assignment.
 /// The main loop is [rx_loop](ContainerChainSpawner::rx_loop).
-pub struct ContainerChainSpawner<SelectSyncMode> {
+pub struct ContainerChainSpawner {
     /// Start container chain params
-    pub params: ContainerChainSpawnParams<SelectSyncMode>,
+    pub params: ContainerChainSpawnParams,
 
     /// State
     pub state: Arc<Mutex<ContainerChainSpawnerState>>,
@@ -106,7 +96,7 @@ pub struct ContainerChainSpawner<SelectSyncMode> {
 /// running an embeded orchestrator node, as this will prevent spawning a container chain in a node
 /// connected to an orchestrator node through WebSocket.
 #[derive(Clone)]
-pub struct ContainerChainSpawnParams<SelectSyncMode> {
+pub struct ContainerChainSpawnParams {
     pub orchestrator_chain_interface: Arc<dyn OrchestratorChainInterface>,
     pub container_chain_cli: ContainerChainCli,
     pub tokio_handle: tokio::runtime::Handle,
@@ -117,7 +107,6 @@ pub struct ContainerChainSpawnParams<SelectSyncMode> {
     pub orchestrator_para_id: ParaId,
     pub spawn_handle: SpawnTaskHandle,
     pub collation_params: Option<CollationParams>,
-    pub sync_mode: SelectSyncMode,
     pub data_preserver: bool,
 }
 
@@ -172,8 +161,8 @@ pub enum CcSpawnMsg {
 // Separate function to allow using `?` to return a result, and also to avoid using `self` in an
 // async function. Mutable state should be written by locking `state`.
 // TODO: `state` should be an async mutex
-async fn try_spawn<SelectSyncMode: TSelectSyncMode>(
-    try_spawn_params: ContainerChainSpawnParams<SelectSyncMode>,
+async fn try_spawn(
+    try_spawn_params: ContainerChainSpawnParams,
     state: Arc<Mutex<ContainerChainSpawnerState>>,
     container_chain_para_id: ParaId,
     start_collation: bool,
@@ -188,7 +177,6 @@ async fn try_spawn<SelectSyncMode: TSelectSyncMode>(
         sync_keystore,
         spawn_handle,
         mut collation_params,
-        sync_mode,
         data_preserver,
         ..
     } = try_spawn_params;
@@ -318,8 +306,7 @@ async fn try_spawn<SelectSyncMode: TSelectSyncMode>(
         // Loop will run at most 2 times: 1 time if the db is good and 2 times if the db needs to be removed
         for _ in 0..2 {
             let db_existed_before = check_db_exists();
-            container_chain_cli.base.base.network_params.sync =
-                sync_mode(db_existed_before, container_chain_para_id)?;
+            container_chain_cli.base.base.network_params.sync = SyncMode::Warp;
             log::info!(
                 "Container chain sync mode: {:?}",
                 container_chain_cli.base.base.network_params.sync
@@ -557,7 +544,7 @@ pub trait Spawner {
     fn stop(&self, container_chain_para_id: ParaId, keep_db: bool) -> Option<PathBuf>;
 }
 
-impl<SelectSyncMode: TSelectSyncMode> Spawner for ContainerChainSpawner<SelectSyncMode> {
+impl Spawner for ContainerChainSpawner {
     /// Access to the Orchestrator Chain Interface
     fn orchestrator_chain_interface(&self) -> Arc<dyn OrchestratorChainInterface> {
         self.params.orchestrator_chain_interface.clone()
@@ -637,7 +624,7 @@ impl<SelectSyncMode: TSelectSyncMode> Spawner for ContainerChainSpawner<SelectSy
     }
 }
 
-impl<SelectSyncMode: TSelectSyncMode> ContainerChainSpawner<SelectSyncMode> {
+impl ContainerChainSpawner {
     /// Receive and process `CcSpawnMsg`s indefinitely
     pub async fn rx_loop(
         mut self,

--- a/container-chains/nodes/simple/src/command.rs
+++ b/container-chains/nodes/simple/src/command.rs
@@ -617,8 +617,6 @@ fn rpc_provider_mode(cli: Cli, profile_id: u64) -> Result<()> {
                     orchestrator_para_id: para_id,
                     collation_params: None,
                     spawn_handle: task_manager.spawn_handle().clone(),
-                    // We can use warp sync because the warp sync bug only affects collators
-                    sync_mode: { move |_db_exists, _para_id| Ok(sc_cli::SyncMode::Warp) },
                     data_preserver: true,
                 },
                 state: Default::default(),

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -464,15 +464,6 @@ async fn start_node_impl(
                     None
                 },
                 spawn_handle,
-                sync_mode: {
-                    move |db_exists, para_id| {
-                        spawner::select_sync_mode_using_client(
-                            db_exists,
-                            &orchestrator_client.clone(),
-                            para_id,
-                        )
-                    }
-                },
             },
             state: Default::default(),
             collate_on_tanssi,
@@ -851,19 +842,6 @@ pub async fn start_solochain_node(
                     None
                 },
                 spawn_handle,
-                sync_mode: {
-                    move |_db_exists, _para_id| {
-                        // Default to full sync because it always works
-                        // TODO: allow select_sync_mode_using_client to use orchestrator_chain_interface
-                        /*
-                        spawner::select_sync_mode_using_client(
-                            db_exists,
-                            &orchestrator_chain_interface,
-                            para_id,
-                        ).await*/
-                        Ok(sc_cli::SyncMode::Full)
-                    }
-                },
                 data_preserver: false,
             },
             state: Default::default(),

--- a/test/suites/warp-sync/test_warp_sync.ts
+++ b/test/suites/warp-sync/test_warp_sync.ts
@@ -260,7 +260,8 @@ describeSuite({
                     "[Container-2000] Warp sync is complete",
                     "[Orchestrator] Detected assignment for container chain 2000",
                     "[Orchestrator] Loaded chain spec for container chain 2000",
-                    "[Orchestrator] Container chain sync mode: Full",
+                    "[Orchestrator] Container chain sync mode: Warp",
+                    "[Container-2000] Can't use warp sync mode with a partially synced database. Reverting to full sync mode.",
                 ]);
             },
         });


### PR DESCRIPTION
Remove the select_sync_mode function which apparently is no longer needed