### PR TITLE
Increase timeout for zombie_tanssi_relay test

### DIFF
--- a/test/suites/zombie-tanssi-relay/test-tanssi-relay.ts
+++ b/test/suites/zombie-tanssi-relay/test-tanssi-relay.ts
@@ -319,7 +319,7 @@ describeSuite({
         it({
             id: "T13",
             title: "Blocks are being produced on container 2002",
-            timeout: 120000,
+            timeout: 180000,
             test: async function () {
                 // Wait 3 blocks because the next test needs to get a non empty value from
                 // container2002Api.query.authoritiesNoting()


### PR DESCRIPTION
Attempt to fix spurious failures that happen because container 2002 takes a bit too long to produce blocks. Example:

https://github.com/moondance-labs/tanssi/actions/runs/10937611643/job/30364262733#step:3:296