### PR TITLE
Revert "Always use warp sync for container chains (#684)"

### DIFF
--- a/client/service-container-chain/src/spawner.rs
+++ b/client/service-container-chain/src/spawner.rs
@@ -69,11 +69,21 @@ const MAX_DB_RESTART_TIMEOUT: Duration = Duration::from_secs(60);
 /// Assuming a syncing speed of 100 blocks per second, this will take 5 minutes to sync.
 const MAX_BLOCK_DIFF_FOR_FULL_SYNC: u32 = 30_000;
 
+pub trait TSelectSyncMode:
+    Send + Sync + Clone + 'static + (Fn(bool, ParaId) -> sc_service::error::Result<SyncMode>)
+{
+}
+impl<
+        T: Send + Sync + Clone + 'static + (Fn(bool, ParaId) -> sc_service::error::Result<SyncMode>),
+    > TSelectSyncMode for T
+{
+}
+
 /// Task that handles spawning a stopping container chains based on assignment.
 /// The main loop is [rx_loop](ContainerChainSpawner::rx_loop).
-pub struct ContainerChainSpawner {
+pub struct ContainerChainSpawner<SelectSyncMode> {
     /// Start container chain params
-    pub params: ContainerChainSpawnParams,
+    pub params: ContainerChainSpawnParams<SelectSyncMode>,
 
     /// State
     pub state: Arc<Mutex<ContainerChainSpawnerState>>,
@@ -96,7 +106,7 @@ pub struct ContainerChainSpawner {
 /// running an embeded orchestrator node, as this will prevent spawning a container chain in a node
 /// connected to an orchestrator node through WebSocket.
 #[derive(Clone)]
-pub struct ContainerChainSpawnParams {
+pub struct ContainerChainSpawnParams<SelectSyncMode> {
     pub orchestrator_chain_interface: Arc<dyn OrchestratorChainInterface>,
     pub container_chain_cli: ContainerChainCli,
     pub tokio_handle: tokio::runtime::Handle,
@@ -107,6 +117,7 @@ pub struct ContainerChainSpawnParams {
     pub orchestrator_para_id: ParaId,
     pub spawn_handle: SpawnTaskHandle,
     pub collation_params: Option<CollationParams>,
+    pub sync_mode: SelectSyncMode,
     pub data_preserver: bool,
 }
 
@@ -161,8 +172,8 @@ pub enum CcSpawnMsg {
 // Separate function to allow using `?` to return a result, and also to avoid using `self` in an
 // async function. Mutable state should be written by locking `state`.
 // TODO: `state` should be an async mutex
-async fn try_spawn(
-    try_spawn_params: ContainerChainSpawnParams,
+async fn try_spawn<SelectSyncMode: TSelectSyncMode>(
+    try_spawn_params: ContainerChainSpawnParams<SelectSyncMode>,
     state: Arc<Mutex<ContainerChainSpawnerState>>,
     container_chain_para_id: ParaId,
     start_collation: bool,
@@ -177,6 +188,7 @@ async fn try_spawn(
         sync_keystore,
         spawn_handle,
         mut collation_params,
+        sync_mode,
         data_preserver,
         ..
     } = try_spawn_params;
@@ -306,7 +318,8 @@ async fn try_spawn(
         // Loop will run at most 2 times: 1 time if the db is good and 2 times if the db needs to be removed
         for _ in 0..2 {
             let db_existed_before = check_db_exists();
-            container_chain_cli.base.base.network_params.sync = SyncMode::Warp;
+            container_chain_cli.base.base.network_params.sync =
+                sync_mode(db_existed_before, container_chain_para_id)?;
             log::info!(
                 "Container chain sync mode: {:?}",
                 container_chain_cli.base.base.network_params.sync
@@ -544,7 +557,7 @@ pub trait Spawner {
     fn stop(&self, container_chain_para_id: ParaId, keep_db: bool) -> Option<PathBuf>;
 }
 
-impl Spawner for ContainerChainSpawner {
+impl<SelectSyncMode: TSelectSyncMode> Spawner for ContainerChainSpawner<SelectSyncMode> {
     /// Access to the Orchestrator Chain Interface
     fn orchestrator_chain_interface(&self) -> Arc<dyn OrchestratorChainInterface> {
         self.params.orchestrator_chain_interface.clone()
@@ -624,7 +637,7 @@ impl Spawner for ContainerChainSpawner {
     }
 }
 
-impl ContainerChainSpawner {
+impl<SelectSyncMode: TSelectSyncMode> ContainerChainSpawner<SelectSyncMode> {
     /// Receive and process `CcSpawnMsg`s indefinitely
     pub async fn rx_loop(
         mut self,

--- a/container-chains/nodes/simple/src/command.rs
+++ b/container-chains/nodes/simple/src/command.rs
@@ -617,6 +617,8 @@ fn rpc_provider_mode(cli: Cli, profile_id: u64) -> Result<()> {
                     orchestrator_para_id: para_id,
                     collation_params: None,
                     spawn_handle: task_manager.spawn_handle().clone(),
+                    // We can use warp sync because the warp sync bug only affects collators
+                    sync_mode: { move |_db_exists, _para_id| Ok(sc_cli::SyncMode::Warp) },
                     data_preserver: true,
                 },
                 state: Default::default(),

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -464,6 +464,15 @@ async fn start_node_impl(
                     None
                 },
                 spawn_handle,
+                sync_mode: {
+                    move |db_exists, para_id| {
+                        spawner::select_sync_mode_using_client(
+                            db_exists,
+                            &orchestrator_client.clone(),
+                            para_id,
+                        )
+                    }
+                },
             },
             state: Default::default(),
             collate_on_tanssi,
@@ -842,6 +851,19 @@ pub async fn start_solochain_node(
                     None
                 },
                 spawn_handle,
+                sync_mode: {
+                    move |_db_exists, _para_id| {
+                        // Default to full sync because it always works
+                        // TODO: allow select_sync_mode_using_client to use orchestrator_chain_interface
+                        /*
+                        spawner::select_sync_mode_using_client(
+                            db_exists,
+                            &orchestrator_chain_interface,
+                            para_id,
+                        ).await*/
+                        Ok(sc_cli::SyncMode::Full)
+                    }
+                },
                 data_preserver: false,
             },
             state: Default::default(),

--- a/test/suites/warp-sync/test_warp_sync.ts
+++ b/test/suites/warp-sync/test_warp_sync.ts
@@ -260,8 +260,7 @@ describeSuite({
                     "[Container-2000] Warp sync is complete",
                     "[Orchestrator] Detected assignment for container chain 2000",
                     "[Orchestrator] Loaded chain spec for container chain 2000",
-                    "[Orchestrator] Container chain sync mode: Warp",
-                    "[Container-2000] Can't use warp sync mode with a partially synced database. Reverting to full sync mode.",
+                    "[Orchestrator] Container chain sync mode: Full",
                 ]);
             },
         });


### PR DESCRIPTION
This reverts commit 1e315f9ac7323174dd9d6b7697db59c60945f012.

The bug has not been fixed after all.

Some logs:

```
2024-09-19 10:03:12 [Container-2002] ⏩ Warping, Downloading target block, 0.00 Mib (0 peers), best: #0 (0x9049…30d0), finalized #0 (0x9049…30d0), ⬇ 0 ⬆ 0    
2024-09-19 10:03:12 [Container-2000] State sync is complete, continuing with block sync.    
2024-09-19 10:03:12 [Container-2000] 🏆 Imported #66 (0x3b40…6e1f → 0xf8bf…c1aa)    
2024-09-19 10:03:12 [Container-2000] 🏆 Imported #67 (0xf8bf…c1aa → 0x5869…53a9)    
2024-09-19 10:03:12 [Container-2000] Block history download is complete.    
2024-09-19 10:03:13 [Relaychain] 💤 Idle (12 peers), best: #114 (0x4e62…cf01), finalized #111 (0x211c…884f), ⬇ 2.7kiB/s ⬆ 3.3kiB/s    
2024-09-19 10:03:16 [Container-2000] 💤 Idle (2 peers), best: #67 (0x5869…53a9), finalized #65 (0x3b40…6e1f), ⬇ 293.2kiB/s ⬆ 1.3kiB/s    
2024-09-19 10:03:17 [Container-2002] ⏩ Warping, Downloading target block, 0.00 Mib (0 peers), best: #0 (0x9049…30d0), finalized #0 (0x9049…30d0), ⬇ 0 ⬆ 0    

2024-09-19 10:03:18 [Container-2002] 🙌 Starting consensus session on top of parent 0x904983072a321a25809274712bfd3e5307f8ab905de42584f9cc8b2e26b630d0 (#0)    
2024-09-19 10:03:18 [Container-2002] 🎁 Prepared block for proposing at 1 (1 ms) [hash: 0xd08e1f4b8fb696249580ff3283dc6d5c9d79b7759d71ef3cac067a9b3314fca1; parent_hash: 0x9049…30d0; extrinsics (4): [0x56cc…39f7, 0x2a3a…4ac2, 0xa653…f215, 0xca7a…4230]    
2024-09-19 10:03:18 [Container-2002] 🔖 Pre-sealed block for proposal at 1. Hash now 0xa61a2cd0d6b6baa4de7a49bed52d9cff1730e296cae4ac0fcc2c80d903a9c5a5, previously 0xd08e1f4b8fb696249580ff3283dc6d5c9d79b7759d71ef3cac067a9b3314fca1.
2024-09-19 10:03:18 [Container-2002] Failed to collect collation info. error=UnknownBlock("Header was not found in the database: 0xa61a2cd0d6b6baa4de7a49bed52d9cff1730e296cae4ac0fcc2c80d903a9c5a5")
2024-09-19 10:03:18 [Container-2002] err="Unable to produce collation"
2024-09-19 10:03:21 [Container-2000] 💤 Idle (2 peers), best: #67 (0x5869…53a9), finalized #65 (0x3b40…6e1f), ⬇ 0.2kiB/s ⬆ 0.1kiB/s    
2024-09-19 10:03:22 [Container-2002] ⏩ Warping, Downloading target block, 0.00 Mib (0 peers), best: #0 (0x9049…30d0), finalized #0 (0x9049…30d0), ⬇ 0 ⬆ 0    
```

https://github.com/moondance-labs/tanssi/actions/runs/10938365240/job/30366523508#step:3:271