### PR TITLE
Starlight: Updated integration test run_block flow

### DIFF
--- a/runtime/dancebox/src/tests/common/mod.rs
+++ b/runtime/dancebox/src/tests/common/mod.rs
@@ -236,9 +236,8 @@ pub fn end_block() {
 }
 
 pub fn run_block() -> RunSummary {
-    end_block();
-
-    start_block()
+    start_block();
+    end_block()
 }
 
 /// Mock the inherent that sets validation data in ParachainSystem, which

--- a/runtime/dancebox/src/tests/common/mod.rs
+++ b/runtime/dancebox/src/tests/common/mod.rs
@@ -239,6 +239,7 @@ pub fn run_block() -> RunSummary {
     end_block();
 
     start_block()
+}
 
 /// Mock the inherent that sets validation data in ParachainSystem, which
 /// contains the `relay_chain_block_number`, which is used in `collator-assignment` as a

--- a/runtime/dancebox/src/tests/common/mod.rs
+++ b/runtime/dancebox/src/tests/common/mod.rs
@@ -236,10 +236,9 @@ pub fn end_block() {
 }
 
 pub fn run_block() -> RunSummary {
-    let summary = start_block();
     end_block();
-    summary
-}
+
+    start_block()
 
 /// Mock the inherent that sets validation data in ParachainSystem, which
 /// contains the `relay_chain_block_number`, which is used in `collator-assignment` as a

--- a/runtime/dancebox/src/tests/common/mod.rs
+++ b/runtime/dancebox/src/tests/common/mod.rs
@@ -236,8 +236,9 @@ pub fn end_block() {
 }
 
 pub fn run_block() -> RunSummary {
-    start_block();
-    end_block()
+    let summary = start_block();
+    end_block();
+    summary
 }
 
 /// Mock the inherent that sets validation data in ParachainSystem, which

--- a/solo-chains/runtime/starlight/src/tests/collator_assignment_tests.rs
+++ b/solo-chains/runtime/starlight/src/tests/collator_assignment_tests.rs
@@ -82,13 +82,11 @@ fn test_collator_assignment_rotation() {
             // Check that the randomness in CollatorAssignment is set
             // in the block before the session change
             run_to_block(session_to_block(rotation_period) - 1);
-            end_block();
             let expected_randomness: [u8; 32] =
                 BabeCurrentBlockRandomnessGetter::get_block_randomness_mixed(b"CollatorAssignment")
                     .unwrap()
                     .into();
             assert_eq!(TanssiCollatorAssignment::randomness(), expected_randomness);
-            start_block();
 
             // Assignment changed
             assert_ne!(

--- a/solo-chains/runtime/starlight/src/tests/common/mod.rs
+++ b/solo-chains/runtime/starlight/src/tests/common/mod.rs
@@ -599,10 +599,6 @@ impl ExtBuilder {
         if let Some(keystore) = keystore {
             ext.register_extension(KeystoreExt(keystore));
         }
-        ext.execute_with(|| {
-            // Start block 1
-            start_block();
-        });
         ext
     }
 }

--- a/solo-chains/runtime/starlight/src/tests/common/mod.rs
+++ b/solo-chains/runtime/starlight/src/tests/common/mod.rs
@@ -240,9 +240,8 @@ pub fn end_block() {
 }
 
 pub fn run_block() {
-    end_block();
-
-    start_block()
+    start_block();
+    end_block()
 }
 
 #[derive(Default, Clone)]

--- a/solo-chains/runtime/starlight/src/tests/common/mod.rs
+++ b/solo-chains/runtime/starlight/src/tests/common/mod.rs
@@ -599,6 +599,10 @@ impl ExtBuilder {
         if let Some(keystore) = keystore {
             ext.register_extension(KeystoreExt(keystore));
         }
+        ext.execute_with(|| {
+            // Start block 1
+            run_to_block(1);
+        });
         ext
     }
 }

--- a/solo-chains/runtime/starlight/src/tests/relay_registrar.rs
+++ b/solo-chains/runtime/starlight/src/tests/relay_registrar.rs
@@ -45,7 +45,7 @@ fn registrar_needs_a_reserved_para_id() {
         .with_next_free_para_id(2000u32.into())
         .build()
         .execute_with(|| {
-            run_to_block(2);
+            //run_to_block(3);
             assert_noop!(
                 Registrar::register(
                     origin_of(ALICE.into()),
@@ -408,7 +408,6 @@ fn deregister_calls_schedule_para_cleanup() {
             );
 
             run_to_session(9);
-            end_block();
 
             assert_eq!(Runtime::genesis_data(1003.into()).as_ref(), None);
 
@@ -553,7 +552,6 @@ fn deregister_two_paras_in_the_same_block() {
             );
 
             run_to_session(9);
-            end_block();
 
             assert_eq!(Runtime::genesis_data(1003.into()).as_ref(), None);
             assert_eq!(Runtime::genesis_data(1004.into()).as_ref(), None);


### PR DESCRIPTION
Updating Starlight runtime integration tests to use start_block + end_block run_block flow instead of the current end_block + start_block