### PR TITLE
Combine `RemoveParaIdsWithNoCredit` and `CollatorAssignmentHook`

### DIFF
--- a/pallets/collator-assignment/src/benchmarking.rs
+++ b/pallets/collator-assignment/src/benchmarking.rs
@@ -68,7 +68,7 @@ mod benchmarks {
         let container_chains: Vec<_> = (0..y).map(|i| ParaId::from(2000 + i)).collect();
         let session_index = 0u32.into();
         T::ContainerChains::set_session_container_chains(session_index, &container_chains);
-        T::RemoveParaIdsWithNoCredits::make_valid_para_ids(&container_chains);
+        T::ParaIdAssignmentHooks::make_valid_para_ids(&container_chains);
         T::HostConfiguration::set_host_configuration(session_index);
 
         // Assign random collators to test worst case: when collators need to be checked against existing collators

--- a/pallets/collator-assignment/src/mock.rs
+++ b/pallets/collator-assignment/src/mock.rs
@@ -33,8 +33,8 @@ use {
     },
     sp_std::collections::{btree_map::BTreeMap, btree_set::BTreeSet},
     tp_traits::{
-        CollatorAssignmentHook, CollatorAssignmentTip, ParaId, ParathreadParams,
-        RemoveInvulnerables, RemoveParaIdsWithNoCredits, SessionContainerChains,
+        CollatorAssignmentTip, ParaId, ParathreadParams, RemoveInvulnerables,
+        RemoveParaIdsWithNoCredits, SessionContainerChains,
     },
     tracing_subscriber::{layer::SubscriberExt, FmtSubscriber},
 };
@@ -310,23 +310,6 @@ impl CollatorAssignmentTip<u32> for MockCollatorAssignmentTip {
         }
     }
 }
-pub struct MockCollatorAssignmentHook;
-
-impl CollatorAssignmentHook<u32> for MockCollatorAssignmentHook {
-    fn on_collators_assigned(
-        para_id: ParaId,
-        _maybe_tip: Option<&u32>,
-        _is_parathread: bool,
-    ) -> Result<Weight, sp_runtime::DispatchError> {
-        // Only fail for para 1001
-        if MockData::mock().assignment_hook_errors && para_id == 1001.into() {
-            // The error doesn't matter
-            Err(sp_runtime::DispatchError::Unavailable)
-        } else {
-            Ok(Weight::default())
-        }
-    }
-}
 
 pub struct GetCoreAllocationConfigurationImpl;
 
@@ -353,7 +336,6 @@ impl pallet_collator_assignment::Config for Test {
     type GetRandomnessForNextBlock = MockGetRandomnessForNextBlock;
     type RemoveInvulnerables = RemoveAccountIdsAbove100;
     type RemoveParaIdsWithNoCredits = RemoveParaIdsAbove5000;
-    type CollatorAssignmentHook = MockCollatorAssignmentHook;
     type CollatorAssignmentTip = MockCollatorAssignmentTip;
     type ForceEmptyOrchestrator = ConstBool<false>;
     type Currency = ();
@@ -416,12 +398,21 @@ impl RemoveInvulnerables<u64> for RemoveAccountIdsAbove100 {
 /// Any ParaId >= 5000 will be considered to not have enough credits
 pub struct RemoveParaIdsAbove5000;
 
-impl RemoveParaIdsWithNoCredits for RemoveParaIdsAbove5000 {
-    fn remove_para_ids_with_no_credits(
+impl<AC> RemoveParaIdsWithNoCredits<u32, AC> for RemoveParaIdsAbove5000 {
+    fn pre_assignment_remove_para_ids_with_no_credits(
         para_ids: &mut Vec<ParaId>,
-        _currently_assigned: &BTreeSet<ParaId>,
+        _old_assigned: &BTreeSet<ParaId>,
     ) {
         para_ids.retain(|para_id| *para_id <= ParaId::from(5000));
+    }
+
+    fn post_assignment_remove_para_ids_with_no_credits(
+        _current_assigned: &BTreeSet<ParaId>,
+        new_assigned: &mut BTreeMap<ParaId, Vec<AC>>,
+        _maybe_tip: &Option<u32>,
+    ) -> Weight {
+        new_assigned.retain(|para_id, _| *para_id <= ParaId::from(5000));
+        Weight::zero()
     }
 
     #[cfg(feature = "runtime-benchmarks")]

--- a/pallets/collator-assignment/src/tests.rs
+++ b/pallets/collator-assignment/src/tests.rs
@@ -1345,64 +1345,6 @@ fn assign_collators_prioritizing_tip() {
 }
 
 #[test]
-fn on_collators_assigned_hook_failure_removes_para_from_assignment() {
-    new_test_ext().execute_with(|| {
-        run_to_block(1);
-
-        MockData::mutate(|m| {
-            m.collators_per_container = 2;
-            m.collators_per_parathread = 2;
-            m.min_orchestrator_chain_collators = 5;
-            m.max_orchestrator_chain_collators = 5;
-
-            m.collators = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
-            m.container_chains = vec![1001, 1002, 1003, 1004];
-            m.assignment_hook_errors = false;
-        });
-        run_to_block(11);
-
-        assert_eq!(
-            assigned_collators(),
-            BTreeMap::from_iter(vec![
-                (1, 1000),
-                (2, 1000),
-                (3, 1000),
-                (4, 1000),
-                (5, 1000),
-                (6, 1001),
-                (7, 1001),
-                (8, 1002),
-                (9, 1002),
-                (10, 1003),
-                (11, 1003),
-            ]),
-        );
-
-        // Para 1001 will fail on_assignment_hook
-        MockData::mutate(|m| {
-            m.assignment_hook_errors = true;
-        });
-
-        run_to_block(21);
-
-        assert_eq!(
-            assigned_collators(),
-            BTreeMap::from_iter(vec![
-                (1, 1000),
-                (2, 1000),
-                (3, 1000),
-                (4, 1000),
-                (5, 1000),
-                (8, 1002),
-                (9, 1002),
-                (10, 1003),
-                (11, 1003),
-            ]),
-        );
-    });
-}
-
-#[test]
 fn assign_collators_truncates_before_shuffling() {
     // Check that if there are more collators than needed, we only assign the first collators
     new_test_ext().execute_with(|| {

--- a/primitives/traits/src/lib.rs
+++ b/primitives/traits/src/lib.rs
@@ -45,7 +45,7 @@ use {
         traits::{CheckedAdd, CheckedMul},
         ArithmeticError, DispatchResult, Perbill, RuntimeDebug,
     },
-    sp_std::{collections::btree_set::BTreeSet, vec::Vec},
+    sp_std::{collections::btree_map::BTreeMap, collections::btree_set::BTreeSet, vec::Vec},
 };
 
 // Separate import as rustfmt wrongly change it to `sp_std::vec::self`, which is the module instead
@@ -272,24 +272,37 @@ impl<AccountId: Clone> RemoveInvulnerables<AccountId> for () {
 
 /// Helper trait for pallet_collator_assignment to be able to not assign collators to container chains with no credits
 /// in pallet_services_payment
-pub trait RemoveParaIdsWithNoCredits {
+pub trait RemoveParaIdsWithNoCredits<B, AC> {
     /// Remove para ids with not enough credits. The resulting order will affect priority: the first para id in the list
     /// will be the first one to get collators.
-    fn remove_para_ids_with_no_credits(
+    fn pre_assignment_remove_para_ids_with_no_credits(
         para_ids: &mut Vec<ParaId>,
-        currently_assigned: &BTreeSet<ParaId>,
+        old_assigned: &BTreeSet<ParaId>,
     );
+    fn post_assignment_remove_para_ids_with_no_credits(
+        current_assigned: &BTreeSet<ParaId>,
+        new_assigned: &mut BTreeMap<ParaId, Vec<AC>>,
+        maybe_tip: &Option<B>,
+    ) -> Weight;
 
     /// Make those para ids valid by giving them enough credits, for benchmarking.
     #[cfg(feature = "runtime-benchmarks")]
     fn make_valid_para_ids(para_ids: &[ParaId]);
 }
 
-impl RemoveParaIdsWithNoCredits for () {
-    fn remove_para_ids_with_no_credits(
+impl<B, AC> RemoveParaIdsWithNoCredits<B, AC> for () {
+    fn pre_assignment_remove_para_ids_with_no_credits(
         _para_ids: &mut Vec<ParaId>,
         _currently_assigned: &BTreeSet<ParaId>,
     ) {
+    }
+
+    fn post_assignment_remove_para_ids_with_no_credits(
+        _current_assigned: &BTreeSet<ParaId>,
+        _new_assigned: &mut BTreeMap<ParaId, Vec<AC>>,
+        _maybe_tip: &Option<B>,
+    ) -> Weight {
+        Default::default()
     }
 
     #[cfg(feature = "runtime-benchmarks")]

--- a/primitives/traits/src/lib.rs
+++ b/primitives/traits/src/lib.rs
@@ -272,14 +272,11 @@ impl<AccountId: Clone> RemoveInvulnerables<AccountId> for () {
 
 /// Helper trait for pallet_collator_assignment to be able to not assign collators to container chains with no credits
 /// in pallet_services_payment
-pub trait RemoveParaIdsWithNoCredits<B, AC> {
+pub trait ParaIdAssignmentHooks<B, AC> {
     /// Remove para ids with not enough credits. The resulting order will affect priority: the first para id in the list
     /// will be the first one to get collators.
-    fn pre_assignment_remove_para_ids_with_no_credits(
-        para_ids: &mut Vec<ParaId>,
-        old_assigned: &BTreeSet<ParaId>,
-    );
-    fn post_assignment_remove_para_ids_with_no_credits(
+    fn pre_assignment(para_ids: &mut Vec<ParaId>, old_assigned: &BTreeSet<ParaId>);
+    fn post_assignment(
         current_assigned: &BTreeSet<ParaId>,
         new_assigned: &mut BTreeMap<ParaId, Vec<AC>>,
         maybe_tip: &Option<B>,
@@ -290,14 +287,10 @@ pub trait RemoveParaIdsWithNoCredits<B, AC> {
     fn make_valid_para_ids(para_ids: &[ParaId]);
 }
 
-impl<B, AC> RemoveParaIdsWithNoCredits<B, AC> for () {
-    fn pre_assignment_remove_para_ids_with_no_credits(
-        _para_ids: &mut Vec<ParaId>,
-        _currently_assigned: &BTreeSet<ParaId>,
-    ) {
-    }
+impl<B, AC> ParaIdAssignmentHooks<B, AC> for () {
+    fn pre_assignment(_para_ids: &mut Vec<ParaId>, _currently_assigned: &BTreeSet<ParaId>) {}
 
-    fn post_assignment_remove_para_ids_with_no_credits(
+    fn post_assignment(
         _current_assigned: &BTreeSet<ParaId>,
         _new_assigned: &mut BTreeMap<ParaId, Vec<AC>>,
         _maybe_tip: &Option<B>,

--- a/runtime/dancebox/src/lib.rs
+++ b/runtime/dancebox/src/lib.rs
@@ -24,18 +24,22 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 pub mod xcm_config;
 
+use frame_support::storage::{with_storage_layer, with_transaction};
+use frame_support::traits::{ExistenceRequirement, WithdrawReasons};
 use polkadot_runtime_common::SlowAdjustingFeeUpdate;
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
+use sp_runtime::{DispatchError, TransactionOutcome};
 
 pub mod weights;
 
 #[cfg(test)]
 mod tests;
 
+use pallet_services_payment::BalanceOf;
 use {
     cumulus_pallet_parachain_system::{
         RelayChainStateProof, RelayNumberMonotonicallyIncreases, RelaychainDataProvider,
@@ -103,6 +107,7 @@ use {
         transaction_validity::{TransactionSource, TransactionValidity},
         AccountId32, ApplyExtrinsicResult,
     },
+    sp_std::collections::btree_map::BTreeMap,
     sp_std::{collections::btree_set::BTreeSet, marker::PhantomData, prelude::*},
     sp_version::RuntimeVersion,
     staging_xcm::{
@@ -809,54 +814,127 @@ impl RemoveInvulnerables<CollatorId> for RemoveInvulnerablesImpl {
 
 pub struct RemoveParaIdsWithNoCreditsImpl;
 
-impl RemoveParaIdsWithNoCredits for RemoveParaIdsWithNoCreditsImpl {
-    fn remove_para_ids_with_no_credits(
+impl RemoveParaIdsWithNoCreditsImpl {
+    fn charge_para_ids_internal(
+        blocks_per_session: tp_traits::BlockNumber,
+        para_id: ParaId,
+        currently_assigned: &BTreeSet<ParaId>,
+        maybe_tip: &Option<BalanceOf<Runtime>>,
+    ) -> Result<Weight, DispatchError> {
+        use frame_support::traits::Currency;
+        type ServicePaymentCurrency = <Runtime as pallet_services_payment::Config>::Currency;
+
+        // Check if the container chain has enough credits for a session assignments
+        let maybe_assignment_imbalance =
+            if  pallet_services_payment::Pallet::<Runtime>::burn_collator_assignment_free_credit_for_para(&para_id).is_err() {
+                let (amount_to_charge, _weight) =
+                    <Runtime as pallet_services_payment::Config>::ProvideCollatorAssignmentCost::collator_assignment_cost(&para_id);
+                Some(<ServicePaymentCurrency as Currency<AccountId>>::withdraw(
+                    &pallet_services_payment::Pallet::<Runtime>::parachain_tank(para_id),
+                    amount_to_charge,
+                    WithdrawReasons::FEE,
+                    ExistenceRequirement::KeepAlive,
+                )?)
+            } else {
+                None
+            };
+
+        if let Some(tip) = maybe_tip {
+            if let Err(e) = pallet_services_payment::Pallet::<Runtime>::charge_tip(&para_id, tip) {
+                // Return assignment imbalance to tank on error
+                if let Some(assignment_imbalance) = maybe_assignment_imbalance {
+                    <Runtime as pallet_services_payment::Config>::Currency::resolve_creating(
+                        &pallet_services_payment::Pallet::<Runtime>::parachain_tank(para_id),
+                        assignment_imbalance,
+                    );
+                }
+                return Err(e);
+            }
+        }
+
+        if let Some(assignment_imbalance) = maybe_assignment_imbalance {
+            <Runtime as pallet_services_payment::Config>::OnChargeForCollatorAssignment::on_unbalanced(assignment_imbalance);
+        }
+
+        // If the para has been assigned collators for this session it must have enough block credits
+        // for the current and the next session.
+        let block_credits_needed = if currently_assigned.contains(&para_id) {
+            blocks_per_session * 2
+        } else {
+            blocks_per_session
+        };
+        // Check if the container chain has enough credits for producing blocks
+        let free_block_credits =
+            pallet_services_payment::BlockProductionCredits::<Runtime>::get(para_id)
+                .unwrap_or_default();
+        let remaining_block_credits = block_credits_needed.saturating_sub(free_block_credits);
+        let (block_production_costs, _) =
+            <Runtime as pallet_services_payment::Config>::ProvideBlockProductionCost::block_cost(
+                &para_id,
+            );
+        // Check if we can withdraw
+        let remaining_block_credits_to_pay =
+            u128::from(remaining_block_credits).saturating_mul(block_production_costs);
+        let remaining_to_pay = remaining_block_credits_to_pay;
+        // This should take into account whether we tank goes below ED
+        // The true refers to keepAlive
+        Balances::can_withdraw(
+            &pallet_services_payment::Pallet::<Runtime>::parachain_tank(para_id),
+            remaining_to_pay,
+        )
+        .into_result(true)?;
+        // TODO: Have proper weight
+        Ok(Weight::zero())
+    }
+}
+
+impl<AC> RemoveParaIdsWithNoCredits<BalanceOf<Runtime>, AC> for RemoveParaIdsWithNoCreditsImpl {
+    fn pre_assignment_remove_para_ids_with_no_credits(
         para_ids: &mut Vec<ParaId>,
         currently_assigned: &BTreeSet<ParaId>,
     ) {
         let blocks_per_session = Period::get();
-
         para_ids.retain(|para_id| {
-            // If the para has been assigned collators for this session it must have enough block credits
-            // for the current and the next session.
-            let block_credits_needed = if currently_assigned.contains(para_id) {
-                blocks_per_session * 2
-            } else {
-                blocks_per_session
-            };
-
-            // Check if the container chain has enough credits for producing blocks
-            let free_block_credits = pallet_services_payment::BlockProductionCredits::<Runtime>::get(para_id)
-                .unwrap_or_default();
-
-            // Check if the container chain has enough credits for a session assignments
-            let free_session_credits = pallet_services_payment::CollatorAssignmentCredits::<Runtime>::get(para_id)
-                .unwrap_or_default();
-
-            // If para's max tip is set it should have enough to pay for one assignment with tip
-            let max_tip = pallet_services_payment::MaxTip::<Runtime>::get(para_id).unwrap_or_default() ;
-
-            // Return if we can survive with free credits
-            if free_block_credits >= block_credits_needed && free_session_credits >= 1 {
-                // Max tip should always be checked, as it can be withdrawn even if free credits were used
-                return Balances::can_withdraw(&pallet_services_payment::Pallet::<Runtime>::parachain_tank(*para_id), max_tip).into_result(true).is_ok()
-            }
-
-            let remaining_block_credits = block_credits_needed.saturating_sub(free_block_credits);
-            let remaining_session_credits = 1u32.saturating_sub(free_session_credits);
-
-            let (block_production_costs, _) = <Runtime as pallet_services_payment::Config>::ProvideBlockProductionCost::block_cost(para_id);
-            let (collator_assignment_costs, _) = <Runtime as pallet_services_payment::Config>::ProvideCollatorAssignmentCost::collator_assignment_cost(para_id);
-            // let's check if we can withdraw
-            let remaining_block_credits_to_pay = u128::from(remaining_block_credits).saturating_mul(block_production_costs);
-            let remaining_session_credits_to_pay = u128::from(remaining_session_credits).saturating_mul(collator_assignment_costs);
-
-            let remaining_to_pay = remaining_block_credits_to_pay.saturating_add(remaining_session_credits_to_pay).saturating_add(max_tip);
-
-            // This should take into account whether we tank goes below ED
-            // The true refers to keepAlive
-            Balances::can_withdraw(&pallet_services_payment::Pallet::<Runtime>::parachain_tank(*para_id), remaining_to_pay).into_result(true).is_ok()
+            with_transaction(|| {
+                let max_tip =
+                    pallet_services_payment::MaxTip::<Runtime>::get(para_id).unwrap_or_default();
+                TransactionOutcome::Rollback(Self::charge_para_ids_internal(
+                    blocks_per_session,
+                    *para_id,
+                    currently_assigned,
+                    &Some(max_tip),
+                ))
+            })
+            .is_ok()
         });
+    }
+
+    fn post_assignment_remove_para_ids_with_no_credits(
+        current_assigned: &BTreeSet<ParaId>,
+        new_assigned: &mut BTreeMap<ParaId, Vec<AC>>,
+        maybe_tip: &Option<BalanceOf<Runtime>>,
+    ) -> Weight {
+        let blocks_per_session = Period::get();
+        let mut total_weight = Weight::zero();
+        new_assigned.retain(|&para_id, collators| {
+            // Short-circuit in case collators are empty
+            if collators.is_empty() {
+                return true;
+            }
+            with_storage_layer(|| {
+                Self::charge_para_ids_internal(
+                    blocks_per_session,
+                    para_id,
+                    current_assigned,
+                    maybe_tip,
+                )
+            })
+            .inspect(|weight| {
+                total_weight += *weight;
+            })
+            .is_ok()
+        });
+        total_weight
     }
 
     /// Make those para ids valid by giving them enough credits, for benchmarking.
@@ -895,7 +973,6 @@ impl pallet_collator_assignment::Config for Runtime {
     type GetRandomnessForNextBlock = BabeGetRandomnessForNextBlock;
     type RemoveInvulnerables = RemoveInvulnerablesImpl;
     type RemoveParaIdsWithNoCredits = RemoveParaIdsWithNoCreditsImpl;
-    type CollatorAssignmentHook = ServicesPayment;
     type CollatorAssignmentTip = ServicesPayment;
     type Currency = Balances;
     type ForceEmptyOrchestrator = ConstBool<false>;

--- a/solo-chains/runtime/dancelight/src/lib.rs
+++ b/solo-chains/runtime/dancelight/src/lib.rs
@@ -20,6 +20,7 @@
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit.
 #![recursion_limit = "512"]
 
+use frame_support::storage::{with_storage_layer, with_transaction};
 // Fix compile error in impl_runtime_weights! macro
 use {
     authority_discovery_primitives::AuthorityId as AuthorityDiscoveryId,
@@ -599,11 +600,12 @@ parameter_types! {
 #[cfg(feature = "runtime-benchmarks")]
 pub struct TreasuryBenchmarkHelper<T>(PhantomData<T>);
 
-#[cfg(feature = "runtime-benchmarks")]
-use frame_support::traits::Currency;
+use frame_support::traits::{ExistenceRequirement, OnUnbalanced, WithdrawReasons};
+use pallet_services_payment::BalanceOf;
 #[cfg(feature = "runtime-benchmarks")]
 use pallet_treasury::ArgumentsFactory;
 use runtime_parachains::configuration::HostConfiguration;
+use sp_runtime::{DispatchError, TransactionOutcome};
 
 #[cfg(feature = "runtime-benchmarks")]
 impl<T> ArgumentsFactory<(), T::AccountId> for TreasuryBenchmarkHelper<T>
@@ -3186,54 +3188,127 @@ impl frame_support::traits::Randomness<Hash, BlockNumber> for BabeCurrentBlockRa
 
 pub struct RemoveParaIdsWithNoCreditsImpl;
 
-impl RemoveParaIdsWithNoCredits for RemoveParaIdsWithNoCreditsImpl {
-    fn remove_para_ids_with_no_credits(
+impl RemoveParaIdsWithNoCreditsImpl {
+    fn charge_para_ids_internal(
+        blocks_per_session: BlockNumber,
+        para_id: ParaId,
+        currently_assigned: &BTreeSet<ParaId>,
+        maybe_tip: &Option<BalanceOf<Runtime>>,
+    ) -> Result<Weight, DispatchError> {
+        use frame_support::traits::Currency;
+        type ServicePaymentCurrency = <Runtime as pallet_services_payment::Config>::Currency;
+
+        // Check if the container chain has enough credits for a session assignments
+        let maybe_assignment_imbalance =
+            if  pallet_services_payment::Pallet::<Runtime>::burn_collator_assignment_free_credit_for_para(&para_id).is_err() {
+                let (amount_to_charge, _weight) =
+                    <Runtime as pallet_services_payment::Config>::ProvideCollatorAssignmentCost::collator_assignment_cost(&para_id);
+                Some(<ServicePaymentCurrency as Currency<AccountId>>::withdraw(
+                    &pallet_services_payment::Pallet::<Runtime>::parachain_tank(para_id),
+                    amount_to_charge,
+                    WithdrawReasons::FEE,
+                    ExistenceRequirement::KeepAlive,
+                )?)
+            } else {
+                None
+            };
+
+        if let Some(tip) = maybe_tip {
+            if let Err(e) = pallet_services_payment::Pallet::<Runtime>::charge_tip(&para_id, tip) {
+                // Return assignment imbalance to tank on error
+                if let Some(assignment_imbalance) = maybe_assignment_imbalance {
+                    <Runtime as pallet_services_payment::Config>::Currency::resolve_creating(
+                        &pallet_services_payment::Pallet::<Runtime>::parachain_tank(para_id),
+                        assignment_imbalance,
+                    );
+                }
+                return Err(e);
+            }
+        }
+
+        if let Some(assignment_imbalance) = maybe_assignment_imbalance {
+            <Runtime as pallet_services_payment::Config>::OnChargeForCollatorAssignment::on_unbalanced(assignment_imbalance);
+        }
+
+        // If the para has been assigned collators for this session it must have enough block credits
+        // for the current and the next session.
+        let block_credits_needed = if currently_assigned.contains(&para_id) {
+            blocks_per_session * 2
+        } else {
+            blocks_per_session
+        };
+        // Check if the container chain has enough credits for producing blocks
+        let free_block_credits =
+            pallet_services_payment::BlockProductionCredits::<Runtime>::get(para_id)
+                .unwrap_or_default();
+        let remaining_block_credits = block_credits_needed.saturating_sub(free_block_credits);
+        let (block_production_costs, _) =
+            <Runtime as pallet_services_payment::Config>::ProvideBlockProductionCost::block_cost(
+                &para_id,
+            );
+        // Check if we can withdraw
+        let remaining_block_credits_to_pay =
+            u128::from(remaining_block_credits).saturating_mul(block_production_costs);
+        let remaining_to_pay = remaining_block_credits_to_pay;
+        // This should take into account whether we tank goes below ED
+        // The true refers to keepAlive
+        Balances::can_withdraw(
+            &pallet_services_payment::Pallet::<Runtime>::parachain_tank(para_id),
+            remaining_to_pay,
+        )
+        .into_result(true)?;
+        // TODO: Have proper weight
+        Ok(Weight::zero())
+    }
+}
+
+impl<AC> RemoveParaIdsWithNoCredits<BalanceOf<Runtime>, AC> for RemoveParaIdsWithNoCreditsImpl {
+    fn pre_assignment_remove_para_ids_with_no_credits(
         para_ids: &mut Vec<ParaId>,
         currently_assigned: &BTreeSet<ParaId>,
     ) {
         let blocks_per_session = EpochDurationInBlocks::get();
-
         para_ids.retain(|para_id| {
-            // If the para has been assigned collators for this session it must have enough block credits
-            // for the current and the next session.
-            let block_credits_needed = if currently_assigned.contains(para_id) {
-                blocks_per_session * 2
-            } else {
-                blocks_per_session
-            };
-
-            // Check if the container chain has enough credits for producing blocks
-            let free_block_credits = pallet_services_payment::BlockProductionCredits::<Runtime>::get(para_id)
-                .unwrap_or_default();
-
-            // Check if the container chain has enough credits for a session assignments
-            let free_session_credits = pallet_services_payment::CollatorAssignmentCredits::<Runtime>::get(para_id)
-                .unwrap_or_default();
-
-            // If para's max tip is set it should have enough to pay for one assignment with tip
-            let max_tip = pallet_services_payment::MaxTip::<Runtime>::get(para_id).unwrap_or_default() ;
-
-            // Return if we can survive with free credits
-            if free_block_credits >= block_credits_needed && free_session_credits >= 1 {
-                // Max tip should always be checked, as it can be withdrawn even if free credits were used
-                return Balances::can_withdraw(&pallet_services_payment::Pallet::<Runtime>::parachain_tank(*para_id), max_tip).into_result(true).is_ok()
-            }
-
-            let remaining_block_credits = block_credits_needed.saturating_sub(free_block_credits);
-            let remaining_session_credits = 1u32.saturating_sub(free_session_credits);
-
-            let (block_production_costs, _) = <Runtime as pallet_services_payment::Config>::ProvideBlockProductionCost::block_cost(para_id);
-            let (collator_assignment_costs, _) = <Runtime as pallet_services_payment::Config>::ProvideCollatorAssignmentCost::collator_assignment_cost(para_id);
-            // let's check if we can withdraw
-            let remaining_block_credits_to_pay = u128::from(remaining_block_credits).saturating_mul(block_production_costs);
-            let remaining_session_credits_to_pay = u128::from(remaining_session_credits).saturating_mul(collator_assignment_costs);
-
-            let remaining_to_pay = remaining_block_credits_to_pay.saturating_add(remaining_session_credits_to_pay).saturating_add(max_tip);
-
-            // This should take into account whether we tank goes below ED
-            // The true refers to keepAlive
-            Balances::can_withdraw(&pallet_services_payment::Pallet::<Runtime>::parachain_tank(*para_id), remaining_to_pay).into_result(true).is_ok()
+            with_transaction(|| {
+                let max_tip =
+                    pallet_services_payment::MaxTip::<Runtime>::get(para_id).unwrap_or_default();
+                TransactionOutcome::Rollback(Self::charge_para_ids_internal(
+                    blocks_per_session,
+                    *para_id,
+                    currently_assigned,
+                    &Some(max_tip),
+                ))
+            })
+            .is_ok()
         });
+    }
+
+    fn post_assignment_remove_para_ids_with_no_credits(
+        current_assigned: &BTreeSet<ParaId>,
+        new_assigned: &mut BTreeMap<ParaId, Vec<AC>>,
+        maybe_tip: &Option<BalanceOf<Runtime>>,
+    ) -> Weight {
+        let blocks_per_session = EpochDurationInBlocks::get();
+        let mut total_weight = Weight::zero();
+        new_assigned.retain(|&para_id, collators| {
+            // Short-circuit in case collators are empty
+            if collators.is_empty() {
+                return true;
+            }
+            with_storage_layer(|| {
+                Self::charge_para_ids_internal(
+                    blocks_per_session,
+                    para_id,
+                    current_assigned,
+                    maybe_tip,
+                )
+            })
+            .inspect(|weight| {
+                total_weight += *weight;
+            })
+            .is_ok()
+        });
+        total_weight
     }
 
     /// Make those para ids valid by giving them enough credits, for benchmarking.
@@ -3323,7 +3398,6 @@ impl pallet_collator_assignment::Config for Runtime {
     type GetRandomnessForNextBlock = BabeGetRandomnessForNextBlock;
     type RemoveInvulnerables = ();
     type RemoveParaIdsWithNoCredits = RemoveParaIdsWithNoCreditsImpl;
-    type CollatorAssignmentHook = ServicesPayment;
     type CollatorAssignmentTip = ServicesPayment;
     type Currency = Balances;
     type ForceEmptyOrchestrator = ConstBool<true>;


### PR DESCRIPTION
# Description
Combine `RemoveParaIdsWithNoCredit` and `CollatorAssignmentHook` in one trait with two methods.

Both method executes same logic. Only difference being `pre_assignment_*` method always rollback while `post_assignment_*` only rollback in case it errors out.

# Note
Naming and tests are still remaining. Just want to get some early feedback on overall design.