### PR TITLE
Increase setMaxParachainCoresPercentage in zombie_tanssi_relay

### DIFF
--- a/test/suites/one-node/test_tanssi_one_node.ts
+++ b/test/suites/one-node/test_tanssi_one_node.ts
@@ -53,7 +53,7 @@ describeSuite({
                 const tx1 = paraApi.tx.configuration.setMinOrchestratorCollators(1);
                 const tx2 = paraApi.tx.configuration.setMaxOrchestratorCollators(1);
                 const tx3 = paraApi.tx.configuration.setFullRotationPeriod(0);
-                const tx123 = await paraApi.tx.utility.batchAll([tx1, tx2, tx3]);
+                const tx123 = paraApi.tx.utility.batchAll([tx1, tx2, tx3]);
                 await signAndSendAndInclude(paraApi.tx.sudo.sudo(tx123), alice);
             },
         });

--- a/test/suites/parathreads/test_tanssi_parathreads.ts
+++ b/test/suites/parathreads/test_tanssi_parathreads.ts
@@ -154,7 +154,7 @@ describeSuite({
             test: async function () {
                 const keyring = new Keyring({ type: "sr25519" });
                 const alice = keyring.addFromUri("//Alice", { name: "Alice default" });
-                const tx4 = await paraApi.tx.configuration.setFullRotationPeriod(0);
+                const tx4 = paraApi.tx.configuration.setFullRotationPeriod(0);
 
                 const tx = paraApi.tx.sudo.sudo(
                     paraApi.tx.xcmCoreBuyer.setRelayXcmWeightConfig({

--- a/test/suites/rotation-para/test_rotation.ts
+++ b/test/suites/rotation-para/test_rotation.ts
@@ -95,10 +95,10 @@ describeSuite({
                 const keyring = new Keyring({ type: "sr25519" });
                 const alice = keyring.addFromUri("//Alice", { name: "Alice default" });
 
-                const tx1 = await paraApi.tx.configuration.setCollatorsPerContainer(1);
-                const tx2 = await paraApi.tx.configuration.setMinOrchestratorCollators(1);
-                const tx3 = await paraApi.tx.configuration.setMaxOrchestratorCollators(1);
-                const tx4 = await paraApi.tx.configuration.setFullRotationPeriod(5);
+                const tx1 = paraApi.tx.configuration.setCollatorsPerContainer(1);
+                const tx2 = paraApi.tx.configuration.setMinOrchestratorCollators(1);
+                const tx3 = paraApi.tx.configuration.setMaxOrchestratorCollators(1);
+                const tx4 = paraApi.tx.configuration.setFullRotationPeriod(5);
                 const tx1234 = paraApi.tx.utility.batchAll([tx1, tx2, tx3, tx4]);
                 await signAndSendAndInclude(paraApi.tx.sudo.sudo(tx1234), alice);
             },

--- a/test/suites/zombie-tanssi-relay/test-tanssi-relay.ts
+++ b/test/suites/zombie-tanssi-relay/test-tanssi-relay.ts
@@ -66,6 +66,21 @@ describeSuite({
         });
 
         it({
+            id: "T02",
+            title: "Set config params",
+            test: async function () {
+                const keyring = new Keyring({ type: "sr25519" });
+                const alice = keyring.addFromUri("//Alice", { name: "Alice default" });
+
+                const tx1 = relayApi.tx.collatorConfiguration.setFullRotationPeriod(5);
+                const fillAmount = 990_000_000; // equal to 99% Perbill
+                const tx2 = relayApi.tx.collatorConfiguration.setMaxParachainCoresPercentage(fillAmount);
+                const txBatch = relayApi.tx.utility.batchAll([tx1, tx2]);
+                await signAndSendAndInclude(relayApi.tx.sudo.sudo(txBatch), alice);
+            },
+        });
+
+        it({
             id: "T03",
             timeout: 600000,
             title: "Test assignation did not change",


### PR DESCRIPTION
* setMaxParachainCoresPercentage to 99%. With the default value of 60% there are only 2 available cores for parachains, we need 3.
* setFullRotationPeriod(5) was already the default value, this is just to make it explicit.
* Remove some unneded awaits