### PR TITLE
add workflow trigger for bridge e2e tests

### DIFF
--- a/.github/workflow-templates/zombienet-tests/action.yml
+++ b/.github/workflow-templates/zombienet-tests/action.yml
@@ -22,22 +22,9 @@ runs:
         node-version: 22.x
         cache: "pnpm"
 
-    - name: "Download binaries"
-      uses: actions/download-artifact@v4
-      with:
-        name: binaries
-        path: target/release
-
     - name: "Run zombie test"
       shell: bash
       run: |
-        chmod uog+x target/release/tanssi-node
-        chmod uog+x target/release/tanssi-relay
-        chmod uog+x target/release/tanssi-relay-prepare-worker
-        chmod uog+x target/release/tanssi-relay-execute-worker
-        chmod uog+x target/release/container-chain-simple-node
-        chmod uog+x target/release/container-chain-frontier-node
-
         cd test
         pnpm install
 

--- a/.github/workflows/e2e-test-bridge.yml
+++ b/.github/workflows/e2e-test-bridge.yml
@@ -100,7 +100,7 @@ jobs:
               with:
                 run_id: ${{ steps.retrieve-run-id.outputs.run_id }}
                 name: binaries
-                path: binaries
+                path: target/release
                 search_artifacts: true
             - name: "Make binaries executable"
               shell: bash

--- a/.github/workflows/e2e-test-bridge.yml
+++ b/.github/workflows/e2e-test-bridge.yml
@@ -90,11 +90,15 @@ jobs:
                 name: binaries
                 path: binaries
                 search_artifacts: true
-            - name: Upload binaires
-              uses: actions/upload-artifact@v4
-              with:
-                  name: binaries
-                  path: binaries
+            - name: "Make binaries executable"
+              shell: bash
+              run: |
+                chmod uog+x target/release/tanssi-node
+                chmod uog+x target/release/tanssi-relay
+                chmod uog+x target/release/tanssi-relay-prepare-worker
+                chmod uog+x target/release/tanssi-relay-execute-worker
+                chmod uog+x target/release/container-chain-simple-node
+                chmod uog+x target/release/container-chain-frontier-node
             - name: Run Zombienet Test zombie_tanssi_relay_eth_bridge
               uses: ./.github/workflow-templates/zombienet-tests
               with:

--- a/.github/workflows/e2e-test-bridge.yml
+++ b/.github/workflows/e2e-test-bridge.yml
@@ -12,6 +12,8 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v4
+              with:
+                ref: ${{ github.event.pull_request.head.sha }}
             - name: Check g++
               id: setup_g_plusplus
               run: |

--- a/.github/workflows/e2e-test-bridge.yml
+++ b/.github/workflows/e2e-test-bridge.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: [CI]
     types: 
-    - in_progress
+    - requested
 
 jobs:
     e2e-bridge-test:

--- a/.github/workflows/e2e-test-bridge.yml
+++ b/.github/workflows/e2e-test-bridge.yml
@@ -90,7 +90,7 @@ jobs:
                 name: binaries
                 path: binaries
                 search_artifacts: true
-            - name: Upload runtimes
+            - name: Upload binaires
               uses: actions/upload-artifact@v4
               with:
                   name: binaries

--- a/.github/workflows/e2e-test-bridge.yml
+++ b/.github/workflows/e2e-test-bridge.yml
@@ -120,3 +120,5 @@ jobs:
               with:
                 sha: ${{ steps.sharef.outputs.sha }}
                 token: ${{ secrets.GITHUB_TOKEN }}
+                name: Bridge e2e test
+                conclusion: ${{ job.status }}

--- a/.github/workflows/e2e-test-bridge.yml
+++ b/.github/workflows/e2e-test-bridge.yml
@@ -25,6 +25,8 @@ jobs:
                   fi
             - name: Checkout
               uses: actions/checkout@v4
+              with:
+                ref: ${{ needs.set-tags.outputs.git_ref }}
             - name: Check g++
               id: setup_g_plusplus
               run: |
@@ -88,3 +90,13 @@ jobs:
                 name: binaries
                 path: target/release
                 search_artifacts: true
+            - name: "Make executables"
+              run: |
+                  chmod uog+x target/release/tanssi-node
+                  chmod uog+x target/release/tanssi-relay
+                  chmod uog+x target/release/tanssi-relay-execute-worker
+                  chmod uog+x target/release/tanssi-relay-prepare-worker
+            - name: Run Zombienet Test zombie_tanssi_relay_eth_bridge
+              uses: ./.github/workflow-templates/zombienet-tests
+              with:
+                test_name: zombie_tanssi_relay_eth_bridge

--- a/.github/workflows/e2e-test-bridge.yml
+++ b/.github/workflows/e2e-test-bridge.yml
@@ -88,14 +88,13 @@ jobs:
               with:
                 run_id: ${{ steps.retrieve-run-id.outputs.run_id }}
                 name: binaries
-                path: target/release
+                path: binaries
                 search_artifacts: true
-            - name: "Make executables"
-              run: |
-                  chmod uog+x target/release/tanssi-node
-                  chmod uog+x target/release/tanssi-relay
-                  chmod uog+x target/release/tanssi-relay-execute-worker
-                  chmod uog+x target/release/tanssi-relay-prepare-worker
+            - name: Upload runtimes
+              uses: actions/upload-artifact@v4
+              with:
+                  name: binaries
+                  path: binaries
             - name: Run Zombienet Test zombie_tanssi_relay_eth_bridge
               uses: ./.github/workflow-templates/zombienet-tests
               with:

--- a/.github/workflows/e2e-test-bridge.yml
+++ b/.github/workflows/e2e-test-bridge.yml
@@ -3,17 +3,28 @@ name: Bridge e2e test
 on:
   workflow_run:
     workflows: [CI]
-    types: 
-    - requested
+    branches: [master]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "Run id from which artifacts are taken"
+        required: true
 
 jobs:
     e2e-bridge-test:
         runs-on: self-hosted
         steps:
+            - name: Retrieve run id
+              id: retrieve-run-id
+              run: |
+                  if [[ -n "${{ github.event_name == 'workflow_dispatch' }}" ]]; then
+                    echo "run_id=${{ github.event.inputs.run_id }}" >> $GITHUB_OUTPUT
+                  else
+                    echo "run_id=${{ github.event.workflow_run.id }}" >> $GITHUB_OUTPUT
+                  fi
             - name: Checkout
               uses: actions/checkout@v4
-              with:
-                ref: ${{ github.event.pull_request.head.sha }}
             - name: Check g++
               id: setup_g_plusplus
               run: |
@@ -73,7 +84,7 @@ jobs:
             - name: Download build artifact from triggered workflow
               uses: dawidd6/action-download-artifact@v2
               with:
-                run_id: ${{ github.event.workflow_run.id }}
+                run_id: ${{ steps.retrieve-run-id.outputs.run_id }}
                 name: binaries
                 path: target/release
                 search_artifacts: true

--- a/.github/workflows/e2e-test-bridge.yml
+++ b/.github/workflows/e2e-test-bridge.yml
@@ -23,6 +23,18 @@ jobs:
                   else
                     echo "run_id=${{ github.event.workflow_run.id }}" >> $GITHUB_OUTPUT
                   fi
+            - name: Recognize sha ref
+              id: sharef
+              run: |
+                if [ ${{ github.event_name }} == 'pull_request' ]
+                then
+                  echo "::set-output name=sha::$(echo ${{github.event.pull_request.head.sha}})"
+                elif [ ${{ github.event_name }} == 'workflow_run' ]
+                then
+                  echo "::set-output name=sha::$(echo ${{github.event.workflow_run.head_sha}})"
+                else
+                  echo "::set-output name=sha::$(echo $GITHUB_SHA)"
+                fi
             - name: Checkout
               uses: actions/checkout@v4
               with:
@@ -103,3 +115,8 @@ jobs:
               uses: ./.github/workflow-templates/zombienet-tests
               with:
                 test_name: zombie_tanssi_relay_eth_bridge
+            - name: Commit Action Status
+              uses: LouisBrunner/checks-action@v1.1.1
+              with:
+                sha: ${{ steps.sharef.outputs.sha }}
+                token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/e2e-test-bridge.yml
+++ b/.github/workflows/e2e-test-bridge.yml
@@ -37,8 +37,6 @@ jobs:
                 fi
             - name: Checkout
               uses: actions/checkout@v4
-              with:
-                ref: ${{ needs.set-tags.outputs.git_ref }}
             - name: Check g++
               id: setup_g_plusplus
               run: |

--- a/.github/workflows/e2e-test-bridge.yml
+++ b/.github/workflows/e2e-test-bridge.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: [CI]
     branches: [girazoki-add-bridge-e2e-testing]
-    types: [completed]
+    types: [in_progress]
 
 jobs:
     e2e-bridge-test:

--- a/.github/workflows/e2e-test-bridge.yml
+++ b/.github/workflows/e2e-test-bridge.yml
@@ -3,8 +3,8 @@ name: Bridge e2e test
 on:
   workflow_run:
     workflows: [CI]
-    branches: [girazoki-add-bridge-e2e-testing]
-    types: [in_progress]
+    types: 
+    - in_progress
 
 jobs:
     e2e-bridge-test:

--- a/.github/workflows/e2e-test-bridge.yml
+++ b/.github/workflows/e2e-test-bridge.yml
@@ -3,7 +3,7 @@ name: Bridge e2e test
 on:
   workflow_run:
     workflows: [CI]
-    branches: [master]
+    branches: [girazoki-add-bridge-e2e-testing]
     types: [completed]
 
 jobs:
@@ -68,3 +68,10 @@ jobs:
               id: check_date
               run: |
                 date --version
+            - name: Download build artifact from triggered workflow
+              uses: dawidd6/action-download-artifact@v2
+              with:
+                run_id: ${{ github.event.workflow_run.id }}
+                name: binaries
+                path: target/release
+                search_artifacts: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -651,6 +651,20 @@ jobs:
             uses: actions/checkout@v4
             with:
               ref: ${{ needs.set-tags.outputs.git_ref }}
+          - name: "Download binaries"
+            uses: actions/download-artifact@v4
+            with:
+              name: binaries
+              path: target/release
+          - name: "Make binaries executable"
+            shell: bash
+            run: |
+              chmod uog+x target/release/tanssi-node
+              chmod uog+x target/release/tanssi-relay
+              chmod uog+x target/release/tanssi-relay-prepare-worker
+              chmod uog+x target/release/tanssi-relay-execute-worker
+              chmod uog+x target/release/container-chain-simple-node
+              chmod uog+x target/release/container-chain-frontier-node
           - name: Run Zombienet Test ${{ matrix.test_name }}
             uses: ./.github/workflow-templates/zombienet-tests
             with:

--- a/.github/workflows/run-zombienet-tests.yml
+++ b/.github/workflows/run-zombienet-tests.yml
@@ -137,6 +137,20 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.get-tests.outputs.matrix) }}
     steps:
+      - name: "Download binaries"
+        uses: actions/download-artifact@v4
+        with:
+          name: binaries
+          path: target/release
+      - name: "Make binaries executable"
+        shell: bash
+        run: |
+          chmod uog+x target/release/tanssi-node
+          chmod uog+x target/release/tanssi-relay
+          chmod uog+x target/release/tanssi-relay-prepare-worker
+          chmod uog+x target/release/tanssi-relay-execute-worker
+          chmod uog+x target/release/container-chain-simple-node
+          chmod uog+x target/release/container-chain-frontier-node
       - name: Run Zombienet Test ${{ matrix.test_name }}
         uses: ./.github/workflow-templates/zombienet-tests
         with:

--- a/test/configs/zombieDancelightBridge.json
+++ b/test/configs/zombieDancelightBridge.json
@@ -46,12 +46,15 @@
         {
             "id": 2000,
             "chain": "dev",
+            "add_to_genesis": false,
+            "register_para": false,
+            "onboard_as_parachain": false,
             "collators": [
                 {
                     "name": "FullNode-2000",
                     "validator": false,
+                    "chain": "dev",
                     "command": "../target/release/container-chain-simple-node",
-                    "args": ["--no-hardware-benchmarks", "--database=paritydb", "--wasmtime-precompiled=wasm"],
                     "ws_port": 9949,
                     "p2p_port": 33049
                 }


### PR DESCRIPTION
Adds a job to run the  e2e bridge tests when we merge to master or when we request workflow dispatch. 

You can check it out dispatching like:

`gh workflow run "Bridge e2e test"  --ref girazoki-add-bridge-e2e-testing -f run_id=11721156969
`