### PR TITLE
remove containers from bridge tests

### DIFF
--- a/test/configs/zombieDancelightBridge.json
+++ b/test/configs/zombieDancelightBridge.json
@@ -42,25 +42,6 @@
             }
         ]
     },
-    "parachains": [
-        {
-            "id": 2000,
-            "chain": "dev",
-            "add_to_genesis": false,
-            "register_para": false,
-            "onboard_as_parachain": false,
-            "collators": [
-                {
-                    "name": "FullNode-2000",
-                    "validator": false,
-                    "chain": "dev",
-                    "command": "../target/release/container-chain-simple-node",
-                    "ws_port": 9949,
-                    "p2p_port": 33049
-                }
-            ]
-        }
-    ],
     "types": {
         "Header": {
             "number": "u64",


### PR DESCRIPTION
We had the limitation before that we could not work with moonwall + zombienet without adding containers. Now that is not the case, therefore I removed the container from the config file