### PR TITLE
Prevent std feature injection in runtime-benchmarks feature

### DIFF
--- a/pallets/external-validator-slashes/Cargo.toml
+++ b/pallets/external-validator-slashes/Cargo.toml
@@ -53,7 +53,6 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"pallet-staking/runtime-benchmarks",
-	"scale-info/std",
 	"sp-runtime/runtime-benchmarks",
 	"sp-staking/runtime-benchmarks",
 	"tp-traits/runtime-benchmarks",


### PR DESCRIPTION
# Description
There was a bug in compilation of dancelight runtime with `runtime-benchmarks` in commit f8b66f38f93dc8fb2a1bbe9d2e44d14d21cbd1ca. 

In that commit we were accidentally injecting `std` feature into `runtime-benchmarks` feature in `external-validator-slashes` pallet. This PR removes it.