### PR TITLE
Bump node and runtime versions to 0.11.0 and 1100

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1772,7 +1772,7 @@ checksum = "cd7e35aee659887cbfb97aaf227ac12cad1a9d7c71e55ff3376839ed4e282d08"
 
 [[package]]
 name = "container-chain-frontier-node"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-io 1.13.0",
  "async-trait",
@@ -1870,7 +1870,7 @@ dependencies = [
 
 [[package]]
 name = "container-chain-simple-node"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-io 1.13.0",
  "async-trait",
@@ -17334,7 +17334,7 @@ dependencies = [
 
 [[package]]
 name = "tanssi-node"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-io 1.13.0",
  "async-trait",
@@ -17435,7 +17435,7 @@ dependencies = [
 
 [[package]]
 name = "tanssi-relay"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "color-eyre",
  "polkadot-core-primitives",
@@ -17495,7 +17495,7 @@ dependencies = [
 
 [[package]]
 name = "tanssi-relay-service"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "assert_matches",
  "async-io 1.13.0",

--- a/container-chains/nodes/frontier/Cargo.toml
+++ b/container-chains/nodes/frontier/Cargo.toml
@@ -5,7 +5,7 @@ build = "build.rs"
 description = "Frontier container chain template node"
 edition = "2021"
 license = "GPL-3.0-only"
-version = "0.10.0"
+version = "0.11.0"
 
 [lints]
 workspace = true

--- a/container-chains/nodes/simple/Cargo.toml
+++ b/container-chains/nodes/simple/Cargo.toml
@@ -5,7 +5,7 @@ build = "build.rs"
 description = "Simple container-chain template node"
 edition = "2021"
 license = "GPL-3.0-only"
-version = "0.10.0"
+version = "0.11.0"
 
 [lints]
 workspace = true

--- a/container-chains/runtime-templates/frontier/src/lib.rs
+++ b/container-chains/runtime-templates/frontier/src/lib.rs
@@ -331,7 +331,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("frontier-template"),
     impl_name: create_runtime_str!("frontier-template"),
     authoring_version: 1,
-    spec_version: 1000,
+    spec_version: 1100,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/container-chains/runtime-templates/simple/src/lib.rs
+++ b/container-chains/runtime-templates/simple/src/lib.rs
@@ -225,7 +225,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("container-chain-template"),
     impl_name: create_runtime_str!("container-chain-template"),
     authoring_version: 1,
-    spec_version: 1000,
+    spec_version: 1100,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -5,7 +5,7 @@ build = "build.rs"
 description = "Tanssi node implementation"
 edition = "2021"
 license = "GPL-3.0-only"
-version = "0.10.0"
+version = "0.11.0"
 
 [lints]
 workspace = true

--- a/runtime/dancebox/src/lib.rs
+++ b/runtime/dancebox/src/lib.rs
@@ -247,7 +247,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("dancebox"),
     impl_name: create_runtime_str!("dancebox"),
     authoring_version: 1,
-    spec_version: 1000,
+    spec_version: 1100,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/flashbox/src/lib.rs
+++ b/runtime/flashbox/src/lib.rs
@@ -223,7 +223,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("flashbox"),
     impl_name: create_runtime_str!("flashbox"),
     authoring_version: 1,
-    spec_version: 1000,
+    spec_version: 1100,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/solo-chains/node/tanssi-relay-service/Cargo.toml
+++ b/solo-chains/node/tanssi-relay-service/Cargo.toml
@@ -4,7 +4,7 @@ authors = { workspace = true }
 description = "Utils to tie different Tanssi components together and allow instantiation of a node."
 edition = "2021"
 license = "GPL-3.0-only"
-version = "0.10.0"
+version = "0.11.0"
 
 [lints]
 workspace = true

--- a/solo-chains/node/tanssi-relay/Cargo.toml
+++ b/solo-chains/node/tanssi-relay/Cargo.toml
@@ -5,7 +5,7 @@ description = "Implementation of a `https://tanssi.network` node in Rust based o
 edition = "2021"
 license = "GPL-3.0-only"
 readme = "README.md"
-version = "0.10.0"
+version = "0.11.0"
 
 [[bin]]
 name = "tanssi-relay"

--- a/solo-chains/runtime/dancelight/src/lib.rs
+++ b/solo-chains/runtime/dancelight/src/lib.rs
@@ -186,7 +186,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("dancelight"),
     impl_name: create_runtime_str!("tanssi-dancelight-v2.0"),
     authoring_version: 0,
-    spec_version: 1000,
+    spec_version: 1100,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 26,


### PR DESCRIPTION
This PR bumps node version to `0.11.0` and runtime spec version to `1100`.