### PR TITLE
Fix bridge e2e test

### DIFF
--- a/test/suites/zombie_tanssi_relay_eth_bridge/test_zombie_tanssi_relay_eth_bridge.ts
+++ b/test/suites/zombie_tanssi_relay_eth_bridge/test_zombie_tanssi_relay_eth_bridge.ts
@@ -196,7 +196,21 @@ describeSuite({
                 }
 
                 // wait some time for the data to be relayed
-                await waitSessions(context, relayApi, 2, null, "Tanssi-relay");
+                await waitSessions(
+                    context,
+                    relayApi,
+                    6,
+                    async () => {
+                        try {
+                            const externalValidators = await relayApi.query.externalValidators.externalValidators();
+                            expect(externalValidators).to.not.deep.eq(externalValidatorsBefore);
+                        } catch (error) {
+                            return false;
+                        }
+                        return true;
+                    },
+                    "Tanssi-relay"
+                );
 
                 const externalValidators = await relayApi.query.externalValidators.externalValidators();
                 expect(externalValidators).to.not.deep.eq(externalValidatorsBefore);


### PR DESCRIPTION
# Description
This PR fixes the bridge e2e test by waiting for more sessions before comparing current validators and previous validators. 
Also, `earlyExit` is configured such that if the validators change before, the `waitSessions` function can return early.