### PR TITLE
Make download eth client test script compatible with macos

### DIFF
--- a/test/scripts/download-ethereum-client-test-files.sh
+++ b/test/scripts/download-ethereum-client-test-files.sh
@@ -19,6 +19,6 @@ fi
 mkdir -p tmp
 wget -O - tmp/ethereum_client_test https://github.com/moondance-labs/polkadot-sdk/archive/$polkadot_release.tar.gz | tar -xz --strip=6 "polkadot-sdk-$polkadot_release/bridges/snowbridge/pallets/ethereum-client/tests/fixtures"
 # remove for a clean move
-rm -rf  tmp/ethereum_client_test
-mv  -u  fixtures tmp/ethereum_client_test
+rm -rf tmp/ethereum_client_test
+mv fixtures tmp/ethereum_client_test
 echo $polkadot_release > tmp/ethereum_client_test/latest_version.txt


### PR DESCRIPTION
# Description

Our current `download-ethereum-client-test-files.sh` is using `mv -u` which is not macos compatible so I modified it to simply use `mv` since we are removing the dest folder and don't make sense to use the `-u` flag