### PR TITLE
Fix off-by-one in inclusion smoke test

### DIFF
--- a/test/suites/smoke-test-dancelight/test-para-inclusion.ts
+++ b/test/suites/smoke-test-dancelight/test-para-inclusion.ts
@@ -127,9 +127,10 @@ describeSuite({
 
                         const parentBlockNumber = blockNumberMap.get(relayParent);
 
-                        // allowedAncestryLen = 1 means that parent + 1 == current
-                        // with allowedAncestryLen = 2, parent + allowedAncestryLen >= current
-                        // +1 because some tests fail otherwise: 1151694 vs current 1151697
+                        // allowedAncestryLen = 0 means that we only allow building on top of the parent block
+                        // allowedAncestryLen = 1 means that we allow 2 different parent blocks,
+                        // so parent + 2 >= current
+                        // In general, parent + allowedAncestryLen + 1 >= current
                         expect(
                             parentBlockNumber + allowedAncestryLen + 1,
                             `Block #${blockNum}: backed candidate for para id ${paraId} has too old relayParent: ${parentBlockNumber} vs current ${blockNum}`

--- a/test/suites/smoke-test-dancelight/test-para-inclusion.ts
+++ b/test/suites/smoke-test-dancelight/test-para-inclusion.ts
@@ -129,8 +129,9 @@ describeSuite({
 
                         // allowedAncestryLen = 1 means that parent + 1 == current
                         // with allowedAncestryLen = 2, parent + allowedAncestryLen >= current
+                        // +1 because some tests fail otherwise: 1151694 vs current 1151697
                         expect(
-                            parentBlockNumber + allowedAncestryLen,
+                            parentBlockNumber + allowedAncestryLen + 1,
                             `Block #${blockNum}: backed candidate for para id ${paraId} has too old relayParent: ${parentBlockNumber} vs current ${blockNum}`
                         ).to.be.greaterThanOrEqual(blockNum);
 


### PR DESCRIPTION
allowedAncestryLen means "how many blocks before the relay parent are allowed as well". So the max difference in block number is not `allowedAncestryLen`, but `allowedAncestryLen + 1`.