### PR TITLE
Proxy sudo validator, session-key management, and staking

### DIFF
--- a/solo-chains/runtime/dancelight/src/lib.rs
+++ b/solo-chains/runtime/dancelight/src/lib.rs
@@ -841,6 +841,7 @@ pub enum ProxyType {
     Auction,
     OnDemandOrdering,
     SudoRegistrar,
+    SudoValidatorManagement,
 }
 impl Default for ProxyType {
     fn default() -> Self {
@@ -910,6 +911,16 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
                             | &RuntimeCall::ContainerRegistrar(..)
                             | &RuntimeCall::Paras(..)
                             | &RuntimeCall::ParasSudoWrapper(..)
+                    )
+                }
+                _ => false,
+            },
+            ProxyType::SudoValidatorManagement => match c {
+                RuntimeCall::Sudo(pallet_sudo::Call::sudo { call: ref x }) => {
+                    matches!(
+                        x.as_ref(),
+                        &RuntimeCall::ExternalValidators(..)
+                            | &RuntimeCall::ExternalValidatorSlashes(..)
                     )
                 }
                 _ => false,

--- a/test/suites/dev-tanssi-relay/proxy/test-proxy-validator-management.ts
+++ b/test/suites/dev-tanssi-relay/proxy/test-proxy-validator-management.ts
@@ -1,0 +1,94 @@
+import "@tanssi/api-augment";
+import { describeSuite, expect, beforeAll } from "@moonwall/cli";
+import { KeyringPair } from "@moonwall/util";
+import { ApiPromise } from "@polkadot/api";
+import { initializeCustomCreateBlock, jumpSessions } from "../../../util/block";
+
+describeSuite({
+    id: "DTR1201",
+    title: "Proxy test suite",
+    foundationMethods: "dev",
+    testCases: ({ it, context }) => {
+        let polkadotJs: ApiPromise;
+        let sudoAlice: KeyringPair;
+        let delegateBob: KeyringPair;
+        let charlie: KeyringPair;
+        const VALIDATOR_PROXY_INDEX = 8;
+
+        beforeAll(() => {
+            initializeCustomCreateBlock(context);
+
+            sudoAlice = context.keyring.alice;
+            delegateBob = context.keyring.bob;
+            charlie = context.keyring.charlie;
+
+            polkadotJs = context.polkadotJs();
+        });
+
+        it({
+            id: "E01",
+            title: "Can add proxy",
+            test: async function () {
+                await context.createBlock();
+
+                const tx = polkadotJs.tx.proxy.addProxy(delegateBob.address, VALIDATOR_PROXY_INDEX, 0);
+                await context.createBlock([await tx.signAsync(sudoAlice)]);
+
+                const proxies = await polkadotJs.query.proxy.proxies(sudoAlice.address);
+                expect(proxies.toJSON()[0]).to.deep.equal([
+                    {
+                        delegate: delegateBob.address,
+                        proxyType: "SudoValidatorManagement",
+                        delay: 0,
+                    },
+                ]);
+            },
+        });
+
+        it({
+            id: "E02",
+            title: "Delegated account can sudo txs in external validators",
+            test: async function () {
+                const txAddWhitelisted = polkadotJs.tx.proxy.proxy(
+                    sudoAlice.address,
+                    null,
+                    polkadotJs.tx.sudo.sudo(
+                        polkadotJs.tx.externalValidators.addWhitelisted(
+                            delegateBob.address,
+                        )
+                    )
+                );
+                await context.createBlock([await txAddWhitelisted.signAsync(delegateBob)]);
+
+                const whitelistedValidatorInfo = await polkadotJs.query.externalValidators.whitelistedValidators();
+                expect(whitelistedValidatorInfo.toHuman().includes(delegateBob.address)).to.be.true;
+            },
+        });
+
+        it({
+            id: "E02",
+            title: "Delegated account can sudo txs in external validator slashes",
+            test: async function () {
+                const txAddWhitelisted = polkadotJs.tx.proxy.proxy(
+                    sudoAlice.address,
+                    null,
+                    polkadotJs.tx.sudo.sudo(
+                        polkadotJs.tx.externalValidatorSlashes.forceInjectSlash(
+                            0,
+                            sudoAlice.address,
+                            1000,
+                        )
+                    )
+                );
+                await context.createBlock([await txAddWhitelisted.signAsync(delegateBob)]);
+
+                const DeferPeriod = (await polkadotJs.consts.externalValidatorSlashes.slashDeferDuration).toNumber();
+
+                // scheduled slashes
+                const expectedSlashes = await polkadotJs.query.externalValidatorSlashes.slashes(DeferPeriod + 1);
+                expect(expectedSlashes.length).to.be.eq(1);
+
+            },
+        });
+    },
+});

--- a/test/suites/dev-tanssi-relay/proxy/test-session-keys-management.ts
+++ b/test/suites/dev-tanssi-relay/proxy/test-session-keys-management.ts
@@ -1,0 +1,77 @@
+import "@polkadot/api-augment";
+import { beforeAll, describeSuite, expect } from "@moonwall/cli";
+import { ApiPromise } from "@polkadot/api";
+
+describeSuite({
+    id: "DT0601",
+    title: "Proxy test suite - ProxyType::SessionKeyManagement",
+    foundationMethods: "dev",
+    testCases: ({ it, context }) => {
+        let polkadotJs: ApiPromise;
+        const sessionKeysManagementProxy = 9;
+        const someKeys = "0x00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF";
+
+        beforeAll(() => {
+            polkadotJs = context.polkadotJs();
+        });
+
+        it({
+            id: "E01",
+            title: "Delegate account can manage keys",
+            test: async function () {
+                const delegator_alice = context.keyring.alice;
+                const delegate_charlie = context.keyring.charlie;
+
+                let tx = polkadotJs.tx.proxy.addProxy(delegate_charlie.address, sessionKeysManagementProxy, 0);
+                await context.createBlock([await tx.signAsync(delegator_alice)]);
+
+                let events = await polkadotJs.query.system.events();
+                let ev1 = events.filter((a) => {
+                    return a.event.method == "ProxyAdded";
+                });
+                expect(ev1.length).to.be.equal(1);
+
+                await context.createBlock();
+
+                tx = polkadotJs.tx.proxy.proxy(
+                    delegator_alice.address,
+                    null,
+                    polkadotJs.tx.session.setKeys(someKeys, "0x")
+                );
+                await context.createBlock([await tx.signAsync(delegate_charlie)]);
+                events = await polkadotJs.query.system.events();
+                ev1 = events.filter((a) => {
+                    return a.event.method == "ProxyExecuted";
+                });
+                expect(ev1.length).to.be.equal(1);
+                expect(ev1[0].event.data[0].toString()).to.be.eq("Ok");
+            },
+        });
+
+        it({
+            id: "E02",
+            title: "Non-Delegate account fails to manage other account's keys",
+            test: async function () {
+                const alice = context.keyring.alice;
+                const non_delegate_dave = context.keyring.dave;
+
+                await context.createBlock();
+
+                const tx = polkadotJs.tx.proxy.proxy(
+                    alice.address,
+                    null,
+                    polkadotJs.tx.session.setKeys(
+                        "0x00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF",
+                        "0x"
+                    )
+                );
+                await context.createBlock([await tx.signAsync(non_delegate_dave)]);
+                const events = await polkadotJs.query.system.events();
+                const ev1 = events.filter((a) => {
+                    return a.event.method == "ProxyExecuted";
+                });
+                expect(ev1.length).to.be.equal(0);
+            },
+        });
+    },
+});


### PR DESCRIPTION
Adds the following proxies:
- **sudoValidatorManagement**: to be able to handle through sudo externalValidators and slashes
- **SessionKeyManagement": to be able to handle session-keys through a proxy
- **Staking**: to be able to handle staking operations through session-keys