### PR TITLE
Benchmark slashes queue processing

### DIFF
--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_external_validator_slashes.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_external_validator_slashes.rs
@@ -108,4 +108,37 @@ impl<T: frame_system::Config> pallet_external_validator_slashes::WeightInfo for 
 			.saturating_add(T::DbWeight::get().reads(3_u64))
 			.saturating_add(T::DbWeight::get().writes(5_u64))
 	}
+
+
+	/// Storage: `ExternalValidators::ActiveEra` (r:1 w:0)
+	/// Proof: `ExternalValidators::ActiveEra` (`max_values`: Some(1), `max_size`: Some(13), added: 508, mode: `MaxEncodedLen`)
+	/// Storage: `ExternalValidatorSlashes::UnreportedSlashesQueue` (r:1 w:1)
+	/// Proof: `ExternalValidatorSlashes::UnreportedSlashesQueue` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `Timestamp::Now` (r:1 w:0)
+	/// Proof: `Timestamp::Now` (`max_values`: Some(1), `max_size`: Some(8), added: 503, mode: `MaxEncodedLen`)
+	/// Storage: `EthereumSystem::Channels` (r:1 w:0)
+	/// Proof: `EthereumSystem::Channels` (`max_values`: None, `max_size`: Some(76), added: 2551, mode: `MaxEncodedLen`)
+	/// Storage: `MessageQueue::BookStateFor` (r:1 w:1)
+	/// Proof: `MessageQueue::BookStateFor` (`max_values`: None, `max_size`: Some(136), added: 2611, mode: `MaxEncodedLen`)
+	/// Storage: `MessageQueue::ServiceHead` (r:1 w:1)
+	/// Proof: `MessageQueue::ServiceHead` (`max_values`: Some(1), `max_size`: Some(33), added: 528, mode: `MaxEncodedLen`)
+	/// Storage: UNKNOWN KEY `0x3a72656c61795f64697370617463685f71756575655f72656d61696e696e675f` (r:0 w:1)
+	/// Proof: UNKNOWN KEY `0x3a72656c61795f64697370617463685f71756575655f72656d61696e696e675f` (r:0 w:1)
+	/// Storage: `MessageQueue::Pages` (r:0 w:1)
+	/// Proof: `MessageQueue::Pages` (`max_values`: None, `max_size`: Some(32845), added: 35320, mode: `MaxEncodedLen`)
+	/// Storage: UNKNOWN KEY `0xf5207f03cfdce586301014700e2c2593fad157e461d71fd4c1f936839a5f1f3e` (r:0 w:1)
+	/// Proof: UNKNOWN KEY `0xf5207f03cfdce586301014700e2c2593fad157e461d71fd4c1f936839a5f1f3e` (r:0 w:1)
+	/// The range of component `s` is `[1, 200]`.
+	fn process_slashes_queue(s: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `393 + s * (42 ±0)`
+		//  Estimated: `3601 + s * (42 ±0)`
+		// Minimum execution time: 46_622_000 picoseconds.
+		Weight::from_parts(72_326_163, 3601)
+			// Standard Error: 58_929
+			.saturating_add(Weight::from_parts(2_894_084, 0).saturating_mul(s.into()))
+			.saturating_add(T::DbWeight::get().reads(4_u64))
+			.saturating_add(T::DbWeight::get().writes(2_u64))
+			.saturating_add(Weight::from_parts(0, 42).saturating_mul(s.into()))
+	}
 }

--- a/pallets/external-validator-slashes/src/benchmarking.rs
+++ b/pallets/external-validator-slashes/src/benchmarking.rs
@@ -104,8 +104,8 @@ mod benchmarks {
     fn process_slashes_queue(s: Linear<1, 200>) -> Result<(), BenchmarkError> {
         let mut queue = VecDeque::new();
         let dummy = || T::AccountId::decode(&mut TrailingZeroInput::zeroes()).unwrap();
-    
-        for _ in 0..(s+1) {
+
+        for _ in 0..(s + 1) {
             queue.push_back(Slash::<T::AccountId, T::SlashId>::default_from(dummy()));
         }
 
@@ -115,11 +115,11 @@ mod benchmarks {
 
         #[block]
         {
-            processed = Pallet::<T>::process_slashes_queue(s as usize);
+            processed = Pallet::<T>::process_slashes_queue(s);
         }
 
         assert_eq!(UnreportedSlashesQueue::<T>::get().len(), 1);
-        assert_eq!(processed, s as usize);
+        assert_eq!(processed, s);
 
         Ok(())
     }

--- a/pallets/external-validator-slashes/src/benchmarking.rs
+++ b/pallets/external-validator-slashes/src/benchmarking.rs
@@ -100,6 +100,30 @@ mod benchmarks {
         Ok(())
     }
 
+    #[benchmark]
+    fn process_slashes_queue(s: Linear<1, 200>) -> Result<(), BenchmarkError> {
+        let mut queue = VecDeque::new();
+        let dummy = || T::AccountId::decode(&mut TrailingZeroInput::zeroes()).unwrap();
+    
+        for _ in 0..(s+1) {
+            queue.push_back(Slash::<T::AccountId, T::SlashId>::default_from(dummy()));
+        }
+
+        UnreportedSlashesQueue::<T>::set(queue);
+
+        let processed;
+
+        #[block]
+        {
+            processed = Pallet::<T>::process_slashes_queue(s as usize);
+        }
+
+        assert_eq!(UnreportedSlashesQueue::<T>::get().len(), 1);
+        assert_eq!(processed, s as usize);
+
+        Ok(())
+    }
+
     impl_benchmark_test_suite!(
         ExternalValidatorSlashes,
         crate::mock::new_test_ext(),

--- a/pallets/external-validator-slashes/src/lib.rs
+++ b/pallets/external-validator-slashes/src/lib.rs
@@ -350,7 +350,7 @@ pub mod pallet {
             let weight = Weight::zero();
 
             log::info!("inside on-initialize");
-            Self::process_slashes_queue_page();
+            let processed = Self::process_slashes_queue(T::QueuedSlashesProcessedPerBlock::get() as usize);
 
             // TODO: Weight
 
@@ -524,27 +524,31 @@ impl<T: Config> Pallet<T> {
         UnreportedSlashesQueue::<T>::mutate(|queue| queue.append(&mut slashes));
     }
 
-    fn process_slashes_queue_page() {
+    fn process_slashes_queue(amount: usize) -> usize {
         let mut slashes_to_send: Vec<_> = vec![];
         let era_index = T::EraIndexProvider::active_era().index;
 
         // prepare up to QueuedSlashesProcessedPerBlock slashes to be sent
-        for _ in 0..(T::QueuedSlashesProcessedPerBlock::get() as usize) {
-            let Some(slash) = UnreportedSlashesQueue::<T>::mutate(VecDeque::pop_front) else {
-                // no more slashes to process in the queue
-                break;
-            };
-
-            // TODO: check if validator.clone().encode() matches with the actual account bytes.
-            slashes_to_send.push((
-                slash.validator.clone().encode(),
-                slash.percentage.deconstruct(),
-            ));
-        }
+        UnreportedSlashesQueue::<T>::mutate(|queue| {
+            for _ in 0..amount {
+                let Some(slash) = queue.pop_front() else {
+                    // no more slashes to process in the queue
+                    break;
+                };
+    
+                // TODO: check if validator.clone().encode() matches with the actual account bytes.
+                slashes_to_send.push((
+                    slash.validator.clone().encode(),
+                    slash.percentage.deconstruct(),
+                ));
+            }
+        });
 
         if slashes_to_send.is_empty() {
-            return;
+            return 0;
         }
+
+        let slashes_count = slashes_to_send.len();
 
         // Build command with slashes.
         let command = Command::ReportSlashes {
@@ -573,6 +577,8 @@ impl<T: Config> Pallet<T> {
                 log::error!(target: "ext_validators_slashes", "OutboundQueue validation of message failed. {err:?}");
             }
         };
+
+        slashes_count
     }
 }
 

--- a/pallets/external-validator-slashes/src/weights.rs
+++ b/pallets/external-validator-slashes/src/weights.rs
@@ -56,6 +56,7 @@ pub trait WeightInfo {
 	fn cancel_deferred_slash(s: u32, ) -> Weight;
 	fn force_inject_slash() -> Weight;
 	fn root_test_send_msg_to_eth() -> Weight;
+	fn process_slashes_queue(s: u32, ) -> Weight;
 }
 
 /// Weights for pallet_external_validator_slashes using the Substrate node and recommended hardware.
@@ -102,6 +103,37 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(3_u64))
 			.saturating_add(T::DbWeight::get().writes(5_u64))
 	}
+	/// Storage: `ExternalValidators::ActiveEra` (r:1 w:0)
+	/// Proof: `ExternalValidators::ActiveEra` (`max_values`: Some(1), `max_size`: Some(13), added: 508, mode: `MaxEncodedLen`)
+	/// Storage: `ExternalValidatorSlashes::UnreportedSlashesQueue` (r:1 w:1)
+	/// Proof: `ExternalValidatorSlashes::UnreportedSlashesQueue` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `Timestamp::Now` (r:1 w:0)
+	/// Proof: `Timestamp::Now` (`max_values`: Some(1), `max_size`: Some(8), added: 503, mode: `MaxEncodedLen`)
+	/// Storage: `EthereumSystem::Channels` (r:1 w:0)
+	/// Proof: `EthereumSystem::Channels` (`max_values`: None, `max_size`: Some(76), added: 2551, mode: `MaxEncodedLen`)
+	/// Storage: `MessageQueue::BookStateFor` (r:1 w:1)
+	/// Proof: `MessageQueue::BookStateFor` (`max_values`: None, `max_size`: Some(136), added: 2611, mode: `MaxEncodedLen`)
+	/// Storage: `MessageQueue::ServiceHead` (r:1 w:1)
+	/// Proof: `MessageQueue::ServiceHead` (`max_values`: Some(1), `max_size`: Some(33), added: 528, mode: `MaxEncodedLen`)
+	/// Storage: UNKNOWN KEY `0x3a72656c61795f64697370617463685f71756575655f72656d61696e696e675f` (r:0 w:1)
+	/// Proof: UNKNOWN KEY `0x3a72656c61795f64697370617463685f71756575655f72656d61696e696e675f` (r:0 w:1)
+	/// Storage: `MessageQueue::Pages` (r:0 w:1)
+	/// Proof: `MessageQueue::Pages` (`max_values`: None, `max_size`: Some(32845), added: 35320, mode: `MaxEncodedLen`)
+	/// Storage: UNKNOWN KEY `0xf5207f03cfdce586301014700e2c2593fad157e461d71fd4c1f936839a5f1f3e` (r:0 w:1)
+	/// Proof: UNKNOWN KEY `0xf5207f03cfdce586301014700e2c2593fad157e461d71fd4c1f936839a5f1f3e` (r:0 w:1)
+	/// The range of component `s` is `[1, 200]`.
+	fn process_slashes_queue(s: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `393 + s * (42 ±0)`
+		//  Estimated: `3601 + s * (42 ±0)`
+		// Minimum execution time: 46_622_000 picoseconds.
+		Weight::from_parts(72_326_163, 3601)
+			// Standard Error: 58_929
+			.saturating_add(Weight::from_parts(2_894_084, 0).saturating_mul(s.into()))
+			.saturating_add(T::DbWeight::get().reads(4_u64))
+			.saturating_add(T::DbWeight::get().writes(2_u64))
+			.saturating_add(Weight::from_parts(0, 42).saturating_mul(s.into()))
+	}
 }
 
 // For backwards compatibility and tests
@@ -146,5 +178,38 @@ impl WeightInfo for () {
 		Weight::from_parts(1_015_195_000, 3601)
 			.saturating_add(RocksDbWeight::get().reads(3_u64))
 			.saturating_add(RocksDbWeight::get().writes(5_u64))
+	}
+
+
+	/// Storage: `ExternalValidators::ActiveEra` (r:1 w:0)
+	/// Proof: `ExternalValidators::ActiveEra` (`max_values`: Some(1), `max_size`: Some(13), added: 508, mode: `MaxEncodedLen`)
+	/// Storage: `ExternalValidatorSlashes::UnreportedSlashesQueue` (r:1 w:1)
+	/// Proof: `ExternalValidatorSlashes::UnreportedSlashesQueue` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `Timestamp::Now` (r:1 w:0)
+	/// Proof: `Timestamp::Now` (`max_values`: Some(1), `max_size`: Some(8), added: 503, mode: `MaxEncodedLen`)
+	/// Storage: `EthereumSystem::Channels` (r:1 w:0)
+	/// Proof: `EthereumSystem::Channels` (`max_values`: None, `max_size`: Some(76), added: 2551, mode: `MaxEncodedLen`)
+	/// Storage: `MessageQueue::BookStateFor` (r:1 w:1)
+	/// Proof: `MessageQueue::BookStateFor` (`max_values`: None, `max_size`: Some(136), added: 2611, mode: `MaxEncodedLen`)
+	/// Storage: `MessageQueue::ServiceHead` (r:1 w:1)
+	/// Proof: `MessageQueue::ServiceHead` (`max_values`: Some(1), `max_size`: Some(33), added: 528, mode: `MaxEncodedLen`)
+	/// Storage: UNKNOWN KEY `0x3a72656c61795f64697370617463685f71756575655f72656d61696e696e675f` (r:0 w:1)
+	/// Proof: UNKNOWN KEY `0x3a72656c61795f64697370617463685f71756575655f72656d61696e696e675f` (r:0 w:1)
+	/// Storage: `MessageQueue::Pages` (r:0 w:1)
+	/// Proof: `MessageQueue::Pages` (`max_values`: None, `max_size`: Some(32845), added: 35320, mode: `MaxEncodedLen`)
+	/// Storage: UNKNOWN KEY `0xf5207f03cfdce586301014700e2c2593fad157e461d71fd4c1f936839a5f1f3e` (r:0 w:1)
+	/// Proof: UNKNOWN KEY `0xf5207f03cfdce586301014700e2c2593fad157e461d71fd4c1f936839a5f1f3e` (r:0 w:1)
+	/// The range of component `s` is `[1, 200]`.
+	fn process_slashes_queue(s: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `393 + s * (42 ±0)`
+		//  Estimated: `3601 + s * (42 ±0)`
+		// Minimum execution time: 46_622_000 picoseconds.
+		Weight::from_parts(72_326_163, 3601)
+			// Standard Error: 58_929
+			.saturating_add(Weight::from_parts(2_894_084, 0).saturating_mul(s.into()))
+			.saturating_add(RocksDbWeight::get().reads(4_u64))
+			.saturating_add(RocksDbWeight::get().writes(2_u64))
+			.saturating_add(Weight::from_parts(0, 42).saturating_mul(s.into()))
 	}
 }


### PR DESCRIPTION
Change the function signature of `process_slashes_queue` to take the limit as argument, which helps benchmarking it. It also now returns the number of slashes processed to return the actually used weight.

Following suggestion in #793, I only read and write from storage once by moving the `for` loop inside the `mutate` call.