### PR TITLE
Fix lscpu regex for ubuntu 24.04

### DIFF
--- a/.github/workflow-templates/typescript-tests-moonwall/action.yml
+++ b/.github/workflow-templates/typescript-tests-moonwall/action.yml
@@ -22,7 +22,7 @@ runs:
       shell: bash
       run: |
         #### Set the number of CPUs to use for parallel tests.
-        echo "CPUS=$(lscpu | egrep '^CPU\(s\)' | grep -o '[0-9]*')" >> $GITHUB_ENV
+        echo "CPUS=$(lscpu | egrep '^CPU\(s\):' | grep -o '[0-9]*')" >> $GITHUB_ENV
 
         echo "CPUS: $CPUS"
 


### PR DESCRIPTION
We have this line in a CI script:

```
echo "CPUS=$(lscpu | egrep '^CPU\(s\)' | grep -o '[0-9]*')" >> $GITHUB_ENV
```

After upgrading to Ubuntu 24.04, that fails. It seems the script expected to just get the number of CPUs, but with the new lscpu, it’s actually grepping two CPU(s) values:

```
CPU(s):                               32
CPU(s) scaling MHz:                   41%
```

so the command is returning two values (32, 41) and breaking the action.

The fix is just to grep for "CPU(s):" instead.