### PR TITLE
fix bridge e2e test

### DIFF
--- a/test/suites/zombie_tanssi_relay_eth_bridge/test_zombie_tanssi_relay_eth_bridge.ts
+++ b/test/suites/zombie_tanssi_relay_eth_bridge/test_zombie_tanssi_relay_eth_bridge.ts
@@ -249,18 +249,40 @@ describeSuite({
             id: "T04",
             title: "Operator produces blocks",
             test: async function () {
-                // 3 sessions per era, 6 blocks per session
-                // just in case we add one additional session
-                for (let i = 0; i < 24; ++i) {
+                // 3 sessions per era, 10 blocks per session
+                // we wait for new era being enacted and then
+                // wait one session more to check if we produce a block
+
+                const sessionsPerEra = await relayApi.consts.externalValidators.sessionsPerEra;
+                const blocksPerSession = 10;
+
+                // Check when next era will be enacted
+                // 1. Get current era info
+                const activeEraInfo = (await relayApi.query.externalValidators.activeEra()).toJSON();
+                // 2. Get next era start block
+                const nextEraStartBlock = (activeEraInfo.index + 1) * sessionsPerEra * blocksPerSession + 1;
+                // 3. Get current block
+                const currentBlock = (await relayApi.rpc.chain.getBlock()).block.header.number.toNumber();
+                // 4. calculate how much to wait
+                const blocksTillNextEra = nextEraStartBlock - currentBlock + 1;
+
+                console.log(
+                    "We will wait for:",
+                    blocksTillNextEra + blocksPerSession,
+                    "blocks to detect block production"
+                );
+
+                await context.waitBlock(blocksTillNextEra, "Tanssi-relay");
+
+                // In new era's first session at least one block need to be produced by the operator
+                for (let i = 0; i < blocksPerSession; ++i) {
                     const latestBlockHash = await relayApi.rpc.chain.getBlockHash();
                     const author = (await relayApi.derive.chain.getHeader(latestBlockHash)).author;
                     if (author == operatorAccount.address) {
                         return;
                     }
-
                     await context.waitBlock(1, "Tanssi-relay");
                 }
-
                 expect.fail("operator didn't produce a block");
             },
         });


### PR DESCRIPTION
# Description
This PR fixes bridge e2e test by accurately checking when current era ends and then waiting one more session after that to check if operator produces a block in that session.

This is different from previous version where we just iterate through n number of blocks.