### PR TITLE
change to use ubuntu 24.04 to support GLIBC_2.39

### DIFF
--- a/docker/container-chain-evm-template.Dockerfile
+++ b/docker/container-chain-evm-template.Dockerfile
@@ -6,11 +6,11 @@ FROM docker.io/library/ubuntu:20.04 AS builder
 
 RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificates
 
-FROM debian:bookworm-slim
+FROM ubuntu:24.04
 LABEL maintainer "gorka@moondancelabs.com"
 LABEL description="Binary for container-chain-template-evm Collator"
 
-RUN useradd -m -u 1000 -U -s /bin/sh -d /container-chain-template-evm container-chain-template-evm && \
+RUN useradd -m -u 2000 -U -s /bin/sh -d /container-chain-template-evm container-chain-template-evm && \
 	mkdir -p /container-chain-template-evm/.local/share && \
 	mkdir /data && \
 	chown -R container-chain-template-evm:container-chain-template-evm /data && \

--- a/docker/container-chain-simple-template.Dockerfile
+++ b/docker/container-chain-simple-template.Dockerfile
@@ -6,11 +6,11 @@ FROM docker.io/library/ubuntu:20.04 AS builder
 
 RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificates
 
-FROM debian:bookworm-slim
+FROM ubuntu:24.04
 LABEL maintainer "gorka@moondancelabs.com"
 LABEL description="Binary for simple container chain template node"
 
-RUN useradd -m -u 1000 -U -s /bin/sh -d /container-chain-template-simple container-chain-template-simple && \
+RUN useradd -m -u 2000 -U -s /bin/sh -d /container-chain-template-simple container-chain-template-simple && \
 	mkdir -p /container-chain-template-simple/.local/share && \
 	mkdir /data && \
 	chown -R container-chain-template-simple:container-chain-template-simple /data && \

--- a/docker/starlight.Dockerfile
+++ b/docker/starlight.Dockerfile
@@ -6,11 +6,11 @@ FROM docker.io/library/ubuntu:20.04 AS builder
 
 RUN apt-get update && apt-get install -y ca-certificates lsof && update-ca-certificates
 
-FROM debian:bookworm-slim
+FROM ubuntu:24.04
 LABEL maintainer "gorka@moondancelabs.com"
 LABEL description="Binary for Dancelight"
 
-RUN useradd -m -u 1000 -U -s /bin/sh -d /tanssi-relay tanssi-relay && \
+RUN useradd -m -u 2000 -U -s /bin/sh -d /tanssi-relay tanssi-relay && \
 	mkdir -p /tanssi-relay/.local/share && \
 	mkdir /data && \
 	chown -R tanssi-relay:tanssi-relay /data && \

--- a/docker/tanssi.Dockerfile
+++ b/docker/tanssi.Dockerfile
@@ -1,21 +1,19 @@
 # Node for Tanssi
-#
-# Requires to run from repository root and to copy the binary in the build folder (part of the release workflow)
-
 FROM docker.io/library/ubuntu:20.04 AS builder
 
 RUN apt-get update && apt-get install -y ca-certificates lsof && update-ca-certificates
 
-FROM debian:bookworm-slim
+# Final stage with Ubuntu 24.04 for newer GLIBC
+FROM ubuntu:24.04
 LABEL maintainer "gorka@moondancelabs.com"
 LABEL description="Binary for Tanssi Collator"
 
-RUN useradd -m -u 1000 -U -s /bin/sh -d /tanssi tanssi && \
-	mkdir -p /tanssi/.local/share && \
-	mkdir /data && \
-	chown -R tanssi:tanssi /data && \
-	ln -s /data /tanssi/.local/share/tanssi && \
-	rm -rf /usr/sbin
+RUN useradd -m -u 2000 -U -s /bin/sh -d /tanssi tanssi && \
+    mkdir -p /tanssi/.local/share && \
+    mkdir /data && \
+    chown -R tanssi:tanssi /data && \
+    ln -s /data /tanssi/.local/share/tanssi && \
+    rm -rf /usr/sbin
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
@@ -24,17 +22,6 @@ USER tanssi
 COPY --chown=tanssi build/tanssi-node* /tanssi
 RUN chmod uog+x /tanssi/tanssi*
 
-# 30333 for parachain p2p
-# 30334 for relaychain p2p
-# 30335 for container p2p
-# 9933 for RPC call
-# 9944 for Websocket
-# 9615 for Prometheus (metrics)
-# 9935 for RPC call container (if we want to expose this)
-# 9946 for Websocket container (if we want to expose this)
-# 9617 for Prometheus container (metrics)
 EXPOSE 30333 30334 30335 9933 9944 9615 9935 9946 9617
-
 VOLUME ["/data"]
-
 ENTRYPOINT ["/tanssi/tanssi-node"]


### PR DESCRIPTION
The old image does not support  GLIBC_2.39. So since version v0.10.1 we are getting error : 
```
/tanssi/tanssi-node: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found (required by /tanssi/tanssi-node)
/tanssi/tanssi-node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by /tanssi/tanssi-node)
/tanssi/tanssi-node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /tanssi/tanssi-node)
```