### PR TITLE
add timestamp to each slash

### DIFF
--- a/chains/orchestrator-relays/runtime/dancelight/src/tests/slashes.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/tests/slashes.rs
@@ -479,13 +479,13 @@ fn test_slashes_are_sent_to_ethereum() {
                 "SlashesMessageSent event should be emitted"
             );
 
-            let expected_slashes = vec![(
-                AccountId::from(ALICE).encode(),
-                Perbill::from_percent(100).deconstruct(),
-            )];
+            let expected_slashes = vec![SlashData {
+                encoded_validator_id: AccountId::from(ALICE).encode(),
+                slash_fraction: Perbill::from_percent(100).deconstruct(),
+                timestamp: 0,
+            }];
 
             let expected_slashes_command = Command::ReportSlashes {
-                timestamp: 0u64,
                 era_index: 1u32,
                 slashes: expected_slashes,
             };
@@ -508,6 +508,7 @@ fn test_slashes_are_sent_to_ethereum() {
 }
 
 use frame_support::traits::Get;
+use tp_bridge::SlashData;
 
 #[test]
 fn test_slashes_are_sent_to_ethereum_accumulatedly() {

--- a/pallets/external-validator-slashes/src/tests.rs
+++ b/pallets/external-validator-slashes/src/tests.rs
@@ -40,6 +40,7 @@ fn root_can_inject_manual_offence() {
         assert_eq!(
             Slashes::<Test>::get(get_slashing_era(0)),
             vec![Slash {
+                timestamp: 0,
                 validator: 1,
                 percentage: Perbill::from_percent(75),
                 confirmed: false,
@@ -142,6 +143,7 @@ fn test_after_bonding_period_we_can_remove_slashes() {
         assert_eq!(
             Slashes::<Test>::get(get_slashing_era(0)),
             vec![Slash {
+                timestamp: 0,
                 validator: 1,
                 percentage: Perbill::from_percent(75),
                 confirmed: false,
@@ -178,6 +180,7 @@ fn test_on_offence_injects_offences() {
         assert_eq!(
             Slashes::<Test>::get(get_slashing_era(0)),
             vec![Slash {
+                timestamp: 0,
                 validator: 3,
                 percentage: Perbill::from_percent(75),
                 confirmed: false,
@@ -221,6 +224,7 @@ fn defer_period_of_zero_confirms_immediately_slashes() {
         assert_eq!(
             Slashes::<Test>::get(get_slashing_era(0)),
             vec![Slash {
+                timestamp: 0,
                 validator: 1,
                 percentage: Perbill::from_percent(75),
                 confirmed: true,
@@ -268,6 +272,7 @@ fn test_on_offence_defer_period_0() {
         assert_eq!(
             Slashes::<Test>::get(get_slashing_era(1)),
             vec![Slash {
+                timestamp: 0,
                 validator: 3,
                 percentage: Perbill::from_percent(75),
                 confirmed: true,
@@ -302,6 +307,7 @@ fn test_slashes_command_matches_event() {
         assert_eq!(
             Slashes::<Test>::get(get_slashing_era(1)),
             vec![Slash {
+                timestamp: 0,
                 validator: 3,
                 percentage: Perbill::from_percent(75),
                 confirmed: true,
@@ -315,9 +321,12 @@ fn test_slashes_command_matches_event() {
         assert_eq!(sent_ethereum_message_nonce(), 1);
 
         // The slash is sent on era 2
-        let expected_slashes = vec![(3u64.encode(), Perbill::from_percent(75).deconstruct())];
-        let expected_command = Command::ReportSlashes {
+        let expected_slashes = vec![SlashData {
+            encoded_validator_id: 3u64.encode(),
+            slash_fraction: Perbill::from_percent(75).deconstruct(),
             timestamp: 0u64,
+        }];
+        let expected_command = Command::ReportSlashes {
             era_index: 2u32,
             slashes: expected_slashes,
         };
@@ -371,6 +380,7 @@ fn test_account_id_encoding() {
         let alice_account: [u8; 32] = [4u8; 32];
 
         let slash = Slash::<OpaqueAccountId, u32> {
+            timestamp: 0,
             validator: OpaqueAccountId::from(alice_account),
             reporters: vec![],
             slash_id: 1,

--- a/primitives/bridge/src/lib.rs
+++ b/primitives/bridge/src/lib.rs
@@ -64,6 +64,13 @@ pub use {
 mod custom_do_process_message;
 mod custom_send_message;
 
+#[derive(Clone, Encode, Decode, RuntimeDebug, TypeInfo, PartialEq)]
+pub struct SlashData {
+    pub encoded_validator_id: Vec<u8>,
+    pub slash_fraction: u32,
+    pub timestamp: u64,
+}
+
 /// A command which is executable by the Gateway contract on Ethereum
 #[derive(Clone, Encode, Decode, RuntimeDebug, TypeInfo, PartialEq)]
 pub enum Command {
@@ -82,12 +89,10 @@ pub enum Command {
         rewards_merkle_root: H256,
     },
     ReportSlashes {
-        // block timestamp
-        timestamp: u64,
         // index of the era we are sending info of
         era_index: u32,
-        // vec of tuples: (validatorId, slash_fraction)
-        slashes: Vec<(Vec<u8>, u32)>,
+        // vec of `SlashData`
+        slashes: Vec<SlashData>,
     },
 }
 
@@ -128,29 +133,22 @@ impl Command {
                     rewards_mr_token,
                 ])])
             }
-            Command::ReportSlashes {
-                timestamp,
-                era_index,
-                slashes,
-            } => {
-                let timestamp_token = Token::Uint(U256::from(*timestamp));
+            Command::ReportSlashes { era_index, slashes } => {
                 let era_index_token = Token::Uint(U256::from(*era_index));
                 let mut slashes_tokens_vec: Vec<Token> = vec![];
 
                 for slash in slashes.into_iter() {
-                    let account_token = Token::FixedBytes(slash.0.clone());
-                    let slash_fraction_token = Token::Uint(U256::from(slash.1));
-                    let tuple_token = Token::Tuple(vec![account_token, slash_fraction_token]);
+                    let account_token = Token::FixedBytes(slash.encoded_validator_id.clone());
+                    let slash_fraction_token = Token::Uint(U256::from(slash.slash_fraction));
+                    let timestamp = Token::Uint(U256::from(slash.timestamp));
+                    let tuple_token =
+                        Token::Tuple(vec![account_token, slash_fraction_token, timestamp]);
 
                     slashes_tokens_vec.push(tuple_token);
                 }
 
                 let slashes_tokens_tuple = Token::Tuple(slashes_tokens_vec);
-                ethabi::encode(&[Token::Tuple(vec![
-                    timestamp_token,
-                    era_index_token,
-                    slashes_tokens_tuple,
-                ])])
+                ethabi::encode(&[Token::Tuple(vec![era_index_token, slashes_tokens_tuple])])
             }
         }
     }

--- a/typescript-api/src/dancelight/interfaces/lookup.ts
+++ b/typescript-api/src/dancelight/interfaces/lookup.ts
@@ -498,11 +498,16 @@ export default {
                 rewardsMerkleRoot: "H256",
             },
             ReportSlashes: {
-                timestamp: "u64",
                 eraIndex: "u32",
-                slashes: "Vec<(Bytes,u32)>",
+                slashes: "Vec<TpBridgeSlashData>",
             },
         },
+    },
+    /** Lookup62: tp_bridge::SlashData */
+    TpBridgeSlashData: {
+        encodedValidatorId: "Bytes",
+        slashFraction: "u32",
+        timestamp: "u64",
     },
     /** Lookup63: pallet_external_validators_rewards::pallet::Event<T> */
     PalletExternalValidatorsRewardsEvent: {
@@ -5535,6 +5540,7 @@ export default {
     },
     /** Lookup622: pallet_external_validator_slashes::Slash<sp_core::crypto::AccountId32, SlashId> */
     PalletExternalValidatorSlashesSlash: {
+        timestamp: "u64",
         validator: "AccountId32",
         reporters: "Vec<AccountId32>",
         slashId: "u32",

--- a/typescript-api/src/dancelight/interfaces/registry.ts
+++ b/typescript-api/src/dancelight/interfaces/registry.ts
@@ -453,6 +453,7 @@ import type {
     StagingXcmV4TraitsOutcome,
     StagingXcmV4Xcm,
     TpBridgeCommand,
+    TpBridgeSlashData,
     TpTraitsActiveEraInfo,
     TpTraitsContainerChainBlockInfo,
     TpTraitsFullRotationMode,
@@ -958,6 +959,7 @@ declare module "@polkadot/types/types/registry" {
         StagingXcmV4TraitsOutcome: StagingXcmV4TraitsOutcome;
         StagingXcmV4Xcm: StagingXcmV4Xcm;
         TpBridgeCommand: TpBridgeCommand;
+        TpBridgeSlashData: TpBridgeSlashData;
         TpTraitsActiveEraInfo: TpTraitsActiveEraInfo;
         TpTraitsContainerChainBlockInfo: TpTraitsContainerChainBlockInfo;
         TpTraitsFullRotationMode: TpTraitsFullRotationMode;

--- a/typescript-api/src/dancelight/interfaces/types-lookup.ts
+++ b/typescript-api/src/dancelight/interfaces/types-lookup.ts
@@ -709,11 +709,17 @@ declare module "@polkadot/types/lookup" {
         } & Struct;
         readonly isReportSlashes: boolean;
         readonly asReportSlashes: {
-            readonly timestamp: u64;
             readonly eraIndex: u32;
-            readonly slashes: Vec<ITuple<[Bytes, u32]>>;
+            readonly slashes: Vec<TpBridgeSlashData>;
         } & Struct;
         readonly type: "Test" | "ReportRewards" | "ReportSlashes";
+    }
+
+    /** @name TpBridgeSlashData (62) */
+    interface TpBridgeSlashData extends Struct {
+        readonly encodedValidatorId: Bytes;
+        readonly slashFraction: u32;
+        readonly timestamp: u64;
     }
 
     /** @name PalletExternalValidatorsRewardsEvent (63) */
@@ -7096,6 +7102,7 @@ declare module "@polkadot/types/lookup" {
 
     /** @name PalletExternalValidatorSlashesSlash (622) */
     interface PalletExternalValidatorSlashesSlash extends Struct {
+        readonly timestamp: u64;
         readonly validator: AccountId32;
         readonly reporters: Vec<AccountId32>;
         readonly slashId: u32;


### PR DESCRIPTION
# Description
This PR removes timestamp from the command and adds it into the slashes itself. This will enable each slash having different timestamp.