### PR TITLE
Add missing workspace lints = true

### DIFF
--- a/client/orchestrator-chain-rpc-interface/Cargo.toml
+++ b/client/orchestrator-chain-rpc-interface/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 license = "GPL-3.0-only"
 version = "0.1.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 async-io = { workspace = true }
 async-trait = { workspace = true }

--- a/pallets/xcm-core-buyer/Cargo.toml
+++ b/pallets/xcm-core-buyer/Cargo.toml
@@ -9,6 +9,9 @@ version = "0.1.0"
 [package.metadata.docs.rs]
 targets = [ "x86_64-unknown-linux-gnu" ]
 
+[lints]
+workspace = true
+
 [dependencies]
 
 dp-core = { workspace = true }


### PR DESCRIPTION
Some crates didn't have this set. In that case they use the default clippy config instead of ours, so we may miss some clippy warnings.