### PR TITLE
Add message id to slash and reward message events

### DIFF
--- a/chains/orchestrator-relays/runtime/dancelight/src/tests/common/mod.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/tests/common/mod.rs
@@ -59,6 +59,7 @@ use {
         BuildStorage, Digest, DigestItem,
     },
     sp_std::collections::btree_map::BTreeMap,
+    sp_storage::well_known_keys,
     test_relay_sproof_builder::ParaHeaderSproofBuilder,
 };
 
@@ -72,6 +73,12 @@ pub use crate::{
 };
 
 pub const UNIT: Balance = 1_000_000_000_000_000_000;
+
+pub fn read_last_entropy() -> [u8; 32] {
+    let mut last = [0u8; 32];
+    sp_io::storage::read(well_known_keys::INTRABLOCK_ENTROPY, &mut last[..], 0);
+    last
+}
 
 pub fn session_to_block(n: u32) -> u32 {
     // let block_number = flashbox_runtime::Period::get() * n;

--- a/chains/orchestrator-relays/runtime/dancelight/src/tests/external_validators_tests.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/tests/external_validators_tests.rs
@@ -1165,6 +1165,7 @@ fn external_validators_rewards_test_command_integrity() {
                     RuntimeEvent::ExternalValidatorsRewards(
                         pallet_external_validators_rewards::Event::RewardsMessageSent {
                             rewards_command,
+                            ..
                         },
                     ) => {
                         rewards_command_found = Some(rewards_command.clone());

--- a/chains/orchestrator-relays/runtime/dancelight/src/tests/external_validators_tests.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/tests/external_validators_tests.rs
@@ -16,6 +16,7 @@
 
 #![cfg(test)]
 
+use sp_core::H256;
 use {
     crate::{
         tests::common::*, EthereumSystem, ExternalValidators, ExternalValidatorsRewards,
@@ -1159,15 +1160,17 @@ fn external_validators_rewards_test_command_integrity() {
             run_to_session(sessions_per_era * 2);
 
             let mut rewards_command_found: Option<Command> = None;
+            let mut message_id_found: Option<H256> = None;
             let ext_validators_rewards_event = System::events()
                 .iter()
                 .filter(|r| match &r.event {
                     RuntimeEvent::ExternalValidatorsRewards(
                         pallet_external_validators_rewards::Event::RewardsMessageSent {
                             rewards_command,
-                            ..
+                            message_id,
                         },
                     ) => {
+                        message_id_found = Some(*message_id);
                         rewards_command_found = Some(rewards_command.clone());
                         true
                     }
@@ -1194,6 +1197,7 @@ fn external_validators_rewards_test_command_integrity() {
                 expected_rewards_command,
                 "Both rewards commands should match!"
             );
+            assert_eq!(message_id_found.unwrap(), read_last_entropy().into());
         });
 }
 

--- a/chains/orchestrator-relays/runtime/dancelight/src/tests/slashes.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/tests/slashes.rs
@@ -485,6 +485,7 @@ fn test_slashes_are_sent_to_ethereum() {
                     RuntimeEvent::ExternalValidatorSlashes(
                         pallet_external_validator_slashes::Event::SlashesMessageSent {
                             slashes_command,
+                            ..
                         },
                     ) => {
                         slashes_command_found = Some(slashes_command.clone());

--- a/chains/orchestrator-relays/runtime/dancelight/src/tests/slashes.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/tests/slashes.rs
@@ -479,15 +479,17 @@ fn test_slashes_are_sent_to_ethereum() {
                 .count();
 
             let mut slashes_command_found: Option<Command> = None;
+            let mut message_id_found: Option<H256> = None;
             let ext_validators_slashes_event = System::events()
                 .iter()
                 .filter(|r| match &r.event {
                     RuntimeEvent::ExternalValidatorSlashes(
                         pallet_external_validator_slashes::Event::SlashesMessageSent {
                             slashes_command,
-                            ..
+                            message_id,
                         },
                     ) => {
+                        message_id_found = Some(*message_id);
                         slashes_command_found = Some(slashes_command.clone());
                         true
                     }
@@ -522,6 +524,8 @@ fn test_slashes_are_sent_to_ethereum() {
                 expected_slashes_command,
                 "Both slashes commands should match!"
             );
+
+            assert_eq!(message_id_found.unwrap(), read_last_entropy().into());
 
             // EthereumOutboundQueue -> queue_message -> MessageQQueuePallet (queue)
             // MessageQueuePallet on_initialize -> dispatch queue -> process_message -> EthereumOutboundQueue_process_message

--- a/pallets/external-validator-slashes/src/tests.rs
+++ b/pallets/external-validator-slashes/src/tests.rs
@@ -333,6 +333,7 @@ fn test_slashes_command_matches_event() {
 
         System::assert_last_event(RuntimeEvent::ExternalValidatorSlashes(
             crate::Event::SlashesMessageSent {
+                message_id: Default::default(),
                 slashes_command: expected_command,
             },
         ));

--- a/pallets/external-validators-rewards/src/tests.rs
+++ b/pallets/external-validators-rewards/src/tests.rs
@@ -121,6 +121,7 @@ fn test_on_era_end() {
 
         System::assert_last_event(RuntimeEvent::ExternalValidatorsRewards(
             crate::Event::RewardsMessageSent {
+                message_id: Default::default(),
                 rewards_command: expected_command,
             },
         ));

--- a/pallets/external-validators-rewards/src/tests.rs
+++ b/pallets/external-validators-rewards/src/tests.rs
@@ -164,6 +164,7 @@ fn test_on_era_end_without_proper_token() {
         let events = System::events();
         let expected_not_thrown_event =
             RuntimeEvent::ExternalValidatorsRewards(crate::Event::RewardsMessageSent {
+                message_id: Default::default(),
                 rewards_command: expected_command,
             });
         assert!(

--- a/primitives/bridge/src/lib.rs
+++ b/primitives/bridge/src/lib.rs
@@ -185,10 +185,26 @@ pub struct Message {
     pub command: Command,
 }
 
+pub trait TicketInfo {
+    fn message_id(&self) -> H256;
+}
+
+impl TicketInfo for () {
+    fn message_id(&self) -> H256 {
+        H256::zero()
+    }
+}
+
+impl<T: snowbridge_pallet_outbound_queue::Config> TicketInfo for Ticket<T> {
+    fn message_id(&self) -> H256 {
+        self.message_id.clone()
+    }
+}
+
 pub struct MessageValidator<T: snowbridge_pallet_outbound_queue::Config>(PhantomData<T>);
 
 pub trait ValidateMessage {
-    type Ticket;
+    type Ticket: TicketInfo;
 
     fn validate(message: &Message) -> Result<(Self::Ticket, Fee<u64>), SendError>;
 }

--- a/primitives/bridge/src/lib.rs
+++ b/primitives/bridge/src/lib.rs
@@ -197,7 +197,7 @@ impl TicketInfo for () {
 
 impl<T: snowbridge_pallet_outbound_queue::Config> TicketInfo for Ticket<T> {
     fn message_id(&self) -> H256 {
-        self.message_id.clone()
+        self.message_id
     }
 }
 

--- a/typescript-api/src/dancelight/interfaces/augment-api-events.ts
+++ b/typescript-api/src/dancelight/interfaces/augment-api-events.ts
@@ -357,8 +357,8 @@ declare module "@polkadot/api-base/types/events" {
             /** The slashes message was sent correctly. */
             SlashesMessageSent: AugmentedEvent<
                 ApiType,
-                [slashesCommand: TpBridgeCommand],
-                { slashesCommand: TpBridgeCommand }
+                [messageId: H256, slashesCommand: TpBridgeCommand],
+                { messageId: H256; slashesCommand: TpBridgeCommand }
             >;
             /** Removed author data */
             SlashReported: AugmentedEvent<
@@ -373,8 +373,8 @@ declare module "@polkadot/api-base/types/events" {
             /** The rewards message was sent correctly. */
             RewardsMessageSent: AugmentedEvent<
                 ApiType,
-                [rewardsCommand: TpBridgeCommand],
-                { rewardsCommand: TpBridgeCommand }
+                [messageId: H256, rewardsCommand: TpBridgeCommand],
+                { messageId: H256; rewardsCommand: TpBridgeCommand }
             >;
             /** Generic event */
             [key: string]: AugmentedEvent<ApiType>;

--- a/typescript-api/src/dancelight/interfaces/lookup.ts
+++ b/typescript-api/src/dancelight/interfaces/lookup.ts
@@ -482,6 +482,7 @@ export default {
                 slashEra: "u32",
             },
             SlashesMessageSent: {
+                messageId: "H256",
                 slashesCommand: "TpBridgeCommand",
             },
         },
@@ -496,6 +497,7 @@ export default {
                 totalPoints: "u128",
                 tokensInflated: "u128",
                 rewardsMerkleRoot: "H256",
+                tokenId: "H256",
             },
             ReportSlashes: {
                 eraIndex: "u32",
@@ -513,6 +515,7 @@ export default {
     PalletExternalValidatorsRewardsEvent: {
         _enum: {
             RewardsMessageSent: {
+                messageId: "H256",
                 rewardsCommand: "TpBridgeCommand",
             },
         },

--- a/typescript-api/src/dancelight/interfaces/lookup.ts
+++ b/typescript-api/src/dancelight/interfaces/lookup.ts
@@ -496,7 +496,6 @@ export default {
                 totalPoints: "u128",
                 tokensInflated: "u128",
                 rewardsMerkleRoot: "H256",
-                tokenId: "H256",
             },
             ReportSlashes: {
                 eraIndex: "u32",

--- a/typescript-api/src/dancelight/interfaces/types-lookup.ts
+++ b/typescript-api/src/dancelight/interfaces/types-lookup.ts
@@ -690,6 +690,7 @@ declare module "@polkadot/types/lookup" {
         } & Struct;
         readonly isSlashesMessageSent: boolean;
         readonly asSlashesMessageSent: {
+            readonly messageId: H256;
             readonly slashesCommand: TpBridgeCommand;
         } & Struct;
         readonly type: "SlashReported" | "SlashesMessageSent";
@@ -706,6 +707,7 @@ declare module "@polkadot/types/lookup" {
             readonly totalPoints: u128;
             readonly tokensInflated: u128;
             readonly rewardsMerkleRoot: H256;
+            readonly tokenId: H256;
         } & Struct;
         readonly isReportSlashes: boolean;
         readonly asReportSlashes: {
@@ -726,6 +728,7 @@ declare module "@polkadot/types/lookup" {
     interface PalletExternalValidatorsRewardsEvent extends Enum {
         readonly isRewardsMessageSent: boolean;
         readonly asRewardsMessageSent: {
+            readonly messageId: H256;
             readonly rewardsCommand: TpBridgeCommand;
         } & Struct;
         readonly type: "RewardsMessageSent";

--- a/typescript-api/src/dancelight/interfaces/types-lookup.ts
+++ b/typescript-api/src/dancelight/interfaces/types-lookup.ts
@@ -706,7 +706,6 @@ declare module "@polkadot/types/lookup" {
             readonly totalPoints: u128;
             readonly tokensInflated: u128;
             readonly rewardsMerkleRoot: H256;
-            readonly tokenId: H256;
         } & Struct;
         readonly isReportSlashes: boolean;
         readonly asReportSlashes: {


### PR DESCRIPTION
# Description
This PR adds `message_id` field to slash and reward messages which is populated by `ticket`'s `message_id`. To extract `message_id` from `ticket`, we added a `TicketInfo` trait.

Adding `message_id` will allow us to track the progress of particular message across the bridge.