### PR TITLE
Slash + rewards e2e test version 1

### DIFF
--- a/primitives/bridge/src/custom_do_process_message.rs
+++ b/primitives/bridge/src/custom_do_process_message.rs
@@ -152,8 +152,8 @@ impl ConstantGasMeter {
         match command {
             Command::Test { .. } => 60_000,
             // TODO: revisit gas cost
-            Command::ReportRewards { .. } => 60_000,
-            Command::ReportSlashes { .. } => 60_000,
+            Command::ReportRewards { .. } => 10_00_000,
+            Command::ReportSlashes { .. } => 10_00_000,
         }
     }
 }

--- a/primitives/bridge/src/custom_do_process_message.rs
+++ b/primitives/bridge/src/custom_do_process_message.rs
@@ -152,8 +152,8 @@ impl ConstantGasMeter {
         match command {
             Command::Test { .. } => 60_000,
             // TODO: revisit gas cost
-            Command::ReportRewards { .. } => 10_00_000,
-            Command::ReportSlashes { .. } => 10_00_000,
+            Command::ReportRewards { .. } => 1_000_000,
+            Command::ReportSlashes { .. } => 1_000_000,
         }
     }
 }

--- a/test/scripts/bridge/build-symbiotic-contracts.sh
+++ b/test/scripts/bridge/build-symbiotic-contracts.sh
@@ -18,10 +18,10 @@ else
   git clone https://github.com/moondance-labs/tanssi-symbiotic $symbiotic_contracts_dir
   pushd $symbiotic_contracts_dir
   git fetch && git checkout $TANSSI_SYMBIOTIC_COMMIT
+  make install
   popd
 fi
 
 pushd $symbiotic_contracts_dir
-make install
 forge build
 popd

--- a/test/scripts/bridge/set-env.sh
+++ b/test/scripts/bridge/set-env.sh
@@ -23,7 +23,7 @@ test_helpers_dir="$web_dir/packages/test-helpers"
 relay_bin="$relayer_root_dir/build/tanssi-bridge-relayer"
 
 RELAYER_BRANCH="main" # TODO: Change to tag when we do releases
-TANSSI_SYMBIOTIC_COMMIT="f42ebae15225282be1b235e0d28b8ab16f67dff5" # TODO: Change to tag when we do release
+TANSSI_SYMBIOTIC_COMMIT="224bf2dfc682b25bf8f757e222de0aa7003ffb9f" # TODO: Change to tag when we do release
 GETH_TAG="v1.14.11" # We will need to investigate if this is right
 LODESTAR_TAG="v1.19.0"
 
@@ -96,6 +96,7 @@ export BRIDGE_HUB_INITIAL_DEPOSIT="${ETH_BRIDGE_HUB_INITIAL_DEPOSIT:-10000000000
 
 ## Message passing
 export PRIMARY_GOVERNANCE_CHANNEL_ID="0x0000000000000000000000000000000000000000000000000000000000000001"
+export SECONDARY_GOVERNANCE_CHANNEL_ID="0x0000000000000000000000000000000000000000000000000000000000000002"
 # Execution relay account (//ExecutionRelay 5CFNWKMFPsw5Cs2Teo6Pvg7rWyjKiFfqPZs8U4MZXzMYFwXL in testnet)
 execution_relayer_assethub_pub_key="${EXECUTION_RELAYER_PUB_KEY:-0x08228efd065c58a043da95c8bf177659fc587643e71e7ed1534666177730196f}"
 # Funded ethereum key

--- a/test/scripts/bridge/setup-relayer.sh
+++ b/test/scripts/bridge/setup-relayer.sh
@@ -62,7 +62,7 @@ config_relayer() {
         $assets_dir/execution-relay.json >$output_dir/execution-relay.json
 
 
-    # Configure substrate relay for ethereum
+    # Configure substrate relay for ethereum for primary channel
     jq \
         --arg k1 "$(snowbridge_address_for GatewayProxy)" \
         --arg k2 "$(snowbridge_address_for BeefyClient)" \
@@ -79,7 +79,27 @@ config_relayer() {
     | .sink.contracts.Gateway = $k1
     | .sink.ethereum.endpoint = $eth_writer_endpoint
     ' \
-        $assets_dir/substrate-relay.json >$output_dir/substrate-relay.json
+        $assets_dir/substrate-relay.json >$output_dir/substrate-relay-primary.json
+
+    # Configure substrate relay for ethereum for secondary channel
+    jq \
+        --arg k1 "$(snowbridge_address_for GatewayProxy)" \
+        --arg k2 "$(snowbridge_address_for BeefyClient)" \
+        --arg eth_endpoint_ws $eth_endpoint_ws \
+        --arg eth_writer_endpoint $eth_writer_endpoint \
+        --arg channelID $SECONDARY_GOVERNANCE_CHANNEL_ID \
+        --arg relay_chain_endpoint $RELAYCHAIN_ENDPOINT \
+        '
+      .source.ethereum.endpoint = $eth_endpoint_ws
+    | .source.polkadot.endpoint = $relay_chain_endpoint
+    | .source.contracts.BeefyClient = $k2
+    | .source.contracts.Gateway = $k1
+    | .source."channel-id" = $channelID
+    | .sink.contracts.Gateway = $k1
+    | .sink.ethereum.endpoint = $eth_writer_endpoint
+    ' \
+        $assets_dir/substrate-relay.json >$output_dir/substrate-relay-secondary.json
+
 }
 
 write_beacon_checkpoint() {

--- a/test/scripts/bridge/start-relayer.sh
+++ b/test/scripts/bridge/start-relayer.sh
@@ -57,19 +57,33 @@ start_relayer() {
     ) &
     echo "execution_relay=$!" >> $artifacts_dir/daemons.pid
 
-     # Launch execution relay
+     # Launch substrate relay for primary channel
     (
-        : >$output_dir/substrate-relay.log
+        : >$output_dir/substrate-relay-primary.log
         while :; do
-            echo "Starting substrate relay at $(date)"
+            echo "Starting substrate relay primary at $(date)"
             "${relay_bin}" run solochain \
-                --config $output_dir/substrate-relay.json \
+                --config $output_dir/substrate-relay-primary.json \
                 --ethereum.private-key $ethereum_key \
-                >>"$logs_dir"/substrate-relay.log 2>&1 || true
+                >>"$logs_dir"/substrate-relay-primary.log 2>&1 || true
             sleep 20
         done
     ) &
-    echo "substrate_relay=$!" >> $artifacts_dir/daemons.pid
+    echo "substrate_relay_primary=$!" >> $artifacts_dir/daemons.pid
+    
+     # Launch substrate relay for secondary channel
+    (
+        : >$output_dir/substrate-relay-secondary.log
+        while :; do
+            echo "Starting substrate relay secondary at $(date)"
+            "${relay_bin}" run solochain \
+                --config $output_dir/substrate-relay-secondary.json \
+                --ethereum.private-key $ethereum_key \
+                >>"$logs_dir"/substrate-relay-secondary.log 2>&1 || true
+            sleep 20
+        done
+    ) &
+    echo "substrate_relay_secondary=$!" >> $artifacts_dir/daemons.pid
 }
 
 echo "start relayers only!"

--- a/test/suites/zombie_tanssi_relay_eth_bridge/test_zombie_tanssi_relay_eth_bridge.ts
+++ b/test/suites/zombie_tanssi_relay_eth_bridge/test_zombie_tanssi_relay_eth_bridge.ts
@@ -5,6 +5,7 @@ import { signAndSendAndInclude, waitSessions } from "../../util/block.ts";
 import { ethers } from "ethers";
 import { decodeAddress } from "@polkadot/util-crypto";
 import { u8aToHex } from "@polkadot/util";
+import { MultiLocation } from "@polkadot/types/interfaces/xcm/types";
 
 // Change this if we change the storage parameter in runtime
 const GATEWAY_STORAGE_KEY = "0xaed97c7854d601808b98ae43079dafb3";
@@ -19,6 +20,21 @@ function execCommand(command: string, options?) {
             }
         });
     });
+}
+
+async function calculateNumberOfBlocksTillNextEra(api, blocksPerSession) {
+    // Wait till the second block of next era
+    const sessionsPerEra = await api.consts.externalValidators.sessionsPerEra;
+
+    // Check when next era will be enacted
+    // 1. Get current era info
+    const activeEraInfo = (await api.query.externalValidators.activeEra()).toJSON();
+    // 2. Get next era start block
+    const nextEraStartBlock = (activeEraInfo.index + 1) * sessionsPerEra * blocksPerSession + 1;
+    // 3. Get current block
+    const currentBlock = (await api.rpc.chain.getBlock()).block.header.number.toNumber();
+    // 4. calculate how much to wait
+    return nextEraStartBlock - currentBlock;
 }
 
 describeSuite({
@@ -37,6 +53,7 @@ describeSuite({
         let customHttpProvider;
         let ethereumWallet;
         let middlewareContract;
+        let gatewayContract;
         let gatewayProxyAddress;
         let middlewareDetails;
 
@@ -122,7 +139,7 @@ describeSuite({
             const tx = await middlewareContract.setGateway(gatewayProxyAddress);
             await tx.wait();
 
-            const gatewayContract = new ethers.Contract(
+            gatewayContract = new ethers.Contract(
                 gatewayProxyAddress,
                 ethInfo.snowbridge_info.contracts.Gateway.abi,
                 ethereumWallet
@@ -145,6 +162,26 @@ describeSuite({
             // Once that is done, we can start the relayer
             await signAndSendAndInclude(
                 relayApi.tx.sudo.sudo(relayApi.tx.ethereumBeaconClient.forceCheckpoint(initialBeaconUpdate)),
+                alice
+            );
+
+            const tokenLocation: MultiLocation = {
+                parents: 0,
+                interior: "Here",
+            };
+            const versionedLocation = {
+                V3: tokenLocation,
+            };
+
+            const metadata = {
+                name: "dance",
+                symbol: "dance",
+                decimals: 18,
+            };
+
+            // Register reward token
+            await signAndSendAndInclude(
+                relayApi.tx.sudo.sudo(relayApi.tx.ethereumSystem.registerToken(versionedLocation, metadata)),
                 alice
             );
 
@@ -257,33 +294,26 @@ describeSuite({
             id: "T04",
             title: "Operator produces blocks",
             test: async function () {
-                // 3 sessions per era, 10 blocks per session
-                // we wait for new era being enacted and then
-                // wait one session more to check if we produce a block
-
-                const sessionsPerEra = await relayApi.consts.externalValidators.sessionsPerEra;
-                const blocksPerSession = 10;
-
-                // Check when next era will be enacted
-                // 1. Get current era info
-                const activeEraInfo = (await relayApi.query.externalValidators.activeEra()).toJSON();
-                // 2. Get next era start block
-                const nextEraStartBlock = (activeEraInfo.index + 1) * sessionsPerEra * blocksPerSession + 1;
-                // 3. Get current block
-                const currentBlock = (await relayApi.rpc.chain.getBlock()).block.header.number.toNumber();
-                // 4. calculate how much to wait
-                const blocksTillNextEra = nextEraStartBlock - currentBlock + 1;
-
-                console.log(
-                    "We will wait for:",
-                    blocksTillNextEra + blocksPerSession,
-                    "blocks to detect block production"
+                // wait some time for the operator to be part of session validator
+                await waitSessions(
+                    context,
+                    relayApi,
+                    6,
+                    async () => {
+                        try {
+                            const sessionValidators = await relayApi.query.session.validators();
+                            expect(sessionValidators).to.contain(operatorAccount.address);
+                        } catch (error) {
+                            return false;
+                        }
+                        return true;
+                    },
+                    "Tanssi-relay"
                 );
 
-                await context.waitBlock(blocksTillNextEra, "Tanssi-relay");
-
                 // In new era's first session at least one block need to be produced by the operator
-                for (let i = 0; i < blocksPerSession; ++i) {
+                const blocksPerSession = 10;
+                for (let i = 0; i < 3 * blocksPerSession; ++i) {
                     const latestBlockHash = await relayApi.rpc.chain.getBlockHash();
                     const author = (await relayApi.derive.chain.getHeader(latestBlockHash)).author;
                     if (author == operatorAccount.address) {
@@ -292,6 +322,86 @@ describeSuite({
                     await context.waitBlock(1, "Tanssi-relay");
                 }
                 expect.fail("operator didn't produce a block");
+            },
+        });
+
+        it({
+            id: "T05",
+            title: "Rewards and slashes are being sent to symbiotic successfully",
+            test: async function () {
+                // Send slash event forcefully
+                const activeEraInfo = (await relayApi.query.externalValidators.activeEra()).toJSON();
+                const forceInjectSlashCall = relayApi.tx.externalValidatorSlashes.forceInjectSlash(
+                    activeEraInfo.index,
+                    operatorAccount.address,
+                    1000
+                );
+                const forceInjectTx = await relayApi.tx.sudo.sudo(forceInjectSlashCall).signAndSend(alice);
+
+                console.log("Force inject tx was submitted:", forceInjectTx.toHex());
+
+                const blocksToWaitForRewards = await calculateNumberOfBlocksTillNextEra(relayApi, 10);
+                // The slash message event is fired in the second block of Era
+                const blocksToWaitForSlashes = blocksToWaitForRewards + 1;
+                const blocksToWaitFor = Math.max(blocksToWaitForRewards, blocksToWaitForSlashes) + 1;
+
+                const currentBlock = (await relayApi.rpc.chain.getBlock()).block.header.number.toNumber();
+                const blockToFetchRewardEventFrom = currentBlock + blocksToWaitForRewards;
+                const blockToFetchSlashEventFrom = currentBlock + blocksToWaitForSlashes;
+
+                console.log("We will wait till", currentBlock + blocksToWaitFor, "blocks");
+
+                await context.waitBlock(blocksToWaitFor, "Tanssi-relay");
+                const relayApiAtRewardEventBlock = await relayApi.at(
+                    await relayApi.query.system.blockHash(blockToFetchRewardEventFrom)
+                );
+                const relayApiAtSlashEventBlock = await relayApi.at(
+                    await relayApi.query.system.blockHash(blockToFetchSlashEventFrom)
+                );
+
+                // Get the reward event
+                const rewardBlockEvents = await relayApiAtRewardEventBlock.query.system.events();
+                const filteredEventsForReward = rewardBlockEvents.filter((a) => {
+                    return a.event.method == "RewardsMessageSent";
+                });
+                expect(filteredEventsForReward.length).to.be.equal(1);
+                const rewardEvent = filteredEventsForReward[0];
+                // Extract message id
+                const rewardMessageId = rewardEvent.event.toJSON().data[0];
+                console.log("Reward message id:", rewardMessageId);
+
+                // Get the slash event
+                const slashBlockEvents = await relayApiAtSlashEventBlock.query.system.events();
+                const filteredEventsForSlash = slashBlockEvents.filter((a) => {
+                    return a.event.method == "SlashesMessageSent";
+                });
+                expect(filteredEventsForSlash.length).to.be.equal(1);
+                const slashEvent = filteredEventsForSlash[0];
+                // Extract message id
+                const slashMessageId = slashEvent.event.toJSON().data[0];
+                console.log("Slash message id:", slashMessageId);
+
+                let rewardMessageReceived = false;
+                let slashMessageReceived = false;
+                let rewardMessageSuccess = false;
+                let slashMessageSuccess = false;
+
+                gatewayContract.on("InboundMessageDispatched", (_channelID, _nonce, messageID, success) => {
+                    if (rewardMessageId == messageID) {
+                        rewardMessageReceived = true;
+                        rewardMessageSuccess = success;
+                    } else if (slashMessageId == messageID) {
+                        slashMessageReceived = true;
+                        slashMessageSuccess = success;
+                    }
+                });
+
+                while (!rewardMessageReceived || !slashMessageReceived) {
+                    await sleep(1000);
+                }
+
+                expect(rewardMessageSuccess).to.be.true;
+                expect(slashMessageSuccess).to.be.true;
             },
         });
 

--- a/test/suites/zombie_tanssi_relay_eth_bridge/test_zombie_tanssi_relay_eth_bridge.ts
+++ b/test/suites/zombie_tanssi_relay_eth_bridge/test_zombie_tanssi_relay_eth_bridge.ts
@@ -158,13 +158,6 @@ describeSuite({
                 ).stdout
             );
 
-            // We need to read initial checkpoint data and address of gateway contract to setup the ethereum client
-            // Once that is done, we can start the relayer
-            await signAndSendAndInclude(
-                relayApi.tx.sudo.sudo(relayApi.tx.ethereumBeaconClient.forceCheckpoint(initialBeaconUpdate)),
-                alice
-            );
-
             const tokenLocation: MultiLocation = {
                 parents: 0,
                 interior: "Here",
@@ -179,9 +172,16 @@ describeSuite({
                 decimals: 18,
             };
 
-            // Register reward token
+            // We need to read initial checkpoint data and address of gateway contract to setup the ethereum client
+            // We also need to register token
+            // Once that is done, we can start the relayer
             await signAndSendAndInclude(
-                relayApi.tx.sudo.sudo(relayApi.tx.ethereumSystem.registerToken(versionedLocation, metadata)),
+                relayApi.tx.sudo.sudo(
+                    relayApi.tx.utility.batch([
+                        relayApi.tx.ethereumBeaconClient.forceCheckpoint(initialBeaconUpdate),
+                        relayApi.tx.ethereumSystem.registerToken(versionedLocation, metadata),
+                    ])
+                ),
                 alice
             );
 


### PR DESCRIPTION
# Description
This PR implements slash + rewards e2e tests version 1. 

The version 1 only checks if the message is indicated to be successfully processed by gateway. But, it does not verify if it is processed by trying to claim the reward and actually checking if slash is applied. This will be implemented by version 2.

Other changes:
- We increased `max_dispatch_gas` for `ReportRewards` and `ReportSlashes` to 1 million from 60k gas.
- We modified the test to check operator block production to check if operator is part of session validators.
- We now start secondary governance channel relayer for token registration.