### PR TITLE
Don't send message to Ethereum with zero rewards

### DIFF
--- a/chains/orchestrator-relays/runtime/dancelight/src/genesis_config_presets.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/genesis_config_presets.rs
@@ -437,6 +437,7 @@ fn dancelight_testnet_genesis(
                     x.stash.clone()
                 })
                 .collect::<Vec<_>>(),
+            ..Default::default()
         },
     })
 }

--- a/chains/orchestrator-relays/runtime/dancelight/src/tests/common/mod.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/tests/common/mod.rs
@@ -18,8 +18,8 @@
 
 use {
     crate::{
-        BlockProductionCost, CollatorAssignmentCost, ExternalValidatorSlashes, MessageQueue,
-        RuntimeCall, Authorship
+        Authorship, BlockProductionCost, CollatorAssignmentCost, ExternalValidatorSlashes,
+        MessageQueue, RuntimeCall,
     },
     babe_primitives::{
         digests::{PreDigest, SecondaryPlainPreDigest},
@@ -407,7 +407,6 @@ impl ExtBuilder {
         self
     }
 
-
     pub fn with_collators(mut self, collators: Vec<(AccountId, Balance)>) -> Self {
         self.collators = collators;
         self
@@ -626,7 +625,7 @@ impl ExtBuilder {
 
         if !self.external_validators.is_empty() {
             let validator_keys: Vec<_> = self
-                .validators
+                .external_validators
                 .clone()
                 .into_iter()
                 .map(|(account, _balance)| {

--- a/chains/orchestrator-relays/runtime/dancelight/src/tests/common/mod.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/tests/common/mod.rs
@@ -250,10 +250,10 @@ pub fn start_block() -> RunSummary {
 
     // Initialize the new block
     Babe::on_initialize(System::block_number());
+    Authorship::on_initialize(System::block_number());
     ContainerRegistrar::on_initialize(System::block_number());
     ExternalValidatorSlashes::on_initialize(System::block_number());
     Session::on_initialize(System::block_number());
-    Authorship::on_initialize(System::block_number());
 
     Initializer::on_initialize(System::block_number());
     TanssiCollatorAssignment::on_initialize(System::block_number());
@@ -281,6 +281,7 @@ pub fn end_block() {
     advance_block_state_machine(RunBlockState::End(block_number));
     // Finalize the block
     Babe::on_finalize(System::block_number());
+    Authorship::on_finalize(System::block_number());
     Session::on_finalize(System::block_number());
     Grandpa::on_finalize(System::block_number());
     TransactionPayment::on_finalize(System::block_number());

--- a/chains/orchestrator-relays/runtime/dancelight/src/tests/external_validators_tests.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/tests/external_validators_tests.rs
@@ -834,7 +834,10 @@ fn external_validators_rewards_merkle_proofs() {
                 vec![AccountId::from(CHARLIE), AccountId::from(DAVE)]
             );
 
-            // Validators are automatically rewarded.
+            // Reward all validators in era 1
+            crate::RewardValidators::reward_backing(vec![ValidatorIndex(0)]);
+            crate::RewardValidators::reward_backing(vec![ValidatorIndex(1)]);
+            
             assert_eq!(
                 pallet_external_validators_rewards::RewardPointsForEra::<Runtime>::iter().count(),
                 1
@@ -845,6 +848,8 @@ fn external_validators_rewards_merkle_proofs() {
                     .next()
                     .unwrap();
             assert!(era_rewards.total > 0);
+
+            println!("era_rewards: {era_rewards:?}");
 
             let charlie_merkle_proof = ExternalValidatorsRewards::generate_rewards_merkle_proof(
                 AccountId::from(CHARLIE),
@@ -1169,10 +1174,15 @@ fn external_validators_rewards_test_command_integrity() {
                 .count();
 
             let rewards_utils = ExternalValidatorsRewards::generate_era_rewards_utils(1, None);
+
+            let blocks_per_session: u128 = Babe::current_epoch().duration.into();
+            let points_per_block = 20;
+            let expected_total_points = (sessions_per_era as u128) * blocks_per_session * points_per_block;            
+
             let expected_rewards_command = Command::ReportRewards {
                 external_idx: 1u64,
                 era_index: 1u32,
-                total_points: 40u128,
+                total_points: expected_total_points,
                 tokens_inflated: expected_inflation,
                 rewards_merkle_root: rewards_utils.unwrap().rewards_merkle_root,
                 token_id,

--- a/chains/orchestrator-relays/runtime/dancelight/src/tests/external_validators_tests.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/tests/external_validators_tests.rs
@@ -713,6 +713,11 @@ fn external_validators_rewards_sends_message_on_era_end() {
             (AccountId::from(ALICE), 210_000 * UNIT),
             (AccountId::from(BOB), 100_000 * UNIT),
         ])
+        .with_validators(vec![])
+        .with_external_validators(vec![
+            (AccountId::from(ALICE), 210 * UNIT),
+            (AccountId::from(BOB), 100 * UNIT),
+        ])
         .build()
         .execute_with(|| {
             let token_location: VersionedLocation = Location::here().into();
@@ -829,18 +834,10 @@ fn external_validators_rewards_merkle_proofs() {
                 vec![AccountId::from(CHARLIE), AccountId::from(DAVE)]
             );
 
-            assert!(
-                pallet_external_validators_rewards::RewardPointsForEra::<Runtime>::iter().count()
-                    == 0
-            );
-
-            // Reward all validators in era 1
-            crate::RewardValidators::reward_backing(vec![ValidatorIndex(0)]);
-            crate::RewardValidators::reward_backing(vec![ValidatorIndex(1)]);
-
-            assert!(
-                pallet_external_validators_rewards::RewardPointsForEra::<Runtime>::iter().count()
-                    == 1
+            // Validators are automatically rewarded.
+            assert_eq!(
+                pallet_external_validators_rewards::RewardPointsForEra::<Runtime>::iter().count(),
+                1
             );
 
             let (_era_index, era_rewards) =
@@ -1139,18 +1136,10 @@ fn external_validators_rewards_test_command_integrity() {
                 vec![AccountId::from(CHARLIE), AccountId::from(DAVE)]
             );
 
-            assert!(
-                pallet_external_validators_rewards::RewardPointsForEra::<Runtime>::iter().count()
-                    == 0
-            );
-
-            // Reward Alice and Bob in era 1
-            crate::RewardValidators::reward_backing(vec![ValidatorIndex(0)]);
-            crate::RewardValidators::reward_backing(vec![ValidatorIndex(1)]);
-
-            assert!(
-                pallet_external_validators_rewards::RewardPointsForEra::<Runtime>::iter().count()
-                    == 1
+            // Validators are automatically rewarded.
+            assert_eq!(
+                pallet_external_validators_rewards::RewardPointsForEra::<Runtime>::iter().count(),
+                1
             );
 
             let expected_inflation =
@@ -1209,6 +1198,15 @@ fn external_validators_rewards_are_minted_in_sovereign_account() {
             (AccountId::from(ALICE), 210_000 * UNIT),
             (AccountId::from(BOB), 100_000 * UNIT),
         ])
+        .with_validators(
+            vec![]
+        )
+        .with_external_validators(
+            vec![
+                (AccountId::from(ALICE), 210 * UNIT),
+                (AccountId::from(BOB), 100 * UNIT),
+            ]
+        )
         .build()
         .execute_with(|| {
             let token_location: VersionedLocation = Location::here()

--- a/chains/orchestrator-relays/runtime/dancelight/src/tests/inbound_queue_tests/integration_tests.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/tests/inbound_queue_tests/integration_tests.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Tanssi.  If not, see <http://www.gnu.org/licenses/>
 
-use crate::tests::common::{mock_snowbridge_message_proof, ExtBuilder};
+use crate::tests::common::{mock_snowbridge_message_proof, ExtBuilder, ALICE, BOB, UNIT};
 use crate::{AccountId, EthereumInboundQueue, ExternalValidators, Runtime};
 use alloy_sol_types::SolEvent;
 use frame_system::pallet_prelude::OriginFor;
@@ -33,7 +33,16 @@ use tp_bridge::symbiotic_message_processor::{
 
 #[test]
 fn test_inbound_queue_message_passing() {
-    ExtBuilder::default().build().execute_with(|| {
+    ExtBuilder::default()
+    .with_validators(
+        vec![]
+    )
+    .with_external_validators(
+        vec![
+            (AccountId::from(ALICE), 210 * UNIT),
+            (AccountId::from(BOB), 100 * UNIT),
+        ]
+    ).build().execute_with(|| {
         let current_nonce = 1;
 
         snowbridge_pallet_system::Channels::<Runtime>::set(PRIMARY_GOVERNANCE_CHANNEL, Some(Channel {
@@ -58,8 +67,6 @@ fn test_inbound_queue_message_passing() {
             },
             proof: dummy_proof.clone(),
         }), Err(DispatchError::Other("No handler for message found")));
-
-        assert_eq!(ExternalValidators::validators(), ExternalValidators::whitelisted_validators());
 
         let payload_validators = vec![
             AccountKeyring::Charlie.to_account_id(),
@@ -90,7 +97,6 @@ fn test_inbound_queue_message_passing() {
             },
             proof: dummy_proof.clone(),
         }), Ok(()));
-
 
         let expected_validators = [ExternalValidators::whitelisted_validators(), payload_validators].concat();
         assert_eq!(ExternalValidators::validators(), expected_validators);

--- a/chains/orchestrator-relays/runtime/dancelight/src/tests/slashes.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/tests/slashes.rs
@@ -407,6 +407,11 @@ fn test_slashes_are_sent_to_ethereum() {
             (AccountId::from(CHARLIE), 100_000 * UNIT),
             (AccountId::from(DAVE), 100_000 * UNIT),
         ])
+        .with_validators(vec![])
+        .with_external_validators(vec![
+            (AccountId::from(ALICE), 210 * UNIT),
+            (AccountId::from(BOB), 100 * UNIT),
+        ])
         .build()
         .execute_with(|| {
             let token_location: VersionedLocation = Location::here().into();
@@ -422,10 +427,6 @@ fn test_slashes_are_sent_to_ethereum() {
             ));
 
             run_to_block(2);
-            assert_ok!(ExternalValidators::remove_whitelisted(
-                RuntimeOrigin::root(),
-                AccountId::from(ALICE)
-            ));
 
             inject_babe_slash(&AccountId::from(ALICE).to_string());
 
@@ -552,6 +553,15 @@ fn test_slashes_are_sent_to_ethereum_accumulatedly() {
             (AccountId::from(CHARLIE), 100_000 * UNIT),
             (AccountId::from(DAVE), 100_000 * UNIT),
         ])
+        .with_validators(
+            vec![]
+        )
+        .with_external_validators(
+            vec![
+                (AccountId::from(ALICE), 210 * UNIT),
+                (AccountId::from(BOB), 100 * UNIT),
+            ]
+        )
         .build()
         .execute_with(|| {
             let token_location: VersionedLocation = Location::here()
@@ -683,6 +693,15 @@ fn test_slashes_are_sent_to_ethereum_accumulate_until_next_era() {
             (AccountId::from(CHARLIE), 100_000 * UNIT),
             (AccountId::from(DAVE), 100_000 * UNIT),
         ])
+        .with_validators(
+            vec![]
+        )
+        .with_external_validators(
+            vec![
+                (AccountId::from(ALICE), 210 * UNIT),
+                (AccountId::from(BOB), 100 * UNIT),
+            ]
+        )
         .build()
         .execute_with(|| {
             let token_location: VersionedLocation = Location::here()

--- a/pallets/external-validators-rewards/src/lib.rs
+++ b/pallets/external-validators-rewards/src/lib.rs
@@ -43,7 +43,7 @@ use {
     snowbridge_core::{ChannelId, TokenId},
     snowbridge_outbound_queue_merkle_tree::{merkle_proof, merkle_root, verify_proof, MerkleProof},
     sp_core::H256,
-    sp_runtime::traits::{Hash, MaybeEquivalence},
+    sp_runtime::traits::{Hash, MaybeEquivalence, Zero},
     sp_staking::SessionIndex,
     sp_std::collections::btree_set::BTreeSet,
     sp_std::vec,
@@ -274,6 +274,16 @@ pub mod pallet {
             if let Some(token_id) = token_id {
                 if let Some(utils) = Self::generate_era_rewards_utils(era_index, None) {
                     let tokens_inflated = T::EraInflationProvider::get();
+
+                    if tokens_inflated.is_zero() {
+                        log::error!(target: "ext_validators_rewards", "Not sending message because tokens_inflated is 0");
+                        return;
+                    }
+
+                    if utils.total_points.is_zero() {
+                        log::error!(target: "ext_validators_rewards", "Not sending message because total_points is 0");
+                        return;
+                    }
 
                     let ethereum_sovereign_account = T::RewardsEthereumSovereignAccount::get();
                     if let Err(err) =

--- a/pallets/external-validators-rewards/src/mock.rs
+++ b/pallets/external-validators-rewards/src/mock.rs
@@ -17,7 +17,7 @@ use {
     crate as pallet_external_validators_rewards,
     frame_support::{
         parameter_types,
-        traits::{ConstU128, ConstU32, ConstU64},
+        traits::{ConstU32, ConstU64},
     },
     pallet_balances::AccountData,
     snowbridge_core::{
@@ -156,6 +156,7 @@ parameter_types! {
     pub const RewardsEthereumSovereignAccount: u64
         = 0xffffffffffffffff;
     pub RewardTokenLocation: Location = Location::here();
+    pub EraInflationProvider: u128 = Mock::mock().era_inflation.unwrap_or(42);
 }
 
 impl pallet_external_validators_rewards::Config for Test {
@@ -164,7 +165,7 @@ impl pallet_external_validators_rewards::Config for Test {
     type HistoryDepth = ConstU32<10>;
     type BackingPoints = ConstU32<20>;
     type DisputeStatementPoints = ConstU32<20>;
-    type EraInflationProvider = ConstU128<42>;
+    type EraInflationProvider = EraInflationProvider;
     type ExternalIndexProvider = TimestampProvider;
     type GetWhitelistedValidators = ();
     type Hashing = Keccak256;
@@ -191,6 +192,7 @@ pub mod mock_data {
     #[derive(Clone, Default, Encode, Decode, sp_core::RuntimeDebug, scale_info::TypeInfo)]
     pub struct Mocks {
         pub active_era: Option<ActiveEraInfo>,
+        pub era_inflation: Option<u128>,
     }
 
     #[pallet::config]

--- a/pallets/external-validators-rewards/src/tests.rs
+++ b/pallets/external-validators-rewards/src/tests.rs
@@ -175,7 +175,6 @@ fn test_on_era_end_without_proper_token() {
     })
 }
 
-
 #[test]
 fn test_on_era_end_with_zero_inflation() {
     new_test_ext().execute_with(|| {

--- a/pallets/external-validators-rewards/src/tests.rs
+++ b/pallets/external-validators-rewards/src/tests.rs
@@ -16,7 +16,6 @@
 
 use {
     crate::{self as pallet_external_validators_rewards, mock::*},
-    frame_support::traits::Get,
     sp_core::H256,
     sp_std::collections::btree_map::BTreeMap,
     tp_bridge::Command,
@@ -140,6 +139,104 @@ fn test_on_era_end_without_proper_token() {
         });
         Mock::set_location(Location::parent());
         let points = vec![10u32, 30u32, 50u32];
+        let total_points: u32 = points.iter().cloned().sum();
+        let accounts = vec![1u64, 3u64, 5u64];
+        let accounts_points: Vec<(u64, crate::RewardPoints)> = accounts
+            .iter()
+            .cloned()
+            .zip(points.iter().cloned())
+            .collect();
+        ExternalValidatorsRewards::reward_by_ids(accounts_points);
+        ExternalValidatorsRewards::on_era_end(1);
+
+        let rewards_utils = ExternalValidatorsRewards::generate_era_rewards_utils(1, None);
+        let expected_command = Command::ReportRewards {
+            external_idx: 31000u64,
+            era_index: 1u32,
+            total_points: total_points as u128,
+            tokens_inflated:
+                <Test as pallet_external_validators_rewards::Config>::EraInflationProvider::get(), // test inflation value used in mock
+            rewards_merkle_root: rewards_utils.unwrap().rewards_merkle_root,
+            token_id: H256::repeat_byte(0x01),
+        };
+
+        let events = System::events();
+        let expected_not_thrown_event =
+            RuntimeEvent::ExternalValidatorsRewards(crate::Event::RewardsMessageSent {
+                message_id: Default::default(),
+                rewards_command: expected_command,
+            });
+        assert!(
+            !events
+                .iter()
+                .any(|record| record.event == expected_not_thrown_event),
+            "event should not have been thrown",
+        );
+    })
+}
+
+
+#[test]
+fn test_on_era_end_with_zero_inflation() {
+    new_test_ext().execute_with(|| {
+        run_to_block(1);
+
+        Mock::mutate(|mock| {
+            mock.active_era = Some(ActiveEraInfo {
+                index: 1,
+                start: None,
+            });
+            mock.era_inflation = Some(0);
+        });
+        let points = vec![10u32, 30u32, 50u32];
+        let total_points: u32 = points.iter().cloned().sum();
+        let accounts = vec![1u64, 3u64, 5u64];
+        let accounts_points: Vec<(u64, crate::RewardPoints)> = accounts
+            .iter()
+            .cloned()
+            .zip(points.iter().cloned())
+            .collect();
+        ExternalValidatorsRewards::reward_by_ids(accounts_points);
+        ExternalValidatorsRewards::on_era_end(1);
+
+        let rewards_utils = ExternalValidatorsRewards::generate_era_rewards_utils(1, None);
+        let expected_command = Command::ReportRewards {
+            external_idx: 31000u64,
+            era_index: 1u32,
+            total_points: total_points as u128,
+            tokens_inflated:
+                <Test as pallet_external_validators_rewards::Config>::EraInflationProvider::get(), // test inflation value used in mock
+            rewards_merkle_root: rewards_utils.unwrap().rewards_merkle_root,
+            token_id: H256::repeat_byte(0x01),
+        };
+
+        let events = System::events();
+        let expected_not_thrown_event =
+            RuntimeEvent::ExternalValidatorsRewards(crate::Event::RewardsMessageSent {
+                message_id: Default::default(),
+                rewards_command: expected_command,
+            });
+        assert!(
+            !events
+                .iter()
+                .any(|record| record.event == expected_not_thrown_event),
+            "event should not have been thrown",
+        );
+    })
+}
+
+#[test]
+fn test_on_era_end_with_zero_points() {
+    new_test_ext().execute_with(|| {
+        run_to_block(1);
+
+        Mock::mutate(|mock| {
+            mock.active_era = Some(ActiveEraInfo {
+                index: 1,
+                start: None,
+            });
+        });
+        let points = vec![0u32, 0u32, 0u32];
         let total_points: u32 = points.iter().cloned().sum();
         let accounts = vec![1u64, 3u64, 5u64];
         let accounts_points: Vec<(u64, crate::RewardPoints)> = accounts

--- a/pallets/external-validators/src/lib.rs
+++ b/pallets/external-validators/src/lib.rs
@@ -214,6 +214,7 @@ pub mod pallet {
     pub struct GenesisConfig<T: Config> {
         pub skip_external_validators: bool,
         pub whitelisted_validators: Vec<T::ValidatorId>,
+        pub external_validators: Vec<T::ValidatorId>,
     }
 
     #[pallet::genesis_build]
@@ -236,10 +237,16 @@ pub mod pallet {
             )
             .expect("genesis validators are more than T::MaxWhitelistedValidators");
 
+            let bounded_external_validators = BoundedVec::<_, T::MaxExternalValidators>::try_from(
+                self.external_validators.clone(),
+            )
+            .expect("genesis external validators are more than T::MaxExternalValidators");
+
             <SkipExternalValidators<T>>::put(self.skip_external_validators);
             <WhitelistedValidators<T>>::put(&bounded_validators);
             <WhitelistedValidatorsActiveEra<T>>::put(&bounded_validators);
             <WhitelistedValidatorsActiveEraPending<T>>::put(&bounded_validators);
+            <ExternalValidators<T>>::put(&bounded_external_validators);
         }
     }
 

--- a/tools/iforgor/tanssi.toml
+++ b/tools/iforgor/tanssi.toml
@@ -58,9 +58,17 @@ cargo test --release --all --features fast-runtime
 name = "[Tanssi] Cargo Test Crate"
 only_in_dir = "**/tanssi"
 script = """
-cargo test --release -p $1 --features runtime-benchmarks
+cargo test --release -p $1 --features=fast-runtime $2
 """
-args = ["Which crate to test"]
+args = ["Which crate to test", "Tests filter"]
+
+[[entries]]
+name = "[Tanssi] Cargo Test Crate (with benchmarks)"
+only_in_dir = "**/tanssi"
+script = """
+cargo test --release -p $1 --features=fast-runtime,benchmarks $2
+"""
+args = ["Which crate to test", "Tests filter"]
 
 ## Build
 


### PR DESCRIPTION
- Early return if token inflation or points are zero.
- Refactor the code to favor if-guard style (if => early return, avoid nesting)
- Update tests that assumed message was always emitted