### PR TITLE
Fix type in BABE smoke test

### DIFF
--- a/test/suites/smoke-test-dancelight/test-babe.ts
+++ b/test/suites/smoke-test-dancelight/test-babe.ts
@@ -156,7 +156,7 @@ describeSuite({
 
                         expect(sealLogs.length).to.eq(1);
                         const sealLog = api.registry.createType(
-                            "PolkadotPrimitivesV7ValidatorAppSignature",
+                            "PolkadotPrimitivesV8ValidatorAppSignature",
                             sealLogs[0].asSeal[1].toHex()
                         );
 


### PR DESCRIPTION
Updates to the new `PolkadotPrimitivesV8ValidatorAppSignature` type, the old `V7` doesn't exist anymore which makes the test to fail.