### PR TITLE
fix smoke test regarding external validators rewards

### DIFF
--- a/test/suites/smoke-test-dancelight/test-external-validators-rewards.ts
+++ b/test/suites/smoke-test-dancelight/test-external-validators-rewards.ts
@@ -99,6 +99,8 @@ describeSuite({
             test: async () => {
                 const historyDepth = api.consts.externalValidatorsRewards.historyDepth;
 
+                console.log(historyDepth);
+
                 // Checkpoint A: current era index - historyDepth
                 const eraIndexCheckpointA =
                     (await api.query.externalValidators.activeEra()).unwrap().index.toNumber() -
@@ -106,14 +108,15 @@ describeSuite({
                 // Checkpoint B: eraIndexCheckpointA + 1
                 const eraIndexCheckpointB = eraIndexCheckpointA + 1;
 
-                const validatorRewardCheckpointA =
-                    await api.query.externalValidatorsRewards.rewardPointsForEra(eraIndexCheckpointA);
-
-                const validatorRewardCheckpointB =
-                    await api.query.externalValidatorsRewards.rewardPointsForEra(eraIndexCheckpointB);
-
-                expect(validatorRewardCheckpointA.isEmpty).toBe(true);
-                expect(validatorRewardCheckpointB.isEmpty).toBe(false);
+                // The mapping only contains the keys that are in `externalValidatorsRewards`
+                const rewardMappingKeys = (await api.query.externalValidatorsRewards.rewardPointsForEra.keys()).map(
+                    (key) => {
+                        // Convert "1,020" into 1020
+                        return Number.parseInt(key.toHuman().toString().replace(",", ""));
+                    }
+                );
+                expect(rewardMappingKeys.includes(eraIndexCheckpointB)).toBe(true);
+                expect(rewardMappingKeys.includes(eraIndexCheckpointA)).toBe(false);
             },
         });
     },

--- a/test/suites/smoke-test-dancelight/test-external-validators-rewards.ts
+++ b/test/suites/smoke-test-dancelight/test-external-validators-rewards.ts
@@ -108,10 +108,7 @@ describeSuite({
 
                 // The mapping only contains the keys that are in `externalValidatorsRewards`
                 const rewardMappingKeys = (await api.query.externalValidatorsRewards.rewardPointsForEra.keys()).map(
-                    (key) => {
-                        // Convert "1,020" into 1020
-                        return Number.parseInt(key.toHuman().toString().replace(",", ""));
-                    }
+                    (key) => key.args[0].toNumber()
                 );
                 expect(rewardMappingKeys.includes(eraIndexCheckpointB)).toBe(true);
                 expect(rewardMappingKeys.includes(eraIndexCheckpointA)).toBe(false);

--- a/test/suites/smoke-test-dancelight/test-external-validators-rewards.ts
+++ b/test/suites/smoke-test-dancelight/test-external-validators-rewards.ts
@@ -99,8 +99,6 @@ describeSuite({
             test: async () => {
                 const historyDepth = api.consts.externalValidatorsRewards.historyDepth;
 
-                console.log(historyDepth);
-
                 // Checkpoint A: current era index - historyDepth
                 const eraIndexCheckpointA =
                     (await api.query.externalValidators.activeEra()).unwrap().index.toNumber() -


### PR DESCRIPTION
There was an error in a smoke test regarding how we check whether rewards expire. And this was because polkadotjs by default returns a default value there, so we cannot check this properly. Instead I changed it to retrieve all keys, and then check whether the key exists