### PR TITLE
fix check wasm size

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -273,13 +273,19 @@ jobs:
             - name: Download Twiggy
               run: cargo install twiggy
             - name: Lookup for latest target branch build
+              id: latest-target-build
               run: |
                   TARGET_BRANCH=${{ github.event.pull_request.base.ref }}
                   LATEST_TARGET_BRANCH_BUILD=$(gh run -R moondance-labs/tanssi list -w CI --limit=100 --json databaseId,url,headBranch,event,status,conclusion,createdAt --jq ".[] | select(.headBranch == \"$TARGET_BRANCH\" and .event == \"push\" and .status == \"completed\" and .conclusion == \"success\") | .databaseId" | head -n 1)
                   echo "LATEST_TARGET_BRANCH_BUILD=$LATEST_TARGET_BRANCH_BUILD" >> $GITHUB_OUTPUT
-            - name: Download latest target branch build artifacts
-              run: |
-                  gh run download $LATEST_TARGET_BRANCH_BUILD -n runtimes --dir runtimes-target-branch
+            - name: "Download runtimes from target branch"
+              uses: actions/download-artifact@v4
+              with:
+                name: runtimes
+                path: runtimes-target-branch
+                merge-multiple: true
+                github-token: ${{ github.token }}
+                run-id: ${{ steps.latest-target-build.outputs.LATEST_TARGET_BRANCH_BUILD }}
             - name: "Download branch built runtime"
               uses: actions/download-artifact@v4
               with:


### PR DESCRIPTION
Fixes check wasm size. Before we were not correctly passing the latest build id between steps, yielding the  job to always download the latest build (hence the typical no changes). Now we have changed this