### PR TITLE
Use 12 decimals for UNIT

### DIFF
--- a/chains/container-chains/runtime-templates/frontier/src/lib.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/lib.rs
@@ -180,10 +180,10 @@ pub type Executive = frame_executive::Executive<
 pub mod currency {
     use super::Balance;
 
-    pub const MICROUNIT: Balance = 1_000_000_000_000;
-    pub const MILLIUNIT: Balance = 1_000_000_000_000_000;
-    pub const UNIT: Balance = 1_000_000_000_000_000_000;
-    pub const KILOUNIT: Balance = 1_000_000_000_000_000_000_000;
+    pub const MICROUNIT: Balance = 1_000_000;
+    pub const MILLIUNIT: Balance = 1_000_000_000;
+    pub const UNIT: Balance = 1_000_000_000_000;
+    pub const KILOUNIT: Balance = 1_000_000_000_000_000;
 
     pub const STORAGE_BYTE_FEE: Balance = 100 * MICROUNIT;
 

--- a/chains/container-chains/runtime-templates/frontier/src/lib.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/lib.rs
@@ -180,10 +180,10 @@ pub type Executive = frame_executive::Executive<
 pub mod currency {
     use super::Balance;
 
-    pub const MICROUNIT: Balance = 1_000_000;
-    pub const MILLIUNIT: Balance = 1_000_000_000;
-    pub const UNIT: Balance = 1_000_000_000_000;
-    pub const KILOUNIT: Balance = 1_000_000_000_000_000;
+    pub const MICROUNIT: Balance = 1_000_000_000_000;
+    pub const MILLIUNIT: Balance = 1_000_000_000_000_000;
+    pub const UNIT: Balance = 1_000_000_000_000_000_000;
+    pub const KILOUNIT: Balance = 1_000_000_000_000_000_000_000;
 
     pub const STORAGE_BYTE_FEE: Balance = 100 * MICROUNIT;
 

--- a/chains/orchestrator-paras/runtime/dancebox/src/tests/common/mod.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/tests/common/mod.rs
@@ -47,7 +47,7 @@ pub use crate::{
 
 mod xcm;
 
-pub const UNIT: Balance = 1_000_000_000_000_000_000;
+pub const UNIT: Balance = 1_000_000_000_000;
 
 pub fn session_to_block(n: u32) -> u32 {
     let block_number = crate::Period::get() * n;

--- a/chains/orchestrator-paras/runtime/dancebox/src/tests/integration_test.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/tests/integration_test.rs
@@ -2569,16 +2569,16 @@ fn test_staking_join_no_self_delegation() {
     ExtBuilder::default()
         .with_balances(vec![
             // Alice gets 10k extra tokens for her mapping deposit
-            (AccountId::from(ALICE), 210_000 * UNIT),
-            (AccountId::from(BOB), 100_000 * UNIT),
-            (AccountId::from(CHARLIE), 100_000 * UNIT),
-            (AccountId::from(DAVE), 100_000 * UNIT),
+            (AccountId::from(ALICE), 210_000_000_000 * UNIT),
+            (AccountId::from(BOB), 100_000_000_000 * UNIT),
+            (AccountId::from(CHARLIE), 100_000_000_000 * UNIT),
+            (AccountId::from(DAVE), 100_000_000_000 * UNIT),
         ])
         .with_collators(vec![
-            (AccountId::from(ALICE), 210 * UNIT),
-            (AccountId::from(BOB), 100 * UNIT),
-            (AccountId::from(CHARLIE), 100 * UNIT),
-            (AccountId::from(DAVE), 100 * UNIT),
+            (AccountId::from(ALICE), 210_000_000 * UNIT),
+            (AccountId::from(BOB), 100_000_000 * UNIT),
+            (AccountId::from(CHARLIE), 100_000_000 * UNIT),
+            (AccountId::from(DAVE), 100_000_000 * UNIT),
         ])
         .with_empty_parachains(vec![1001, 1002])
         .build()
@@ -2605,16 +2605,16 @@ fn test_staking_join_before_self_delegation() {
     ExtBuilder::default()
         .with_balances(vec![
             // Alice gets 10k extra tokens for her mapping deposit
-            (AccountId::from(ALICE), 210_000 * UNIT),
-            (AccountId::from(BOB), 100_000 * UNIT),
-            (AccountId::from(CHARLIE), 100_000 * UNIT),
-            (AccountId::from(DAVE), 100_000 * UNIT),
+            (AccountId::from(ALICE), 210_000_000_000 * UNIT),
+            (AccountId::from(BOB), 100_000_000_000 * UNIT),
+            (AccountId::from(CHARLIE), 100_000_000_000 * UNIT),
+            (AccountId::from(DAVE), 100_000_000_000 * UNIT),
         ])
         .with_collators(vec![
-            (AccountId::from(ALICE), 210 * UNIT),
-            (AccountId::from(BOB), 100 * UNIT),
-            (AccountId::from(CHARLIE), 100 * UNIT),
-            (AccountId::from(DAVE), 100 * UNIT),
+            (AccountId::from(ALICE), 210_000_000 * UNIT),
+            (AccountId::from(BOB), 100_000_000 * UNIT),
+            (AccountId::from(CHARLIE), 100_000_000 * UNIT),
+            (AccountId::from(DAVE), 100_000_000 * UNIT),
         ])
         .with_empty_parachains(vec![1001, 1002])
         .build()
@@ -3365,15 +3365,15 @@ fn test_pallet_session_takes_validators_from_invulnerables_and_staking() {
     ExtBuilder::default()
         .with_balances(vec![
             // Alice gets 10k extra tokens for her mapping deposit
-            (AccountId::from(ALICE), 210_000 * UNIT),
-            (AccountId::from(BOB), 100_000 * UNIT),
-            (AccountId::from(CHARLIE), 100_000 * UNIT),
-            (AccountId::from(DAVE), 100_000 * UNIT),
+            (AccountId::from(ALICE), 210_000_000_000 * UNIT),
+            (AccountId::from(BOB), 100_000_000_000 * UNIT),
+            (AccountId::from(CHARLIE), 100_000_000_000 * UNIT),
+            (AccountId::from(DAVE), 100_000_000_000 * UNIT),
         ])
         .with_collators(vec![
-            (AccountId::from(ALICE), 210 * UNIT),
-            (AccountId::from(BOB), 100 * UNIT),
-            (AccountId::from(CHARLIE), 100 * UNIT),
+            (AccountId::from(ALICE), 210_000_000 * UNIT),
+            (AccountId::from(BOB), 100_000_000 * UNIT),
+            (AccountId::from(CHARLIE), 100_000_000 * UNIT),
         ])
         .with_empty_parachains(vec![1001, 1002])
         .build()
@@ -3452,15 +3452,15 @@ fn test_pallet_session_limits_num_validators() {
     ExtBuilder::default()
         .with_balances(vec![
             // Alice gets 10k extra tokens for her mapping deposit
-            (AccountId::from(ALICE), 210_000 * UNIT),
-            (AccountId::from(BOB), 100_000 * UNIT),
-            (AccountId::from(CHARLIE), 100_000 * UNIT),
-            (AccountId::from(DAVE), 100_000 * UNIT),
+            (AccountId::from(ALICE), 210_000_000_000 * UNIT),
+            (AccountId::from(BOB), 100_000_000_000 * UNIT),
+            (AccountId::from(CHARLIE), 100_000_000_000 * UNIT),
+            (AccountId::from(DAVE), 100_000_000_000 * UNIT),
         ])
         .with_collators(vec![
-            (AccountId::from(ALICE), 210 * UNIT),
-            (AccountId::from(BOB), 100 * UNIT),
-            (AccountId::from(CHARLIE), 100 * UNIT),
+            (AccountId::from(ALICE), 210_000_000 * UNIT),
+            (AccountId::from(BOB), 100_000_000 * UNIT),
+            (AccountId::from(CHARLIE), 100_000_000 * UNIT),
         ])
         .with_empty_parachains(vec![1001, 1002])
         .with_config(pallet_configuration::HostConfiguration {
@@ -3542,12 +3542,12 @@ fn test_pallet_session_limits_num_validators_from_staking() {
     ExtBuilder::default()
         .with_balances(vec![
             // Alice gets 10k extra tokens for her mapping deposit
-            (AccountId::from(ALICE), 210_000 * UNIT),
-            (AccountId::from(BOB), 100_000 * UNIT),
-            (AccountId::from(CHARLIE), 100_000 * UNIT),
-            (AccountId::from(DAVE), 100_000 * UNIT),
+            (AccountId::from(ALICE), 210_000_000_000 * UNIT),
+            (AccountId::from(BOB), 100_000_000_000 * UNIT),
+            (AccountId::from(CHARLIE), 100_000_000_000 * UNIT),
+            (AccountId::from(DAVE), 100_000_000_000 * UNIT),
         ])
-        .with_collators(vec![(AccountId::from(ALICE), 210 * UNIT)])
+        .with_collators(vec![(AccountId::from(ALICE), 210_000_000 * UNIT)])
         .with_empty_parachains(vec![1001, 1002])
         .with_config(pallet_configuration::HostConfiguration {
             max_collators: 2,
@@ -3651,12 +3651,12 @@ fn test_reward_to_staking_candidate() {
     ExtBuilder::default()
         .with_balances(vec![
             // Alice gets 10k extra tokens for her mapping deposit
-            (AccountId::from(ALICE), 210_000 * UNIT),
-            (AccountId::from(BOB), 100_000 * UNIT),
-            (AccountId::from(CHARLIE), 100_000 * UNIT),
-            (AccountId::from(DAVE), 100_000 * UNIT),
+            (AccountId::from(ALICE), 210_000_000_000 * UNIT),
+            (AccountId::from(BOB), 100_000_000_000 * UNIT),
+            (AccountId::from(CHARLIE), 100_000_000_000 * UNIT),
+            (AccountId::from(DAVE), 100_000_000_000 * UNIT),
         ])
-        .with_collators(vec![(AccountId::from(ALICE), 210 * UNIT)])
+        .with_collators(vec![(AccountId::from(ALICE), 210_000_000 * UNIT)])
         .with_empty_parachains(vec![1001, 1002])
         .build()
         .execute_with(|| {
@@ -4034,14 +4034,14 @@ fn test_collator_assignment_gives_priority_to_invulnerables() {
     ExtBuilder::default()
         .with_balances(vec![
             // Alice gets 10k extra tokens for her mapping deposit
-            (AccountId::from(ALICE), 210_000 * UNIT),
-            (AccountId::from(BOB), 100_000 * UNIT),
-            (AccountId::from(CHARLIE), 100_000 * UNIT),
-            (AccountId::from(DAVE), 100_000 * UNIT),
+            (AccountId::from(ALICE), 210_000_000_000 * UNIT),
+            (AccountId::from(BOB), 100_000_000_000 * UNIT),
+            (AccountId::from(CHARLIE), 100_000_000_000 * UNIT),
+            (AccountId::from(DAVE), 100_000_000_000 * UNIT),
         ])
         .with_collators(vec![
-            (AccountId::from(ALICE), 210 * UNIT),
-            (AccountId::from(DAVE), 100 * UNIT),
+            (AccountId::from(ALICE), 210_000_000 * UNIT),
+            (AccountId::from(DAVE), 100_000_000 * UNIT),
         ])
         .with_empty_parachains(vec![1001, 1002])
         .build()

--- a/chains/orchestrator-paras/runtime/flashbox/src/tests/common/mod.rs
+++ b/chains/orchestrator-paras/runtime/flashbox/src/tests/common/mod.rs
@@ -44,7 +44,7 @@ pub use crate::{
     RuntimeCall, ServicesPayment, Session, StreamPayment, System, TransactionPayment,
 };
 
-pub const UNIT: Balance = 1_000_000_000_000_000_000;
+pub const UNIT: Balance = 1_000_000_000_000;
 
 pub fn session_to_block(n: u32) -> u32 {
     let block_number = crate::Period::get() * n;

--- a/chains/orchestrator-relays/runtime/dancelight/src/tests/common/mod.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/tests/common/mod.rs
@@ -75,7 +75,7 @@ pub use crate::{
     System, TanssiAuthorityAssignment, TanssiCollatorAssignment, TransactionPayment,
 };
 
-pub const UNIT: Balance = 1_000_000_000_000_000_000;
+pub const UNIT: Balance = 1_000_000_000_000;
 
 pub fn read_last_entropy() -> [u8; 32] {
     let mut last = [0u8; 32];

--- a/chains/orchestrator-relays/runtime/dancelight/src/tests/staking.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/tests/staking.rs
@@ -356,16 +356,16 @@ fn test_staking_join_no_self_delegation() {
     ExtBuilder::default()
         .with_balances(vec![
             // Alice gets 10k extra tokens for her mapping deposit
-            (AccountId::from(ALICE), 210_000 * UNIT),
-            (AccountId::from(BOB), 100_000 * UNIT),
-            (AccountId::from(CHARLIE), 100_000 * UNIT),
-            (AccountId::from(DAVE), 100_000 * UNIT),
+            (AccountId::from(ALICE), 210_000_000_000 * UNIT),
+            (AccountId::from(BOB), 100_000_000_000 * UNIT),
+            (AccountId::from(CHARLIE), 100_000_000_000 * UNIT),
+            (AccountId::from(DAVE), 100_000_000_000 * UNIT),
         ])
         .with_collators(vec![
-            (AccountId::from(ALICE), 210 * UNIT),
-            (AccountId::from(BOB), 100 * UNIT),
-            (AccountId::from(CHARLIE), 100 * UNIT),
-            (AccountId::from(DAVE), 100 * UNIT),
+            (AccountId::from(ALICE), 210_000_000 * UNIT),
+            (AccountId::from(BOB), 100_000_000 * UNIT),
+            (AccountId::from(CHARLIE), 100_000_000 * UNIT),
+            (AccountId::from(DAVE), 100_000_000 * UNIT),
         ])
         .with_empty_parachains(vec![1001, 1002])
         .build()
@@ -392,16 +392,16 @@ fn test_staking_join_before_self_delegation() {
     ExtBuilder::default()
         .with_balances(vec![
             // Alice gets 10k extra tokens for her mapping deposit
-            (AccountId::from(ALICE), 210_000 * UNIT),
-            (AccountId::from(BOB), 100_000 * UNIT),
-            (AccountId::from(CHARLIE), 100_000 * UNIT),
-            (AccountId::from(DAVE), 100_000 * UNIT),
+            (AccountId::from(ALICE), 210_000_000_000 * UNIT),
+            (AccountId::from(BOB), 100_000_000_000 * UNIT),
+            (AccountId::from(CHARLIE), 100_000_000_000 * UNIT),
+            (AccountId::from(DAVE), 100_000_000_000 * UNIT),
         ])
         .with_collators(vec![
-            (AccountId::from(ALICE), 210 * UNIT),
-            (AccountId::from(BOB), 100 * UNIT),
-            (AccountId::from(CHARLIE), 100 * UNIT),
-            (AccountId::from(DAVE), 100 * UNIT),
+            (AccountId::from(ALICE), 210_000_000 * UNIT),
+            (AccountId::from(BOB), 100_000_000 * UNIT),
+            (AccountId::from(CHARLIE), 100_000_000 * UNIT),
+            (AccountId::from(DAVE), 100_000_000 * UNIT),
         ])
         .with_empty_parachains(vec![1001, 1002])
         .build()


### PR DESCRIPTION
# Description

Currently we are using 18 decimales instead of 12 for the UNIT const.
This PR updates this to use 12 decimals like polkadot