### PR TITLE
Add more external validator slashes smoke tests

### DIFF
--- a/test/suites/smoke-test-dancelight/test-external-validator-slashes.ts
+++ b/test/suites/smoke-test-dancelight/test-external-validator-slashes.ts
@@ -95,7 +95,7 @@ describeSuite({
                 const activeEra = (await api.query.externalValidators.activeEra()).unwrap();
                 const bondedDuration = api.consts.externalValidatorSlashes.bondingDuration;
 
-                const firstKeptIndex = activeEra.index.toNumber() - bondedDuration.toNumber();
+                const firstKeptIndex = Math.max(activeEra.index.toNumber() - bondedDuration.toNumber(), 0);
 
                 const allSlashes = await api.query.externalValidatorSlashes.slashes.entries();
                 const eraIndexes = allSlashes.map((entry) => {
@@ -118,7 +118,7 @@ describeSuite({
                 const activeEra = (await api.query.externalValidators.activeEra()).unwrap();
                 const bondedDuration = api.consts.externalValidatorSlashes.bondingDuration;
 
-                const firstKeptIndex = activeEra.index.toNumber() - bondedDuration.toNumber();
+                const firstKeptIndex = Math.max(activeEra.index.toNumber() - bondedDuration.toNumber(), 0);
                 const allBondedEras = await api.query.externalValidatorSlashes.bondedEras();
 
                 // We shouldn't have more bonded eras than the bondedDuration


### PR DESCRIPTION
# Description

Add smoke tests for validator slashes for the following cases:

- slashes expires after bonding period
- Bonded eras are rotated after bonding period
- Slashes message should't contain more slashes than the amount defined in `queuedSlashesProcessedPerBlock`