### PR TITLE
Disable polkadot binary checksum check in unsupported archs

### DIFF
--- a/test/polkadotReleaseMapping.json
+++ b/test/polkadotReleaseMapping.json
@@ -5,8 +5,8 @@
     "polkadot-execute-worker": "8932f0b07323a497470de2c7d8b9b7583af27de3836518fbf62047a68bc788f9"
   },
   "stable2412": {
-    "polkadot": "815cf5ee797c07e4f5ebf0f925d6f737e7abf110e2fb8b9776da1ad965ee0fc0",
-    "polkadot-execute-worker": "c6e7228c34979794791a82ff153b9ade4c262b07345f93b8c003a158ba4d7351",
-    "polkadot-prepare-worker": "eae795259656b7acd07effc4921a99cf116a15cdabab331cef8f798c25499636"
+    "polkadot": "b84b2942edf66dd23c8f91f1db3bb2b4ba00c5b0836c400150f9f64479f013f1",
+    "polkadot-execute-worker": "23938ddc767ebf943d281ad154aabb8d987ce6c8bacbf7978f445f6d8935cf55",
+    "polkadot-prepare-worker": "ea258816aac8a0a7e3870ebec33f300dccc1e04f1f6e594dd53c282ae58bf089"
   }
 }

--- a/test/scripts/download-polkadot.sh
+++ b/test/scripts/download-polkadot.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# This script is deprecated, use downloadPolkadot.ts instead
+
 # Exit on any error
 set -e
 

--- a/test/scripts/downloadPolkadot.ts
+++ b/test/scripts/downloadPolkadot.ts
@@ -7,6 +7,7 @@ import { parse } from "toml";
 import path from "node:path";
 import { execSync } from "node:child_process";
 import { createHash } from "node:crypto";
+import os from "node:os";
 
 const CONFIG = {
     FOLDER_NAME: "tmp",
@@ -20,6 +21,7 @@ async function main() {
     const cargoToml = parse(fileContents) as CargoToml;
     const stableVersion = findPolkadotStableVersion(cargoToml.workspace.dependencies);
     console.log(`🔎 Found polkadot-sdk version: ${stableVersion}`);
+    checkSupportedArch(stableVersion);
 
     for (const binName of CONFIG.BINARIES) {
         const pathName = path.join(CONFIG.FOLDER_NAME, binName);
@@ -145,3 +147,18 @@ const getSha256 = (filePath: string) => {
 };
 
 const mini = (hash: string) => `<${hash.slice(0, 4)}...${hash.slice(-4)}>`;
+
+function checkSupportedArch(stableVersion: string): void {
+    const supportedOS = "linux";
+    const supportedArch = "x64"; // x86_64
+
+    const currentOS = os.platform();
+    const currentArch = os.arch();
+
+    if (currentOS !== supportedOS || currentArch !== supportedArch) {
+        const errorMsg = `Unsupported environment: expected (${supportedOS}, ${supportedArch}), found (${currentOS}, ${currentArch}).`;
+        console.error(errorMsg);
+        console.info(`You will need to manually compile the required binaries. Make sure they are for version ${stableVersion}`);
+        throw new Error(errorMsg);
+    }
+}


### PR DESCRIPTION
Polkadot binaries can only be downloaded in linux x86_64, anything else needs manual compilation so the downloadPolkadot script is not useful.

Also update the checksum file because there has been a new minor polkadot release. When moonwall is asked to download the binaries for stable2412, it will check the most recent release. So if the checksum is for 1.16.2 but the latest binary is 1.16.3, it will download 1.16.3 and the checksum won't match, so it will be updated.

For the future, a better solution would be to save a mapping of branchName to binaryVersion, like "stable2412": "1.16.2"