### PR TITLE
Fix swapped inflation rates in dancelight

### DIFF
--- a/chains/orchestrator-relays/runtime/dancelight/src/lib.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/lib.rs
@@ -1444,7 +1444,7 @@ parameter_types! {
             &EthereumLocation::get()
         ).expect("to convert EthereumSovereignAccount");
 
-    pub ExternalRewardsEraInflationProvider: u128 = CollatorsInflationRatePerBlock::get() * Balances::total_issuance();
+    pub ExternalRewardsEraInflationProvider: u128 = ValidatorsInflationRatePerEra::get() * Balances::total_issuance();
 
     pub TokenLocationReanchored: Location = xcm_config::TokenLocation::get().reanchored(
         &EthereumLocation::get(),
@@ -1470,6 +1470,8 @@ impl tp_bridge::TokenChannelSetterBenchmarkHelperTrait for RewardsBenchHelper {
 
     fn set_up_channel(_channel_id: ChannelId, _para_id: ParaId, _agent_id: AgentId) {}
 }
+
+// Pallet to reward validators.
 impl pallet_external_validators_rewards::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type EraIndexProvider = ExternalValidators;
@@ -1711,12 +1713,13 @@ impl frame_support::traits::OnUnbalanced<Credit<AccountId, Balances>> for OnUnba
     }
 }
 
+// Pallet to reward container chains collators.
 impl pallet_inflation_rewards::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type Currency = Balances;
     type ContainerChains = ContainerRegistrar;
     type GetSelfChainBlockAuthor = ();
-    type InflationRate = ValidatorsInflationRatePerEra;
+    type InflationRate = CollatorsInflationRatePerBlock;
     type OnUnbalanced = OnUnbalancedInflation;
     type PendingRewardsAccount = PendingRewardsAccount;
     type StakingRewardsDistributor = InvulnerableRewardDistribution<Self, Balances, PooledStaking>;


### PR DESCRIPTION
Inflation rates are swapped between block and era. This PR fixes it and add tests ensuring they are used properly.