### PR TITLE
unhash-key script

### DIFF
--- a/test/package.json
+++ b/test/package.json
@@ -21,6 +21,7 @@
         "duplicate-function-finder": "tsx scripts/duplicateFunctionFinder.ts check suites",
         "sudo-register-para": "tsx scripts/sudoRegisterPara.ts",
         "sudo-starlight-register-para": "tsx scripts/sudoStarlightRegisterPara.ts",
+        "unhash-key": "tsx scripts/unhashKey.ts",
         "zombienet-restart": "tsx scripts/zombienetRestart.ts"
     },
     "keywords": [],

--- a/test/scripts/unhashKey.ts
+++ b/test/scripts/unhashKey.ts
@@ -1,4 +1,17 @@
-#!/usr/bin/env node
+/**
+unhash-key
+
+Given a raw storage key, try to find which pallet it belongs to, and which storage item
+
+Usage:
+# List all pallet prefixes for a selected chain
+pnpm unhash-key
+# Search for a key in all endpoints
+pnpm unhash-key 0x94eadf0156a8ad5156507773d0471e4a49f6c9aa90c04982c05388649310f22f
+# Search for a key in a specific endpoint
+pnpm unhash-key --url 'wss://dancelight.tanssi-api.network' 0x94eadf0156a8ad5156507773d0471e4a49f6c9aa90c04982c05388649310f22f
+ */
+
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import { NETWORK_YARGS_OPTIONS, getApiFor } from "./utils/network";

--- a/test/scripts/unhashKey.ts
+++ b/test/scripts/unhashKey.ts
@@ -19,11 +19,15 @@ import { xxhashAsHex } from "@polkadot/util-crypto";
 import type { ApiPromise } from "@polkadot/api/promise/Api";
 
 const DEFAULT_ENDPOINTS = [
+    "wss://rpc.polkadot.io",
     "wss://dancelight.tanssi-api.network",
     "wss://stagelight.tanssi-dev.network",
     "wss://dancebox.tanssi-api.network",
     "wss://fraa-flashbox-rpc.a.stagenet.tanssi.network",
     "wss://stagebox.tanssi-dev.network",
+    // Relay chains, ideally we should use our relay endpoint
+    "wss://rococo-rpc.polkadot.io",
+    "wss://westend-rpc.polkadot.io",
     // Frontier template
     "wss://dancebox-3001.tanssi-api.network",
     // TODO: add simple template rpc endpoint

--- a/test/scripts/unhashKey.ts
+++ b/test/scripts/unhashKey.ts
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+import { NETWORK_YARGS_OPTIONS, getApiFor } from "./utils/network";
+import { xxhashAsHex } from '@polkadot/util-crypto';
+
+yargs(hideBin(process.argv))
+    .usage("Usage: $0 [key]")
+    .version("1.0.0")
+    .command(
+        "$0 [key]",
+        "List pallets sorted by storage prefix or search for a storage key",
+        (yargs) => {
+            return yargs
+                .positional("key", {
+                    describe: "Hex key to search for",
+                    type: "string",
+                })
+                .options({
+                    ...NETWORK_YARGS_OPTIONS,
+                });
+        },
+        async (argv) => {
+            const api = await getApiFor(argv);
+            try {
+                if (!argv.key) {
+                    // No key provided: list all pallets sorted by storage prefix.
+                    console.log("All pallets sorted by storage prefix:");
+                    const pallets = [];
+                    const mt = api.runtimeMetadata;
+
+                    for (const module of mt.asLatest.pallets) {
+                        if (module.storage.isNone) {
+                            continue;
+                        }
+                        const prefix = xxhashAsHex(module.storage.unwrap().prefix.toString(), 128);
+                        pallets.push({ pallet: module.name.toString(), prefix });
+                    }
+                    // Sort pallets by hex prefix lexicographically.
+                    pallets.sort((a, b) => (a.prefix > b.prefix ? 1 : a.prefix < b.prefix ? -1 : 0));
+                    pallets.forEach((p) => {
+                        console.log(`${p.prefix}  ${p.pallet}`);
+                    });
+                } else {
+                    if (!argv.key.startsWith("0x")) {
+                        console.error("Key must start with 0x");
+                        throw new Error("Key must start with 0x");
+                    }
+                    // A key is provided: search for matching storage queries in each pallet.
+                    console.log(`Searching for key ${argv.key}`);
+                    const pallets = [];
+                    const mt = api.runtimeMetadata;
+
+                    for (const module of mt.asLatest.pallets) {
+                        if (module.storage.isNone) {
+                            continue;
+                        }
+                        const prefix = xxhashAsHex(module.storage.unwrap().prefix.toString(), 128);
+                        pallets.push({ pallet: module.name.toString(), prefix });
+
+                        if (argv.key.startsWith(prefix)) {
+                            // Found pallet, now find key
+                            console.log("✅ Found matching prefix: pallet", module.name.toString());
+
+                            const storages = module.storage.unwrap().items;
+
+                            let foundMatch = false;
+                            for (const storage of storages) {
+                                let keyValue = prefix + xxhashAsHex(storage.name.toString(), 128).slice(2);
+
+                                // Check if the provided key and the storage key are prefix matches.
+                                if (argv.key.startsWith(keyValue)) {
+                                    console.log("✅ Found key:");
+                                    console.log("");
+                                    console.log(`${keyValue}: ${module.name.toString()} ${storage.name.toString()}`);
+                                    console.log("");
+                                    foundMatch = true;
+                                    break;
+                                }
+                            }
+                            if (!foundMatch) {
+                                console.log("No matching storage found");
+                            }
+
+                        }
+                    }
+                }
+            } finally {
+                await api.disconnect();
+            }
+        }
+    )
+    .parse();

--- a/test/scripts/unhashKey.ts
+++ b/test/scripts/unhashKey.ts
@@ -2,7 +2,7 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import { NETWORK_YARGS_OPTIONS, getApiFor } from "./utils/network";
-import { xxhashAsHex } from '@polkadot/util-crypto';
+import { xxhashAsHex } from "@polkadot/util-crypto";
 
 yargs(hideBin(process.argv))
     .usage("Usage: $0 [key]")
@@ -13,7 +13,7 @@ yargs(hideBin(process.argv))
         (yargs) => {
             return yargs
                 .positional("key", {
-                    describe: "Hex key to search for",
+                    describe: "Storage key to search for. Prefixed by 0x",
                     type: "string",
                 })
                 .options({
@@ -21,14 +21,13 @@ yargs(hideBin(process.argv))
                 });
         },
         async (argv) => {
-            const api = await getApiFor(argv);
-            try {
-                if (!argv.key) {
-                    // No key provided: list all pallets sorted by storage prefix.
+            // No key provided: list pallets from a single network
+            if (!argv.key) {
+                const api = await getApiFor(argv);
+                try {
                     console.log("All pallets sorted by storage prefix:");
                     const pallets = [];
                     const mt = api.runtimeMetadata;
-
                     for (const module of mt.asLatest.pallets) {
                         if (module.storage.isNone) {
                             continue;
@@ -41,52 +40,105 @@ yargs(hideBin(process.argv))
                     pallets.forEach((p) => {
                         console.log(`${p.prefix}  ${p.pallet}`);
                     });
-                } else {
-                    if (!argv.key.startsWith("0x")) {
-                        console.error("Key must start with 0x");
-                        throw new Error("Key must start with 0x");
+                } finally {
+                    await api.disconnect();
+                }
+                return;
+            }
+
+            // Key provided: search mode
+            if (!argv.key.startsWith("0x")) {
+                console.error("Key must start with 0x");
+                process.exit(1);
+            }
+
+            // Determine the list of endpoints to check.
+            // If a URL is provided via the network options, use that only.
+            let endpoints = [];
+            if (argv.url) {
+                endpoints = [argv.url];
+            } else {
+                console.log("No rpc provided. Will try to check all the known endpoints. Use --url to specify one")
+                endpoints = [
+                    "wss://dancelight.tanssi-api.network",
+                    "wss://stagelight.tanssi-dev.network",
+                    "wss://dancebox.tanssi-api.network",
+                    "wss://fraa-flashbox-rpc.a.stagenet.tanssi.network",
+                    "wss://stagebox.tanssi-dev.network",
+                ];
+            }
+
+            let found = false;
+            for (const endpoint of endpoints) {
+                console.log(`\nTrying network endpoint: ${endpoint}`);
+                let api;
+                try {
+                    // Wrap connection attempt in a 10 second timeout.
+                    const connectPromise = getApiFor({ ...argv, url: endpoint });
+                    const timeoutPromise = new Promise((_, reject) =>
+                        setTimeout(
+                            () => reject(new Error("Connection timed out after 10 seconds")),
+                            10000
+                        )
+                    );
+                    api = await Promise.race([connectPromise, timeoutPromise]);
+                } catch (err) {
+                    console.error(`Failed to connect to ${endpoint}: ${err}`);
+                    continue;
+                }
+
+                const mt = api.runtimeMetadata;
+                // Iterate over all pallets.
+                for (const module of mt.asLatest.pallets) {
+                    if (module.storage.isNone) {
+                        continue;
                     }
-                    // A key is provided: search for matching storage queries in each pallet.
-                    console.log(`Searching for key ${argv.key}`);
-                    const pallets = [];
-                    const mt = api.runtimeMetadata;
-
-                    for (const module of mt.asLatest.pallets) {
-                        if (module.storage.isNone) {
-                            continue;
+                    // Compute pallet storage prefix.
+                    const prefix = xxhashAsHex(
+                        module.storage.unwrap().prefix.toString(),
+                        128
+                    );
+                    // Check if the provided key starts with the pallet prefix.
+                    if (argv.key.startsWith(prefix)) {
+                        // Found pallet, now find key
+                        console.log("✅ Found matching prefix: pallet", module.name.toString(), prefix);
+                        const storages = module.storage.unwrap().items;
+                        let foundMatch = false;
+                        for (const storage of storages) {
+                            // Each storage key is computed by concatenating the pallet prefix with
+                            // the 128-bit hash (without the '0x' prefix) of the storage item name.
+                            let keyValue =
+                                prefix + xxhashAsHex(storage.name.toString(), 128).slice(2);
+                            // Check if the provided key and the storage key are prefix matches.
+                            if (argv.key.startsWith(keyValue)) {
+                                console.log("✅ Found key:");
+                                console.log("");
+                                console.log(
+                                    `${keyValue}: ${module.name.toString()} ${storage.name.toString()}`
+                                );
+                                console.log("");
+                                foundMatch = true;
+                                found = true;
+                                break;
+                            }
                         }
-                        const prefix = xxhashAsHex(module.storage.unwrap().prefix.toString(), 128);
-                        pallets.push({ pallet: module.name.toString(), prefix });
-
-                        if (argv.key.startsWith(prefix)) {
-                            // Found pallet, now find key
-                            console.log("✅ Found matching prefix: pallet", module.name.toString());
-
-                            const storages = module.storage.unwrap().items;
-
-                            let foundMatch = false;
-                            for (const storage of storages) {
-                                let keyValue = prefix + xxhashAsHex(storage.name.toString(), 128).slice(2);
-
-                                // Check if the provided key and the storage key are prefix matches.
-                                if (argv.key.startsWith(keyValue)) {
-                                    console.log("✅ Found key:");
-                                    console.log("");
-                                    console.log(`${keyValue}: ${module.name.toString()} ${storage.name.toString()}`);
-                                    console.log("");
-                                    foundMatch = true;
-                                    break;
-                                }
-                            }
-                            if (!foundMatch) {
-                                console.log("No matching storage found");
-                            }
-
+                        if (!foundMatch) {
+                            console.log("No matching storage found in this pallet.");
+                        }
+                        // Stop checking pallets if key found.
+                        if (found) {
+                            break;
                         }
                     }
                 }
-            } finally {
                 await api.disconnect();
+                // Stop checking endpoints if key found.
+                if (found) {
+                    break;
+                }
+            }
+            if (!found) {
+                console.log("Key not found in any provided network endpoint.");
             }
         }
     )

--- a/test/scripts/utils/network.ts
+++ b/test/scripts/utils/network.ts
@@ -53,6 +53,7 @@ export const getApiFor = async (argv: Argv) => {
     return await ApiPromise.create({
         noInitWarn: true,
         provider: wsProvider,
+        throwOnConnect: true,
     });
 };
 
@@ -61,7 +62,9 @@ export function isKnownNetwork(name: string): name is NETWORK_NAME {
 }
 
 export const getWsProviderForNetwork = (name: NETWORK_NAME) => {
-    return new WsProvider(NETWORK_WS_URLS[name]);
+    // Override default timeout of 60s
+    const timeout = 10_000;
+    return new WsProvider(NETWORK_WS_URLS[name], undefined, undefined, timeout);
 };
 
 // Supports providing an URL or a known network
@@ -69,5 +72,7 @@ export const getWsProviderFor = (argv: Argv) => {
     if (isKnownNetwork(argv.network)) {
         return getWsProviderForNetwork(argv.network);
     }
-    return new WsProvider(argv.url);
+    // Override default timeout of 60s
+    const timeout = 10_000;
+    return new WsProvider(argv.url, undefined, undefined, timeout);
 };


### PR DESCRIPTION
Given a raw storage key, try to find which pallet it belongs to, and which storage item

Usage:

```
# List all pallet prefixes for a selected chain
pnpm unhash-key
# Search for a key in all endpoints
pnpm unhash-key 0x94eadf0156a8ad5156507773d0471e4a49f6c9aa90c04982c05388649310f22f
# Search for a key in a specific endpoint
pnpm unhash-key --url 'wss://dancelight.tanssi-api.network' 0x94eadf0156a8ad5156507773d0471e4a49f6c9aa90c04982c05388649310f22f
```

Sample output:

```
✅ Found matching prefix: pallet ParaScheduler 0x94eadf0156a8ad5156507773d0471e4a
✅ Found key in network Polkadot:

0x94eadf0156a8ad5156507773d0471e4a49f6c9aa90c04982c05388649310f22f: ParaScheduler ClaimQueue
```