### PR TITLE
Add xcm versioning test to chopsticks upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,7 +567,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "asset-test-utils"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
@@ -596,7 +596,7 @@ dependencies = [
 [[package]]
 name = "assets-common"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -967,7 +967,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "13.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "hash-db",
  "log",
@@ -1220,7 +1220,7 @@ dependencies = [
 [[package]]
 name = "bp-header-chain"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bp-runtime",
  "finality-grandpa",
@@ -1237,7 +1237,7 @@ dependencies = [
 [[package]]
 name = "bp-messages"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -1253,7 +1253,7 @@ dependencies = [
 [[package]]
 name = "bp-parachains"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
@@ -1270,7 +1270,7 @@ dependencies = [
 [[package]]
 name = "bp-polkadot-core"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1287,7 +1287,7 @@ dependencies = [
 [[package]]
 name = "bp-relayers"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -1305,7 +1305,7 @@ dependencies = [
 [[package]]
 name = "bp-runtime"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1328,7 +1328,7 @@ dependencies = [
 [[package]]
 name = "bp-test-utils"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -1348,7 +1348,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub"
 version = "0.2.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1365,7 +1365,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.6.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1377,7 +1377,7 @@ dependencies = [
 [[package]]
 name = "bridge-hub-common"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1394,7 +1394,7 @@ dependencies = [
 [[package]]
 name = "bridge-runtime-common"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -2605,7 +2605,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -2622,7 +2622,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -2645,7 +2645,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -2691,7 +2691,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -2721,7 +2721,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-proposer"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2736,7 +2736,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -2762,7 +2762,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2784,7 +2784,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2810,7 +2810,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -2847,7 +2847,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -2883,7 +2883,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
@@ -2894,7 +2894,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
 version = "9.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2907,7 +2907,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2922,7 +2922,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bounded-collections 0.2.2",
  "bp-xcm-bridge-hub-router",
@@ -2947,7 +2947,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "sp-api",
  "sp-consensus-aura",
@@ -2956,7 +2956,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2972,7 +2972,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2986,7 +2986,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.2.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2996,7 +2996,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -3013,7 +3013,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -3023,7 +3023,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -3040,7 +3040,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3064,7 +3064,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3083,7 +3083,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -3118,7 +3118,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3159,7 +3159,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -4211,7 +4211,7 @@ dependencies = [
 [[package]]
 name = "emulated-integration-tests-common"
 version = "3.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "asset-test-utils",
  "bp-messages",
@@ -5098,7 +5098,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "12.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -5226,7 +5226,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -5250,7 +5250,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "32.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -5312,7 +5312,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "13.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
@@ -5323,7 +5323,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -5339,7 +5339,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -5392,7 +5392,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "array-bytes",
  "const-hex",
@@ -5408,7 +5408,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.35.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "futures 0.3.31",
  "indicatif",
@@ -5430,7 +5430,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -5473,7 +5473,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "23.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -5493,7 +5493,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "10.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.2.0",
@@ -5505,7 +5505,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "11.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5515,7 +5515,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "cfg-if",
  "docify",
@@ -5535,7 +5535,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5549,7 +5549,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "26.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -5559,7 +5559,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.34.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -8320,7 +8320,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "29.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "futures 0.3.31",
  "log",
@@ -8339,7 +8339,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "jsonrpsee 0.24.7",
  "parity-scale-codec",
@@ -9169,7 +9169,7 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 [[package]]
 name = "pallet-asset-conversion"
 version = "10.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9187,7 +9187,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9201,7 +9201,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9218,7 +9218,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "29.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9363,7 +9363,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9376,7 +9376,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9399,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "27.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "aquamarine",
  "docify",
@@ -9420,7 +9420,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9449,7 +9449,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9468,7 +9468,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
@@ -9493,7 +9493,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "27.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9510,7 +9510,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-grandpa"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -9529,7 +9529,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-messages"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -9548,7 +9548,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-parachains"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -9568,7 +9568,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-relayers"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -9592,7 +9592,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.6.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -9639,7 +9639,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "27.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9689,7 +9689,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "9.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9708,7 +9708,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9743,7 +9743,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -9794,7 +9794,7 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9809,7 +9809,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9826,7 +9826,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "27.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9848,7 +9848,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "27.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9861,7 +9861,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "29.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10233,7 +10233,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "27.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10270,7 +10270,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10292,7 +10292,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "29.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -10308,7 +10308,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "27.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10327,7 +10327,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10418,7 +10418,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10434,7 +10434,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "31.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -10472,7 +10472,7 @@ dependencies = [
 [[package]]
 name = "pallet-migrations"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "cfg-if",
  "docify",
@@ -10490,7 +10490,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "27.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10507,7 +10507,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10518,7 +10518,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10533,7 +10533,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "25.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10551,7 +10551,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "26.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10571,7 +10571,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "23.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -10596,7 +10596,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "27.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10612,7 +10612,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10647,7 +10647,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10687,7 +10687,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10703,7 +10703,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10713,7 +10713,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10731,7 +10731,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10745,7 +10745,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -10825,7 +10825,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "4.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10839,7 +10839,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "29.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10884,7 +10884,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10905,7 +10905,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10921,7 +10921,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10938,7 +10938,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10960,7 +10960,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "11.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
@@ -10971,7 +10971,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "19.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -10980,7 +10980,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "14.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10990,7 +10990,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "29.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11041,7 +11041,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11056,7 +11056,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "27.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11075,7 +11075,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "27.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11093,7 +11093,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11109,7 +11109,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "30.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "jsonrpsee 0.24.7",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -11125,7 +11125,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -11137,7 +11137,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "27.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11156,7 +11156,7 @@ dependencies = [
 [[package]]
 name = "pallet-tx-pause"
 version = "9.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11173,7 +11173,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11188,7 +11188,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11202,7 +11202,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "27.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11216,7 +11216,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bounded-collections 0.2.2",
  "frame-benchmarking",
@@ -11239,7 +11239,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11257,7 +11257,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub"
 version = "0.2.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -11279,7 +11279,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub-router"
 version = "0.5.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bp-xcm-bridge-hub-router",
  "frame-benchmarking",
@@ -11364,7 +11364,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -11394,7 +11394,7 @@ dependencies = [
 [[package]]
 name = "parachains-runtimes-test-utils"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
@@ -11719,7 +11719,7 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 [[package]]
 name = "polkadot-approval-distribution"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bitvec",
  "futures 0.3.31",
@@ -11738,7 +11738,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "always-assert",
  "futures 0.3.31",
@@ -11754,7 +11754,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "derive_more 0.99.18",
  "fatality",
@@ -11778,7 +11778,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "fatality",
@@ -11811,7 +11811,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "cfg-if",
  "clap",
@@ -11839,7 +11839,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bitvec",
  "fatality",
@@ -11862,7 +11862,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11873,7 +11873,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "derive_more 0.99.18",
  "fatality",
@@ -11898,7 +11898,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -11912,7 +11912,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -11934,7 +11934,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -11957,7 +11957,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "futures 0.3.31",
  "parity-scale-codec",
@@ -11976,7 +11976,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -12009,7 +12009,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting-parallel"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -12039,7 +12039,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bitvec",
  "futures 0.3.31",
@@ -12060,7 +12060,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bitvec",
  "fatality",
@@ -12081,7 +12081,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "futures 0.3.31",
  "polkadot-node-subsystem",
@@ -12096,7 +12096,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -12118,7 +12118,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "futures 0.3.31",
  "polkadot-node-metrics",
@@ -12132,7 +12132,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -12149,7 +12149,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "fatality",
  "futures 0.3.31",
@@ -12168,7 +12168,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -12185,7 +12185,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "6.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "fatality",
  "futures 0.3.31",
@@ -12199,7 +12199,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bitvec",
  "fatality",
@@ -12217,7 +12217,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "always-assert",
  "array-bytes",
@@ -12247,7 +12247,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "futures 0.3.31",
  "polkadot-node-primitives",
@@ -12263,7 +12263,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "cpu-time",
  "futures 0.3.31",
@@ -12289,7 +12289,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-execute-worker"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "cfg-if",
  "cpu-time",
@@ -12307,7 +12307,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-prepare-worker"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "blake3",
  "cfg-if",
@@ -12330,7 +12330,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "futures 0.3.31",
  "polkadot-node-metrics",
@@ -12345,7 +12345,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bs58",
  "futures 0.3.31",
@@ -12364,7 +12364,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -12389,7 +12389,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -12415,7 +12415,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-overseer",
@@ -12424,7 +12424,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-test-helpers"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -12446,7 +12446,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -12475,7 +12475,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "derive_more 0.99.18",
@@ -12510,7 +12510,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -12532,7 +12532,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "6.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bounded-collections 0.2.2",
  "derive_more 0.99.18",
@@ -12548,7 +12548,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bitvec",
  "hex-literal 0.4.1",
@@ -12576,7 +12576,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives-test-helpers"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "polkadot-primitives",
  "rand",
@@ -12589,7 +12589,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "jsonrpsee 0.24.7",
  "mmr-rpc",
@@ -12624,7 +12624,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -12675,7 +12675,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -12687,7 +12687,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -12737,7 +12737,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -12771,7 +12771,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -12879,7 +12879,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "arrayvec 0.7.6",
  "bitvec",
@@ -12902,7 +12902,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -12913,7 +12913,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-client"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "parity-scale-codec",
@@ -12941,7 +12941,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-runtime"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-election-provider-support",
  "frame-executive",
@@ -12997,7 +12997,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-service"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-system",
  "futures 0.3.31",
@@ -14187,7 +14187,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -14289,7 +14289,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -14713,7 +14713,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "23.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "log",
  "sp-core",
@@ -14724,7 +14724,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.34.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -14754,7 +14754,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.34.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -14776,7 +14776,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.33.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -14791,7 +14791,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "array-bytes",
  "docify",
@@ -14818,7 +14818,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "11.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
@@ -14829,7 +14829,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.36.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -14874,7 +14874,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "fnv",
  "futures 0.3.31",
@@ -14901,7 +14901,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.35.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -14927,7 +14927,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.33.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -14951,7 +14951,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.34.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -14980,7 +14980,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.34.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -15016,7 +15016,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.34.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "futures 0.3.31",
  "jsonrpsee 0.24.7",
@@ -15038,7 +15038,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "13.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -15074,7 +15074,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "13.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "futures 0.3.31",
  "jsonrpsee 0.24.7",
@@ -15094,7 +15094,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.33.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -15107,7 +15107,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.19.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "ahash",
  "array-bytes",
@@ -15151,7 +15151,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.19.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "finality-grandpa",
  "futures 0.3.31",
@@ -15171,7 +15171,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.35.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -15206,7 +15206,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.33.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -15229,7 +15229,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.32.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -15253,7 +15253,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.29.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "parity-scale-codec",
  "polkavm",
@@ -15267,7 +15267,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.29.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "log",
  "polkavm",
@@ -15278,7 +15278,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.29.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -15297,7 +15297,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.33.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "console",
  "futures 0.3.31",
@@ -15314,7 +15314,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "25.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
@@ -15328,7 +15328,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.4.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.6",
@@ -15357,7 +15357,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.34.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -15408,7 +15408,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.33.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -15426,7 +15426,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.34.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "ahash",
  "futures 0.3.31",
@@ -15445,7 +15445,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.33.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -15466,7 +15466,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.33.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -15502,7 +15502,7 @@ dependencies = [
 [[package]]
 name = "sc-network-test"
 version = "0.8.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -15534,7 +15534,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.33.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "array-bytes",
  "futures 0.3.31",
@@ -15553,7 +15553,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.10.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bs58",
  "ed25519-dalek",
@@ -15570,7 +15570,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "29.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -15607,7 +15607,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.17.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -15616,7 +15616,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "29.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "futures 0.3.31",
  "jsonrpsee 0.24.7",
@@ -15648,7 +15648,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.33.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "jsonrpsee 0.24.7",
  "parity-scale-codec",
@@ -15668,7 +15668,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "11.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -15692,7 +15692,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.34.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "array-bytes",
  "futures 0.3.31",
@@ -15724,7 +15724,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.35.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "directories",
@@ -15788,7 +15788,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.30.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -15799,7 +15799,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.16.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "clap",
  "fs4",
@@ -15812,7 +15812,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.34.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "jsonrpsee 0.24.7",
  "parity-scale-codec",
@@ -15831,7 +15831,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "27.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "derive_more 0.99.18",
  "futures 0.3.31",
@@ -15852,7 +15852,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "15.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "chrono",
  "futures 0.3.31",
@@ -15872,7 +15872,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "chrono",
  "console",
@@ -15900,7 +15900,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
@@ -15911,7 +15911,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -15942,7 +15942,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -15958,7 +15958,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "14.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-channel 1.9.0",
  "futures 0.3.31",
@@ -16626,7 +16626,7 @@ dependencies = [
 [[package]]
 name = "slot-range-helper"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -16900,7 +16900,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-beacon-primitives"
 version = "0.2.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "byte-slice-cast",
  "frame-support",
@@ -16922,7 +16922,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-core"
 version = "0.2.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "ethabi-decode",
  "frame-support",
@@ -16945,7 +16945,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-ethereum"
 version = "0.3.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "ethabi-decode",
  "ethbloom",
@@ -16980,7 +16980,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-outbound-queue-merkle-tree"
 version = "0.3.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16991,7 +16991,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-outbound-queue-runtime-api"
 version = "0.2.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -17004,7 +17004,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-ethereum-client"
 version = "0.2.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -17030,7 +17030,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-ethereum-client-fixtures"
 version = "0.9.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "hex-literal 0.4.1",
  "snowbridge-beacon-primitives",
@@ -17042,7 +17042,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-inbound-queue"
 version = "0.2.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -17070,7 +17070,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-inbound-queue-fixtures"
 version = "0.10.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "hex-literal 0.4.1",
  "snowbridge-beacon-primitives",
@@ -17082,7 +17082,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-outbound-queue"
 version = "0.2.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bridge-hub-common",
  "ethabi-decode",
@@ -17104,7 +17104,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-system"
 version = "0.2.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -17124,7 +17124,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-router-primitives"
 version = "0.9.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -17197,7 +17197,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "26.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "docify",
  "hash-db",
@@ -17219,7 +17219,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -17233,7 +17233,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "30.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17245,7 +17245,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "23.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -17259,7 +17259,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "26.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17271,7 +17271,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "26.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -17281,7 +17281,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "futures 0.3.31",
  "parity-scale-codec",
@@ -17300,7 +17300,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.32.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -17315,7 +17315,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.32.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -17331,7 +17331,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.32.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -17349,7 +17349,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "13.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17369,7 +17369,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "13.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -17386,7 +17386,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.32.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17397,7 +17397,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "array-bytes",
  "bitflags 1.3.2",
@@ -17457,7 +17457,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -17470,7 +17470,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "quote",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412)",
@@ -17480,7 +17480,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -17489,7 +17489,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -17499,7 +17499,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.25.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -17509,7 +17509,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.8.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17521,7 +17521,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "26.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -17534,7 +17534,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "30.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bytes",
  "docify",
@@ -17560,7 +17560,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "31.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -17570,7 +17570,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.34.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -17581,7 +17581,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -17590,7 +17590,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.6.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-metadata 18.0.0",
  "parity-scale-codec",
@@ -17600,7 +17600,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.4.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17611,7 +17611,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "26.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -17628,7 +17628,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "26.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17641,7 +17641,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "26.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -17651,7 +17651,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "backtrace",
  "regex",
@@ -17660,7 +17660,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "26.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -17670,7 +17670,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "31.0.1"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "binary-merkle-tree",
  "docify",
@@ -17699,7 +17699,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "24.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -17718,7 +17718,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "17.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "Inflector",
  "expander",
@@ -17731,7 +17731,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "27.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17745,7 +17745,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "26.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -17758,7 +17758,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.35.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "hash-db",
  "log",
@@ -17778,7 +17778,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "10.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -17802,12 +17802,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 
 [[package]]
 name = "sp-storage"
 version = "19.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "impl-serde 0.5.0",
  "parity-scale-codec",
@@ -17819,7 +17819,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "26.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -17831,7 +17831,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "16.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -17842,7 +17842,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "26.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -17851,7 +17851,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "26.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -17865,7 +17865,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "29.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "ahash",
  "hash-db",
@@ -17887,7 +17887,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "29.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "impl-serde 0.5.0",
  "parity-scale-codec",
@@ -17904,7 +17904,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "13.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning 1.0.2",
@@ -17916,7 +17916,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "20.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -17928,7 +17928,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "27.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "bounded-collections 0.2.2",
  "parity-scale-codec",
@@ -18151,7 +18151,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-parachain-info"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -18164,12 +18164,12 @@ dependencies = [
 [[package]]
 name = "staging-tracking-allocator"
 version = "2.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 
 [[package]]
 name = "staging-xcm"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "array-bytes",
  "bounded-collections 0.2.2",
@@ -18190,7 +18190,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -18212,7 +18212,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -18335,7 +18335,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.4.7"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -18347,12 +18347,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "28.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -18372,7 +18372,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "http-body-util",
  "hyper 1.5.2",
@@ -18386,7 +18386,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.33.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "async-trait",
  "jsonrpsee 0.24.7",
@@ -18399,7 +18399,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "27.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "jsonrpsee 0.24.7",
  "parity-scale-codec",
@@ -18416,7 +18416,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -18443,7 +18443,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "array-bytes",
  "frame-executive",
@@ -18487,7 +18487,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "futures 0.3.31",
  "sc-block-builder",
@@ -18505,7 +18505,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "17.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "array-bytes",
  "build-helper",
@@ -19396,7 +19396,7 @@ dependencies = [
 [[package]]
 name = "test-runtime-constants"
 version = "1.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -19989,7 +19989,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -20000,7 +20000,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "expander",
  "proc-macro-crate 3.2.0",
@@ -20892,7 +20892,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -21002,7 +21002,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -21433,7 +21433,7 @@ dependencies = [
 [[package]]
 name = "xcm-emulator"
 version = "0.5.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "array-bytes",
  "cumulus-pallet-parachain-system",
@@ -21485,7 +21485,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "7.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -21496,7 +21496,7 @@ dependencies = [
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#33a925ed7a1a70f3db904cb88bc301c7b6c0ce30"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2412#dc67d11292a3baa36a873e2d04c41b2ed5805f31"
 dependencies = [
  "frame-support",
  "parity-scale-codec",

--- a/test/configs/dancebox.yml
+++ b/test/configs/dancebox.yml
@@ -12,3 +12,5 @@ import-storage:
                     free: "100000000000000000000000"
     Sudo:
         Key: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+    PolkadotXcm:
+        QueryCounter: 0

--- a/test/configs/frontierContainer.yml
+++ b/test/configs/frontierContainer.yml
@@ -14,3 +14,6 @@ import-storage:
                     free: "100000000000000000000000"
     Sudo:
         Key: "0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"
+    PolkadotXcm:
+        QueryCounter: 0
+

--- a/test/configs/stagenet-dancebox.yml
+++ b/test/configs/stagenet-dancebox.yml
@@ -12,3 +12,5 @@ import-storage:
                     free: "100000000000000000000000"
     Sudo:
         Key: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+    PolkadotXcm:
+        QueryCounter: 0

--- a/test/suites/rt-upgrade-chopsticks-frontier-template/test-upgrade-chain.ts
+++ b/test/suites/rt-upgrade-chopsticks-frontier-template/test-upgrade-chain.ts
@@ -10,7 +10,7 @@ describeSuite({
     foundationMethods: "chopsticks",
     testCases: ({ it, context, log }) => {
         let api: ApiPromise;
-        let xcmQueryToAnalyze: Number;
+        let xcmQueryToAnalyze: number;
 
         beforeAll(async () => {
             api = context.polkadotJs();

--- a/test/suites/rt-upgrade-chopsticks-frontier-template/test-upgrade-chain.ts
+++ b/test/suites/rt-upgrade-chopsticks-frontier-template/test-upgrade-chain.ts
@@ -1,6 +1,7 @@
 import { MoonwallContext, beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { alith, generateKeyringPair } from "@moonwall/util";
 import type { ApiPromise } from "@polkadot/api";
+import { chopsticksWaitTillIncluded } from "utils";
 
 const MAX_BALANCE_TRANSFER_TRIES = 5;
 describeSuite({
@@ -9,6 +10,7 @@ describeSuite({
     foundationMethods: "chopsticks",
     testCases: ({ it, context, log }) => {
         let api: ApiPromise;
+        let xcmQueryToAnalyze: Number;
 
         beforeAll(async () => {
             api = context.polkadotJs();
@@ -29,6 +31,23 @@ describeSuite({
 
             const specName = api.consts.system.version.specName.toString();
             log(`Currently connected to chain: ${specName}`);
+
+            // Inject a forceSubscribe version to create a query to check migration to xcm
+            const queryLocation = {
+                parents: 1,
+                interior: "Here",
+            };
+            // fetch on-chain later
+            // TODO:Once we update the next runtime, remove this and take it form onchain
+            const previousXcmVersion = 5;
+            const latestVersion = "V" + previousXcmVersion.toString();
+
+            const versionedLocation = {
+                [latestVersion]: queryLocation,
+            };
+            xcmQueryToAnalyze = await api.query.polkadotXcm.queryCounter();
+            const finalTx = api.tx.sudo.sudo(api.tx.polkadotXcm.forceSubscribeVersionNotify(versionedLocation));
+            await chopsticksWaitTillIncluded(context, api, alith, finalTx);
         });
 
         it({
@@ -49,29 +68,27 @@ describeSuite({
             test: async () => {
                 const randomAccount = generateKeyringPair("ethereum");
 
-                let tries = 0;
                 const balanceBefore = (await api.query.system.account(randomAccount.address)).data.free.toBigInt();
 
-                /// It might happen that by accident we hit a session change
-                /// A block in which a session change occurs cannot hold any tx
-                /// Chopsticks does not have the notion of tx pool either, so we need to retry
-                /// Therefore we just retry at most MAX_BALANCE_TRANSFER_TRIES
-                while (tries < MAX_BALANCE_TRANSFER_TRIES) {
-                    const txHash = await api.tx.balances
-                        .transferAllowDeath(randomAccount.address, 1_000_000_000)
-                        .signAndSend(alith);
-                    const result = await context.createBlock({ count: 1 });
+                const balanceTransferTx = await api.tx.balances.transferAllowDeath(
+                    randomAccount.address,
+                    1_000_000_000
+                );
 
-                    const block = await api.rpc.chain.getBlock(result.result);
-                    const includedTxHashes = block.block.extrinsics.map((x) => x.hash.toString());
-                    if (includedTxHashes.includes(txHash.toString())) {
-                        break;
-                    }
-                    tries++;
-                }
+                await chopsticksWaitTillIncluded(context, api, alith, balanceTransferTx);
 
                 const balanceAfter = (await api.query.system.account(randomAccount.address)).data.free.toBigInt();
                 expect(balanceBefore < balanceAfter).to.be.true;
+            },
+        });
+        it({
+            id: "T3",
+            title: "Xcm migrations have runned, if any",
+            test: async () => {
+                const currentXcmVersion = await api.consts.polkadotXcm.advertisedXcmVersion.toNumber();
+                const query = await api.query.polkadotXcm.queries(xcmQueryToAnalyze);
+                const version = Object.keys(query.toJSON()["versionNotifier"]["origin"])[0];
+                expect(version).to.be.equal("v" + currentXcmVersion.toString());
             },
         });
     },

--- a/test/suites/rt-upgrade-chopsticks-frontier-template/test-upgrade-chain.ts
+++ b/test/suites/rt-upgrade-chopsticks-frontier-template/test-upgrade-chain.ts
@@ -40,7 +40,7 @@ describeSuite({
             // fetch on-chain later
             // TODO:Once we update the next runtime, remove this and take it form onchain
             const previousXcmVersion = 5;
-            const latestVersion = "V" + previousXcmVersion.toString();
+            const latestVersion = `V${previousXcmVersion.toString()}`;
 
             const versionedLocation = {
                 [latestVersion]: queryLocation,
@@ -87,8 +87,8 @@ describeSuite({
             test: async () => {
                 const currentXcmVersion = await api.consts.polkadotXcm.advertisedXcmVersion.toNumber();
                 const query = await api.query.polkadotXcm.queries(xcmQueryToAnalyze);
-                const version = Object.keys(query.toJSON()["versionNotifier"]["origin"])[0];
-                expect(version).to.be.equal("v" + currentXcmVersion.toString());
+                const version = Object.keys(query.toJSON().versionNotifier.origin)[0];
+                expect(version).to.be.equal(`v${currentXcmVersion.toString()}`);
             },
         });
     },

--- a/test/suites/rt-upgrade-chopsticks-orchestrator/test-upgrade-chain.ts
+++ b/test/suites/rt-upgrade-chopsticks-orchestrator/test-upgrade-chain.ts
@@ -62,7 +62,7 @@ describeSuite({
                     // we send queries
                     batchTx.push(api.tx.registrar.setCurrentHead(1, "0x11"));
                     batchTx.push(api.tx.xcmPallet.forceSubscribeVersionNotify(versionedLocation));
-                } else if (runtimeName !== "flasbox") {
+                } else if (runtimeName !== "flashbox") {
                     batchTx.push(api.tx.polkadotXcm.forceSubscribeVersionNotify(versionedLocation));
                 }
 

--- a/test/suites/rt-upgrade-chopsticks-orchestrator/test-upgrade-chain.ts
+++ b/test/suites/rt-upgrade-chopsticks-orchestrator/test-upgrade-chain.ts
@@ -2,6 +2,11 @@ import "@tanssi/api-augment/dancelight";
 import { MoonwallContext, beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { generateKeyringPair } from "@moonwall/util";
 import { Keyring, type ApiPromise } from "@polkadot/api";
+import type { KeyringPair } from "@polkadot/keyring/types";
+import { type MultiLocation } from "utils";
+import { PalletXcmQueryStatus } from "@polkadot/types/lookup";
+import { VersionedMultiLocation } from "@polkadot/types/interfaces";
+import { xcm } from "@polkadot/types/interfaces/definitions";
 
 const MAX_BALANCE_TRANSFER_TRIES = 5;
 describeSuite({
@@ -11,17 +16,75 @@ describeSuite({
     testCases: ({ it, context, log }) => {
         let api: ApiPromise;
         let specName: string;
+        let alice: KeyringPair;
+        let runtimeName: String;
+        let xcmQueryToAnalyze: Number;
 
         beforeAll(async () => {
             api = context.pjsApi;
             specName = api.consts.system.version.specName.toString();
             const specVersion = getSpecVersion(api);
             log(`Currently connected to chain: ${specName} : ${specVersion}`);
+
+            // Inject a query so that there are migrations to execute in queries in case of new xcm version
+            // Right now we need to hardcode the xcm version
+            // this should not be necessary after we bring https://github.com/paritytech/polkadot-sdk/pull/8173
+            // since we would be able to fetch it on-chain
+            const keyring = new Keyring({ type: "sr25519" });
+            context.keyring.alice;
+            alice = keyring.addFromUri("//Alice", { name: "Alice default" });
+
+            runtimeName = api.runtimeVersion.specName.toString();
+
+            const queryLocation = runtimeName.includes("light")
+                ? {
+                      parents: 0,
+                      interior: { X1: [{ Parachain: 1 }] },
+                  }
+                : {
+                      parents: 1,
+                      interior: "Here",
+                  };
+
+            // fetch on-chain later
+            const previousXcmVersion = 5;
+            const latestVersion = "V" + previousXcmVersion.toString();
+
+            const versionedLocation = new Object();
+            versionedLocation[latestVersion] = queryLocation;
+
+            xcmQueryToAnalyze = runtimeName.includes("light")
+                ? await api.query.xcmPallet.queryCounter()
+                : await api.query.polkadotXcm.queryCounter();
+
+            let batchTx = [];
+            if (runtimeName.includes("light")) {
+                // We first inject a random paras head in parachain 1. this is necessary as we need a chain to which
+                // we send queries
+                batchTx.push(api.tx.registrar.setCurrentHead(1, "0x11"));
+                batchTx.push(api.tx.xcmPallet.forceSubscribeVersionNotify(versionedLocation));
+            } else {
+                batchTx.push(api.tx.polkadotXcm.forceSubscribeVersionNotify(versionedLocation));
+            }
+
+            let tries = 0;
+
+            while (tries < MAX_BALANCE_TRANSFER_TRIES) {
+                const txHash = await api.tx.sudo.sudo(api.tx.utility.batchAll(batchTx)).signAndSend(alice);
+                const result = await context.createBlock({ count: 1 });
+
+                const block = await api.rpc.chain.getBlock(result.result);
+                const includedTxHashes = block.block.extrinsics.map((x) => x.hash.toString());
+                if (includedTxHashes.includes(txHash.toString())) {
+                    break;
+                }
+                tries++;
+            }
         });
 
         it({
             id: "T1",
-            timeout: 60000,
+            timeout: 80000,
             title: "Can upgrade runtime",
             test: async () => {
                 const rtBefore = getSpecVersion(api);
@@ -68,9 +131,6 @@ describeSuite({
             title: "Can send balance transfers",
             test: async () => {
                 const randomAccount = generateKeyringPair("sr25519");
-                const keyring = new Keyring({ type: "sr25519" });
-                context.keyring.alice;
-                const alice = keyring.addFromUri("//Alice", { name: "Alice default" });
 
                 let tries = 0;
                 const balanceBefore = (await api.query.system.account(randomAccount.address)).data.free.toBigInt();
@@ -100,6 +160,24 @@ describeSuite({
 
         it({
             id: "T4",
+            title: "Xcm migrations have runned, if any",
+            test: async () => {
+                // Regardless of migrations, query should be in the latest version
+                // Unfortunately the api is not very friendly
+                const currentXcmVersion = runtimeName.includes("light")
+                    ? (await api.consts.xcmPallet.advertisedXcmVersion).toNumber()
+                    : (await api.consts.polkadotXcm.advertisedXcmVersion).toNumber();
+
+                const query = runtimeName.includes("light")
+                    ? await api.query.xcmPallet.queries(xcmQueryToAnalyze)
+                    : await api.query.polkadotXcm.queries(xcmQueryToAnalyze);
+                const version = Object.keys(query.toJSON()["versionNotifier"]["origin"])[0];
+                expect(version).to.be.equal("v" + currentXcmVersion.toString());
+            },
+        });
+
+        it({
+            id: "T5",
             timeout: 60000,
             title: "Skip blocks until session change",
             test: async () => {

--- a/test/suites/rt-upgrade-chopsticks-orchestrator/test-upgrade-chain.ts
+++ b/test/suites/rt-upgrade-chopsticks-orchestrator/test-upgrade-chain.ts
@@ -48,8 +48,9 @@ describeSuite({
                 const previousXcmVersion = 5;
                 const latestVersion = "V" + previousXcmVersion.toString();
 
-                const versionedLocation = new Object();
-                versionedLocation[latestVersion] = queryLocation;
+                const versionedLocation = {
+                    [latestVersion]: queryLocation,
+                };
 
                 xcmQueryToAnalyze = runtimeName.includes("light")
                     ? await api.query.xcmPallet.queryCounter()

--- a/test/suites/rt-upgrade-chopsticks-orchestrator/test-upgrade-chain.ts
+++ b/test/suites/rt-upgrade-chopsticks-orchestrator/test-upgrade-chain.ts
@@ -14,8 +14,8 @@ describeSuite({
         let api: ApiPromise;
         let specName: string;
         let alice: KeyringPair;
-        let runtimeName: String;
-        let xcmQueryToAnalyze: Number;
+        let runtimeName: string;
+        let xcmQueryToAnalyze: number;
 
         beforeAll(async () => {
             api = context.pjsApi;
@@ -56,7 +56,7 @@ describeSuite({
                     ? await api.query.xcmPallet.queryCounter()
                     : await api.query.polkadotXcm.queryCounter();
 
-                let batchTx = [];
+                const batchTx = [];
                 if (runtimeName.includes("light")) {
                     // We first inject a random paras head in parachain 1. this is necessary as we need a chain to which
                     // we send queries
@@ -119,7 +119,7 @@ describeSuite({
             test: async () => {
                 const randomAccount = generateKeyringPair("sr25519");
 
-                let tries = 0;
+                const tries = 0;
                 const balanceBefore = (await api.query.system.account(randomAccount.address)).data.free.toBigInt();
 
                 /// It might happen that by accident we hit a session change

--- a/test/suites/rt-upgrade-chopsticks-orchestrator/test-upgrade-chain.ts
+++ b/test/suites/rt-upgrade-chopsticks-orchestrator/test-upgrade-chain.ts
@@ -28,7 +28,7 @@ describeSuite({
             context.keyring.alice;
             alice = keyring.addFromUri("//Alice", { name: "Alice default" });
 
-            if (runtimeName != "flashbox") {
+            if (runtimeName !== "flashbox") {
                 // Inject a query so that there are migrations to execute in queries in case of new xcm version
                 // Right now we need to hardcode the xcm version
                 // this should not be necessary after we bring https://github.com/paritytech/polkadot-sdk/pull/8173
@@ -46,7 +46,7 @@ describeSuite({
                 // fetch on-chain later
                 // TODO:Once we update the next runtime, remove this and take it form onchain
                 const previousXcmVersion = 5;
-                const latestVersion = "V" + previousXcmVersion.toString();
+                const latestVersion = `V${previousXcmVersion.toString()}`;
 
                 const versionedLocation = {
                     [latestVersion]: queryLocation,
@@ -62,7 +62,7 @@ describeSuite({
                     // we send queries
                     batchTx.push(api.tx.registrar.setCurrentHead(1, "0x11"));
                     batchTx.push(api.tx.xcmPallet.forceSubscribeVersionNotify(versionedLocation));
-                } else if (runtimeName != "flasbox") {
+                } else if (runtimeName !== "flasbox") {
                     batchTx.push(api.tx.polkadotXcm.forceSubscribeVersionNotify(versionedLocation));
                 }
 
@@ -150,8 +150,8 @@ describeSuite({
                 const query = runtimeName.includes("light")
                     ? await api.query.xcmPallet.queries(xcmQueryToAnalyze)
                     : await api.query.polkadotXcm.queries(xcmQueryToAnalyze);
-                const version = Object.keys(query.toJSON()["versionNotifier"]["origin"])[0];
-                expect(version).to.be.equal("v" + currentXcmVersion.toString());
+                const version = Object.keys(query.toJSON().versionNotifier.origin)[0];
+                expect(version).to.be.equal(`v${currentXcmVersion.toString()}`);
             },
         });
 

--- a/test/suites/rt-upgrade-chopsticks-orchestrator/test-upgrade-chain.ts
+++ b/test/suites/rt-upgrade-chopsticks-orchestrator/test-upgrade-chain.ts
@@ -22,7 +22,6 @@ describeSuite({
         let alice: KeyringPair;
         let runtimeName: String;
         let xcmQueryToAnalyze: Number;
-        let xcmPalletAlias: SubmittableModuleExtrinsics<ApiTypes>;
 
         beforeAll(async () => {
             api = context.pjsApi;
@@ -51,6 +50,7 @@ describeSuite({
                       };
 
                 // fetch on-chain later
+                // TODO:Once we update the next runtime, remove this and take it form onchain
                 const previousXcmVersion = 5;
                 const latestVersion = "V" + previousXcmVersion.toString();
 

--- a/typescript-api/src/dancebox/interfaces/augment-api-consts.ts
+++ b/typescript-api/src/dancebox/interfaces/augment-api-consts.ts
@@ -310,6 +310,17 @@ declare module "@polkadot/api-base/types/consts" {
              **/
             [key: string]: Codec;
         };
+        polkadotXcm: {
+            /**
+             * The latest supported version that we advertise. Generally just set it to
+             * `pallet_xcm::CurrentXcmVersion`.
+             **/
+            advertisedXcmVersion: u32 & AugmentedConst<ApiType>;
+            /**
+             * Generic const
+             **/
+            [key: string]: Codec;
+        };
         pooledStaking: {
             /**
              * All eligible candidates are stored in a sorted list that is modified each time

--- a/typescript-api/src/dancelight/interfaces/augment-api-consts.ts
+++ b/typescript-api/src/dancelight/interfaces/augment-api-consts.ts
@@ -824,5 +824,16 @@ declare module "@polkadot/api-base/types/consts" {
              **/
             [key: string]: Codec;
         };
+        xcmPallet: {
+            /**
+             * The latest supported version that we advertise. Generally just set it to
+             * `pallet_xcm::CurrentXcmVersion`.
+             **/
+            advertisedXcmVersion: u32 & AugmentedConst<ApiType>;
+            /**
+             * Generic const
+             **/
+            [key: string]: Codec;
+        };
     } // AugmentedConsts
 } // declare module


### PR DESCRIPTION
What this new test does (for non-flashbox chains) is:

- For "*light" chains, it creates a random query with para id 1. after the upgrade, it checks that the version of the query on-storage matches that advertised by the pallet

- For "*box" chains, it creates a query with the relay. THe reason is that mocking the connection to a parachain is much more difficult here. We also reset the query counter because some chains might have already a query to the relay, so we start fresh. The later verification is identical in both cases.

- For containers, same as for "box" chains

Unfortunately I did not get much help from the API for this

Companion: https://github.com/paritytech/polkadot-sdk/pull/8173