### PR TITLE
[MD-989] Increase the PoV size + add a fallback option

### DIFF
--- a/chains/orchestrator-paras/node/src/cli.rs
+++ b/chains/orchestrator-paras/node/src/cli.rs
@@ -144,6 +144,14 @@ pub struct RunCmd {
     /// Id of the parachain this collator collates for.
     #[arg(long)]
     pub parachain_id: Option<u32>,
+
+    /// EXPERIMENTAL: This is meant to be used only if collator is overshooting the PoV size, and
+    /// building blocks that do not fit in the max_pov_size. It is a percentage of the max_pov_size
+    /// configuration of the relay-chain.
+    ///
+    /// It will be removed once <https://github.com/paritytech/polkadot-sdk/issues/6020> is fixed.
+    #[arg(long)]
+    pub experimental_max_pov_percentage: Option<u32>,
 }
 
 impl std::ops::Deref for RunCmd {

--- a/chains/orchestrator-paras/node/src/command.rs
+++ b/chains/orchestrator-paras/node/src/command.rs
@@ -491,6 +491,7 @@ pub fn run() -> Result<()> {
                     collator_options,
                     id,
                     hwbench,
+                    cli.run.experimental_max_pov_percentage,
                 )
                     .await
                     .map(|r| r.0)

--- a/chains/orchestrator-paras/node/src/service.rs
+++ b/chains/orchestrator-paras/node/src/service.rs
@@ -251,6 +251,7 @@ async fn start_node_impl(
     collator_options: CollatorOptions,
     para_id: ParaId,
     hwbench: Option<sc_sysinfo::HwBench>,
+    max_pov_percentage: Option<u32>,
 ) -> sc_service::error::Result<(TaskManager, Arc<ParachainClient>)> {
     let parachain_config = prepare_node_config(orchestrator_config);
     let chain_type: sc_chain_spec::ChainType = parachain_config.chain_spec.chain_type();
@@ -401,6 +402,7 @@ async fn start_node_impl(
                     announce_block.clone(),
                     proposer_factory.clone(),
                     orchestrator_tx_pool.clone(),
+                    max_pov_percentage,
                 )
             }
         };
@@ -523,6 +525,7 @@ fn start_consensus_orchestrator(
     announce_block: Arc<dyn Fn(Hash, Option<Vec<u8>>) + Send + Sync>,
     proposer_factory: ParachainProposerFactory,
     orchestrator_tx_pool: Arc<TransactionPoolHandle<Block, ParachainClient>>,
+    max_pov_percentage: Option<u32>,
 ) -> (CancellationToken, futures::channel::oneshot::Receiver<()>) {
     let slot_duration = cumulus_client_consensus_aura::slot_duration(&*client)
         .expect("start_consensus_orchestrator: slot duration should exist");
@@ -557,6 +560,7 @@ fn start_consensus_orchestrator(
     };
 
     let params = LookaheadTanssiAuraParams {
+        max_pov_percentage,
         get_current_slot_duration: move |block_hash| {
             sc_consensus_aura::standalone::slot_duration_at(
                 &*client_for_slot_duration_provider,
@@ -684,6 +688,7 @@ pub async fn start_parachain_node(
     collator_options: CollatorOptions,
     para_id: ParaId,
     hwbench: Option<sc_sysinfo::HwBench>,
+    max_pov_percentage: Option<u32>,
 ) -> sc_service::error::Result<(TaskManager, Arc<ParachainClient>)> {
     start_node_impl(
         parachain_config,
@@ -692,6 +697,7 @@ pub async fn start_parachain_node(
         collator_options,
         para_id,
         hwbench,
+        max_pov_percentage,
     )
     .instrument(sc_tracing::tracing::info_span!(
         sc_tracing::logging::PREFIX_LOG_SPAN,

--- a/client/consensus/src/mocks.rs
+++ b/client/consensus/src/mocks.rs
@@ -993,6 +993,7 @@ impl CollatorLookaheadTestBuilder {
                 orchestrator_tx_pool: orchestrator_tx_pool.clone(),
             },
             orchestrator_slot_duration: SlotDuration::from_millis(SLOT_DURATION_MS),
+            max_pov_percentage: Some(85),
         };
         let (fut, exit_notification_receiver) = crate::collators::lookahead::run::<
             _,

--- a/client/service-container-chain/src/cli.rs
+++ b/client/service-container-chain/src/cli.rs
@@ -75,6 +75,14 @@ pub struct ContainerChainRunCmd {
     /// Will use the specified relay chain chainspec.
     #[arg(long, conflicts_with_all = ["relay_chain_rpc_urls", "collator"])]
     pub relay_chain_light_client: bool,
+
+    /// EXPERIMENTAL: This is meant to be used only if collator is overshooting the PoV size, and
+    /// building blocks that do not fit in the max_pov_size. It is a percentage of the max_pov_size
+    /// configuration of the relay-chain.
+    ///
+    /// It will be removed once <https://github.com/paritytech/polkadot-sdk/issues/6020> is fixed.
+    #[arg(long)]
+    pub experimental_max_pov_percentage: Option<u32>,
 }
 
 impl ContainerChainRunCmd {

--- a/client/service-container-chain/src/service.rs
+++ b/client/service-container-chain/src/service.rs
@@ -290,6 +290,7 @@ pub fn start_node_impl_container<
                 para_id,
                 overseer_handle.clone(),
                 announce_block.clone(),
+                container_chain_cli.base.experimental_max_pov_percentage,
             );
         }
 
@@ -366,6 +367,7 @@ fn start_consensus_container<RuntimeApi: MinimalContainerRuntimeApi>(
     para_id: ParaId,
     overseer_handle: OverseerHandle,
     announce_block: Arc<dyn Fn(Hash, Option<Vec<u8>>) + Send + Sync>,
+    max_pov_percentage: Option<u32>,
 ) {
     let crate::spawner::CollationParams {
         collator_key,
@@ -432,6 +434,7 @@ fn start_consensus_container<RuntimeApi: MinimalContainerRuntimeApi>(
     };
 
     let params = LookaheadTanssiAuraParams {
+        max_pov_percentage,
         get_current_slot_duration: move |block_hash| {
             // Default to 12s if runtime API does not exist
             let slot_duration_ms = client_for_slot_duration


### PR DESCRIPTION
**Description:**
This PR increases the PoV size from 50% to 85% with the possibility to change it via the CLI parameter, in case the chain stalls temporarily because there are that many tx in the pool which are not benchmarked correctly.