### PR TITLE
Pass fast-runtime feature to nextest

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,4 @@
+[profile.default]
+# Tests that take more than 60 seconds are considered slow
+# Tests that take 2 times that (2 minutes) are terminated making CI fail
+slow-timeout = { period = "60s", terminate-after = 2 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -433,7 +433,7 @@ jobs:
         - name: Install nextest
           uses: taiki-e/install-action@nextest
         - name: Run Tests
-          run: cargo nextest run --release --no-fail-fast --workspace --features=fast-rintime
+          run: cargo nextest run --release --no-fail-fast --workspace --features=fast-runtime
 
     check-api-augment:
         runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -433,7 +433,7 @@ jobs:
         - name: Install nextest
           uses: taiki-e/install-action@nextest
         - name: Run Tests
-          run: cargo nextest run --release --no-fail-fast --workspace
+          run: cargo nextest run --release --no-fail-fast --workspace --features=fast-rintime
 
     check-api-augment:
         runs-on: ubuntu-latest

--- a/chains/orchestrator-relays/runtime/dancelight/src/tests/slashes.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/tests/slashes.rs
@@ -268,7 +268,7 @@ fn test_slashes_are_cleaned_after_bonding_period() {
             assert_eq!(slashes.len(), 1);
             // The first session in which the era 3 will be pruned is
             // (28+3+1)*sessionsPerEra
-            let fist_session_era_3_pruned = (ExternalValidators::current_era().unwrap()
+            let first_session_era_3_pruned = (ExternalValidators::current_era().unwrap()
                 + SlashDeferDuration::get()
                 + 1
                 + BondingDuration::get()
@@ -279,7 +279,11 @@ fn test_slashes_are_cleaned_after_bonding_period() {
                 ExternalValidators::current_era().unwrap() + SlashDeferDuration::get() + 1;
 
             println!("first era deferred {:?}", first_era_deferred);
-            run_to_session(fist_session_era_3_pruned);
+            println!("first_session_era_3_pruned {:?}", first_session_era_3_pruned);
+            if first_session_era_3_pruned > 20 {
+                panic!("Test will take too long, aborting. Make sure to compile with --features fast-runtime");
+            }
+            run_to_session(first_session_era_3_pruned);
 
             let slashes_after_bonding_period =
                 ExternalValidatorSlashes::slashes(first_era_deferred);

--- a/chains/orchestrator-relays/runtime/starlight/src/tests/slashes.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/tests/slashes.rs
@@ -268,7 +268,7 @@ fn test_slashes_are_cleaned_after_bonding_period() {
             assert_eq!(slashes.len(), 1);
             // The first session in which the era 3 will be pruned is
             // (28+3+1)*sessionsPerEra
-            let fist_session_era_3_pruned = (ExternalValidators::current_era().unwrap()
+            let first_session_era_3_pruned = (ExternalValidators::current_era().unwrap()
                 + SlashDeferDuration::get()
                 + 1
                 + BondingDuration::get()
@@ -279,7 +279,11 @@ fn test_slashes_are_cleaned_after_bonding_period() {
                 ExternalValidators::current_era().unwrap() + SlashDeferDuration::get() + 1;
 
             println!("first era deferred {:?}", first_era_deferred);
-            run_to_session(fist_session_era_3_pruned);
+            println!("first_session_era_3_pruned {:?}", first_session_era_3_pruned);
+            if first_session_era_3_pruned > 20 {
+                panic!("Test will take too long, aborting. Make sure to compile with --features fast-runtime");
+            }
+            run_to_session(first_session_era_3_pruned);
 
             let slashes_after_bonding_period =
                 ExternalValidatorSlashes::slashes(first_era_deferred);


### PR DESCRIPTION
Previously we didn't pass it, but rust tests run very fast so the slowest one was 250 seconds. In starlight `EpochDurationInBlocks` is 6x that of dancelight, so that test should take 6x longer. However it takes ~20x longer. I don't know what is this extra factor, but anyway now with fast-runtime the slowest test takes less than 2 seconds.