### PR TITLE
[Dancelight] Add maintenance mode pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3653,6 +3653,7 @@ dependencies = [
  "pallet-inflation-rewards",
  "pallet-initializer",
  "pallet-invulnerables",
+ "pallet-maintenance-mode",
  "pallet-membership",
  "pallet-message-queue",
  "pallet-migrations 0.1.0",

--- a/chains/orchestrator-relays/runtime/dancelight/Cargo.toml
+++ b/chains/orchestrator-relays/runtime/dancelight/Cargo.toml
@@ -154,6 +154,7 @@ tanssi-runtime-common = { workspace = true }
 
 # Moonkit
 pallet-migrations = { workspace = true }
+pallet-maintenance-mode = { workspace = true, features = [ "xcm-support" ] }
 
 # Bridges
 keyring = { workspace = true }
@@ -257,6 +258,7 @@ std = [
 	"pallet-inflation-rewards/std",
 	"pallet-initializer/std",
 	"pallet-invulnerables/std",
+	"pallet-maintenance-mode/std",
 	"pallet-membership/std",
 	"pallet-message-queue/std",
 	"pallet-migrations/std",
@@ -476,6 +478,7 @@ try-runtime = [
 	"pallet-inflation-rewards/try-runtime",
 	"pallet-initializer/try-runtime",
 	"pallet-invulnerables/try-runtime",
+	"pallet-maintenance-mode/try-runtime",
 	"pallet-membership/try-runtime",
 	"pallet-message-queue/try-runtime",
 	"pallet-migrations/try-runtime",

--- a/chains/orchestrator-relays/runtime/dancelight/src/lib.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/lib.rs
@@ -324,7 +324,7 @@ parameter_types! {
 
 #[derive_impl(frame_system::config_preludes::RelayChainDefaultConfig)]
 impl frame_system::Config for Runtime {
-    type BaseCallFilter = EverythingBut<(IsRelayRegister, IsParathreadRegistrar)>;
+    type BaseCallFilter = MaintenanceMode;
     type BlockWeights = BlockWeights;
     type BlockLength = BlockLength;
     type DbWeight = RocksDbWeight;
@@ -1089,7 +1089,7 @@ impl pallet_message_queue::Config for Runtime {
     type MessageProcessor =
         pallet_message_queue::mock_helpers::NoopMessageProcessor<AggregateMessageOrigin>;
     type QueueChangeHandler = ParaInclusion;
-    type QueuePausedQuery = ();
+    type QueuePausedQuery = MaintenanceMode;
     type WeightInfo = weights::pallet_message_queue::SubstrateWeight<Runtime>;
 }
 
@@ -1606,6 +1606,50 @@ impl pallet_multiblock_migrations::Config for Runtime {
     type WeightInfo = weights::pallet_multiblock_migrations::SubstrateWeight<Runtime>;
 }
 
+/// Maintenance mode Call filter
+pub struct MaintenanceFilter;
+impl Contains<RuntimeCall> for MaintenanceFilter {
+    fn contains(c: &RuntimeCall) -> bool {
+        !matches!(
+            c,
+            RuntimeCall::Balances(..)
+                | RuntimeCall::Registrar(..)
+                | RuntimeCall::Session(..)
+                | RuntimeCall::System(..)
+                | RuntimeCall::PooledStaking(..)
+                | RuntimeCall::Utility(..)
+                | RuntimeCall::XcmPallet(..)
+                | RuntimeCall::EthereumBeaconClient(..)
+                | RuntimeCall::EthereumSystem(..)
+                | RuntimeCall::EthereumTokenTransfers(..)
+                | RuntimeCall::ContainerRegistrar(..)
+                | RuntimeCall::ServicesPayment(..)
+                | RuntimeCall::DataPreservers(..)
+                | RuntimeCall::Hrmp(..)
+                | RuntimeCall::Proxy(..)
+                | RuntimeCall::Multisig(..)
+                | RuntimeCall::AssetRate(..)
+                | RuntimeCall::StreamPayment(..)
+        )
+    }
+}
+
+/// Normal Call Filter
+pub struct NormalFilter;
+impl Contains<RuntimeCall> for NormalFilter {
+    fn contains(c: &RuntimeCall) -> bool {
+        !IsRelayRegister::contains(c) || !IsParathreadRegistrar::contains(c)
+    }
+}
+
+impl pallet_maintenance_mode::Config for Runtime {
+    type RuntimeEvent = RuntimeEvent;
+    type NormalCallFilter = NormalFilter;
+    type MaintenanceCallFilter = MaintenanceFilter;
+    type MaintenanceOrigin = EnsureRoot<AccountId>;
+    type XcmExecutionManager = ();
+}
+
 pub const FIXED_BLOCK_PRODUCTION_COST: u128 = 1 * MICROUNITS;
 pub const FIXED_COLLATOR_ASSIGNMENT_COST: u128 = 100 * MICROUNITS;
 
@@ -1959,6 +2003,7 @@ construct_runtime! {
         // Migration stuff
         Migrations: pallet_migrations = 120,
         MultiBlockMigrations: pallet_multiblock_migrations = 121,
+        MaintenanceMode: pallet_maintenance_mode = 122,
 
         // BEEFY Bridges support.
         Beefy: pallet_beefy = 240,

--- a/test/suites/common-all/test-maintenance/test-maintenance-mode.ts
+++ b/test/suites/common-all/test-maintenance/test-maintenance-mode.ts
@@ -6,7 +6,7 @@ import type { ApiPromise } from "@polkadot/api";
 import { initializeCustomCreateBlock } from "utils";
 
 describeSuite({
-    id: "CO0101",
+    id: "C0401",
     title: "Maintenance mode test suite",
     foundationMethods: "dev",
     testCases: ({ it, context }) => {
@@ -14,6 +14,7 @@ describeSuite({
         let alice: KeyringPair;
         let bob: KeyringPair;
         let chain: string;
+        let isStarlight: boolean;
 
         beforeAll(() => {
             initializeCustomCreateBlock(context);
@@ -22,12 +23,20 @@ describeSuite({
             chain = polkadotJs.consts.system.version.specName.toString();
             alice = context.keyring.alice;
             bob = context.keyring.bob;
+            const runtimeName = polkadotJs.runtimeVersion.specName.toString();
+            isStarlight = runtimeName === "starlight";
         });
 
         it({
             id: "E01",
             title: "No maintenance mode at genesis",
             test: async () => {
+                if (isStarlight) {
+                    console.log(`Skipping E01 test for Starlight: maintenance mode is not available yet`);
+                    expect(polkadotJs.query.maintenanceMode).to.be.undefined;
+                    return;
+                }
+
                 await context.createBlock();
                 const enabled = (await polkadotJs.query.maintenanceMode.maintenanceMode()).toJSON();
                 expect(enabled).to.be.false;
@@ -38,6 +47,12 @@ describeSuite({
             id: "E02",
             title: "Signed origin cannot enable maintenance mode",
             test: async () => {
+                if (isStarlight) {
+                    console.log(`Skipping E02 test for Starlight: maintenance mode is not available yet`);
+                    expect(polkadotJs.query.maintenanceMode).to.be.undefined;
+                    return;
+                }
+
                 await context.createBlock();
 
                 const tx = polkadotJs.tx.maintenanceMode.enterMaintenanceMode();
@@ -58,6 +73,11 @@ describeSuite({
             id: "E03",
             title: "Root origin can enable maintenance mode",
             test: async () => {
+                if (isStarlight) {
+                    console.log(`Skipping E03 test for Starlight: maintenance mode is not available yet`);
+                    expect(polkadotJs.query.maintenanceMode).to.be.undefined;
+                    return;
+                }
                 await context.createBlock();
                 await context.createBlock();
 
@@ -79,6 +99,13 @@ describeSuite({
             id: "E04",
             title: "No transfers allowed in maintenance mode",
             test: async () => {
+                if (isStarlight) {
+                    console.log(`Skipping E04 test for Starlight: maintenance mode is not available yet`);
+                    expect(polkadotJs.query.maintenanceMode).to.be.undefined;
+                    return;
+                }
+
+                await context.createBlock();
                 await context.createBlock();
 
                 const enabled = (await polkadotJs.query.maintenanceMode.maintenanceMode()).toJSON();
@@ -106,6 +133,12 @@ describeSuite({
             id: "E05",
             title: "Transfer with sudo allowed in maintenance mode",
             test: async () => {
+                if (isStarlight) {
+                    console.log(`Skipping E05 test for Starlight: maintenance mode is not available yet`);
+                    expect(polkadotJs.query.maintenanceMode).to.be.undefined;
+                    return;
+                }
+
                 await context.createBlock();
                 await context.createBlock();
 
@@ -128,6 +161,12 @@ describeSuite({
             id: "E06",
             title: "Signed origin cannot disable maintenance mode",
             test: async () => {
+                if (isStarlight) {
+                    console.log(`Skipping E06 test for Starlight: maintenance mode is not available yet`);
+                    expect(polkadotJs.query.maintenanceMode).to.be.undefined;
+                    return;
+                }
+
                 await context.createBlock();
                 await context.createBlock();
 
@@ -149,6 +188,12 @@ describeSuite({
             id: "E07",
             title: "Root origin can disable maintenance mode",
             test: async () => {
+                if (isStarlight) {
+                    console.log(`Skipping E07 test for Starlight: maintenance mode is not available yet`);
+                    expect(polkadotJs.query.maintenanceMode).to.be.undefined;
+                    return;
+                }
+
                 await context.createBlock();
 
                 const tx = polkadotJs.tx.maintenanceMode.resumeNormalOperation();
@@ -169,6 +214,12 @@ describeSuite({
             id: "E08",
             title: "Transfers allowed again after disabling maintenance mode",
             test: async () => {
+                if (isStarlight) {
+                    console.log(`Skipping E08 test for Starlight: maintenance mode is not available yet`);
+                    expect(polkadotJs.query.maintenanceMode).to.be.undefined;
+                    return;
+                }
+
                 await context.createBlock();
 
                 const enabled = (await polkadotJs.query.maintenanceMode.maintenanceMode()).toJSON();


### PR DESCRIPTION
## What does it do?

This PR adds the `pallet-maintenance-mode` to Dancelight runtime. It also includes the proper Normal and Maintenance filters which contain the calls to allow and forbid on normal operations and maintenance mode respectively.