### PR TITLE
Enable pallets for starlight runtime 1301 (#1008)

### DIFF
--- a/chains/orchestrator-relays/runtime/starlight/src/lib.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/lib.rs
@@ -287,14 +287,6 @@ impl Convert<AggregateMessageOrigin, ParaId> for GetParaFromAggregateMessageOrig
     }
 }
 
-/// Disable any extrinsic related to the balance transfer
-pub struct IsBalanceTransferExtrinsics;
-impl Contains<RuntimeCall> for IsBalanceTransferExtrinsics {
-    fn contains(c: &RuntimeCall) -> bool {
-        matches!(c, RuntimeCall::Balances(_))
-    }
-}
-
 pub struct IsContainerChainManagementExtrinsics;
 impl Contains<RuntimeCall> for IsContainerChainManagementExtrinsics {
     fn contains(c: &RuntimeCall) -> bool {
@@ -320,13 +312,6 @@ impl Contains<RuntimeCall> for IsDemocracyExtrinsics {
                 | RuntimeCall::Whitelist(_)
                 | RuntimeCall::Preimage(_)
         )
-    }
-}
-
-pub struct IsMiscellaneousExtrinsics;
-impl Contains<RuntimeCall> for IsMiscellaneousExtrinsics {
-    fn contains(c: &RuntimeCall) -> bool {
-        matches!(c, RuntimeCall::Proxy(_) | RuntimeCall::Identity(_))
     }
 }
 
@@ -363,8 +348,8 @@ impl Contains<RuntimeCall> for IsBridgesExtrinsics {
             RuntimeCall::EthereumOutboundQueue(_)
                 | RuntimeCall::EthereumInboundQueue(_)
                 | RuntimeCall::EthereumSystem(_)
-                | RuntimeCall::EthereumBeaconClient(_)
-                | RuntimeCall::EthereumTokenTransfers(_)
+                | RuntimeCall::EthereumTokenTransfers(_) // Beacon client enabled in 1301
+                                                         // | RuntimeCall::EthereumBeaconClient(_)
         )
     }
 }
@@ -384,10 +369,8 @@ parameter_types! {
 #[derive_impl(frame_system::config_preludes::RelayChainDefaultConfig)]
 impl frame_system::Config for Runtime {
     type BaseCallFilter = EverythingBut<(
-        IsBalanceTransferExtrinsics,
         IsContainerChainManagementExtrinsics,
         IsDemocracyExtrinsics,
-        IsMiscellaneousExtrinsics,
         IsXcmExtrinsics,
         IsContainerChainRegistrationExtrinsics,
         IsBridgesExtrinsics,

--- a/chains/orchestrator-relays/runtime/starlight/src/tests/test_disabled_extrinsics.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/tests/test_disabled_extrinsics.rs
@@ -15,6 +15,7 @@
 // along with Tanssi.  If not, see <http://www.gnu.org/licenses/>
 
 #![cfg(test)]
+
 use {
     crate::{tests::common::*, RuntimeCall},
     frame_support::assert_noop,
@@ -22,36 +23,6 @@ use {
     sp_core::H160,
     sp_runtime::traits::Dispatchable,
 };
-
-#[test]
-fn test_disabled_some_extrinsics_for_balances() {
-    ExtBuilder::default().build().execute_with(|| {
-        run_to_block(2);
-
-        assert_noop!(
-            RuntimeCall::Balances(pallet_balances::Call::transfer_allow_death {
-                dest: AccountId::from(BOB).into(),
-                value: 12345,
-            })
-            .dispatch(<Runtime as frame_system::Config>::RuntimeOrigin::signed(
-                AccountId::from(ALICE)
-            )),
-            frame_system::Error::<Runtime>::CallFiltered
-        );
-
-        assert_noop!(
-            RuntimeCall::Balances(pallet_balances::Call::force_transfer {
-                source: AccountId::from(ALICE).into(),
-                dest: AccountId::from(BOB).into(),
-                value: 12345,
-            })
-            .dispatch(<Runtime as frame_system::Config>::RuntimeOrigin::signed(
-                AccountId::from(ALICE)
-            )),
-            frame_system::Error::<Runtime>::CallFiltered
-        );
-    });
-}
 
 #[test]
 fn test_disabled_some_extrinsics_for_bridges() {
@@ -98,14 +69,15 @@ fn test_disabled_some_extrinsics_for_bridges() {
             frame_system::Error::<Runtime>::CallFiltered
         );
 
-        assert_noop!(
+        // EthereumBeaconClient enabled in runtime 1301
+        assert_eq!(
             RuntimeCall::EthereumBeaconClient(
                 snowbridge_pallet_ethereum_client::Call::set_operating_mode { mode: Halted }
             )
             .dispatch(<Runtime as frame_system::Config>::RuntimeOrigin::signed(
                 AccountId::from(ALICE)
             )),
-            frame_system::Error::<Runtime>::CallFiltered
+            Err(sp_runtime::DispatchError::BadOrigin.into())
         );
     });
 }
@@ -230,27 +202,6 @@ fn test_disabled_some_extrinsics_democracy() {
 
         assert_noop!(
             RuntimeCall::Preimage(pallet_preimage::Call::note_preimage { bytes: vec![] }).dispatch(
-                <Runtime as frame_system::Config>::RuntimeOrigin::signed(AccountId::from(ALICE))
-            ),
-            frame_system::Error::<Runtime>::CallFiltered
-        );
-    });
-}
-
-#[test]
-fn test_disabled_some_extrinsics_miscelaneous() {
-    ExtBuilder::default().build().execute_with(|| {
-        run_to_block(2);
-
-        assert_noop!(
-            RuntimeCall::Proxy(pallet_proxy::Call::remove_proxies {}).dispatch(
-                <Runtime as frame_system::Config>::RuntimeOrigin::signed(AccountId::from(ALICE))
-            ),
-            frame_system::Error::<Runtime>::CallFiltered
-        );
-
-        assert_noop!(
-            RuntimeCall::Identity(pallet_identity::Call::set_subs { subs: vec![] }).dispatch(
                 <Runtime as frame_system::Config>::RuntimeOrigin::signed(AccountId::from(ALICE))
             ),
             frame_system::Error::<Runtime>::CallFiltered

--- a/test/suites/dev-tanssi-relay/proxy/test-proxy-registrar.ts
+++ b/test/suites/dev-tanssi-relay/proxy/test-proxy-registrar.ts
@@ -5,7 +5,11 @@ import type { KeyringPair } from "@moonwall/util";
 import type { ApiPromise } from "@polkadot/api";
 import type { u32 } from "@polkadot/types";
 import { initializeCustomCreateBlock, jumpSessions } from "utils";
-import { STARLIGHT_VERSIONS_TO_EXCLUDE_FROM_PROXY, checkCallIsFiltered } from "helpers";
+import {
+    STARLIGHT_VERSIONS_TO_EXCLUDE_FROM_PROXY,
+    checkCallIsFiltered,
+    STARLIGHT_VERSIONS_TO_EXCLUDE_FROM_CONTAINER_REGISTRAR,
+} from "helpers";
 
 describeSuite({
     id: "DEVT1501",
@@ -24,6 +28,7 @@ describeSuite({
         let isStarlight: boolean;
         let specVersion: number;
         let shouldSkipStarlightProxy: boolean;
+        let shouldSkipStarlightRegistrar: boolean;
 
         beforeAll(() => {
             initializeCustomCreateBlock(context);
@@ -59,6 +64,8 @@ describeSuite({
             isStarlight = runtimeName === "starlight";
             specVersion = polkadotJs.consts.system.version.specVersion.toNumber();
             shouldSkipStarlightProxy = isStarlight && STARLIGHT_VERSIONS_TO_EXCLUDE_FROM_PROXY.includes(specVersion);
+            shouldSkipStarlightRegistrar =
+                isStarlight && STARLIGHT_VERSIONS_TO_EXCLUDE_FROM_CONTAINER_REGISTRAR.includes(specVersion);
         });
 
         it({
@@ -129,6 +136,15 @@ describeSuite({
                         context,
                         polkadotJs,
                         await polkadotJs.tx.proxy.proxy(sudoAlice.address, null, "0x").signAsync(delegateBob)
+                    );
+                    return;
+                }
+                if (shouldSkipStarlightRegistrar) {
+                    console.log(`Skipping E03 test for Starlight version ${specVersion}`);
+                    await checkCallIsFiltered(
+                        context,
+                        polkadotJs,
+                        await polkadotJs.tx.registrar.reserve().signAsync(charlie)
                     );
                     return;
                 }
@@ -257,6 +273,15 @@ describeSuite({
                 if (shouldSkipStarlightProxy) {
                     console.log(`Skipping E04 test for Starlight version ${specVersion}`);
                     await checkCallIsFiltered(context, polkadotJs, await txAddsCode.signAsync(charlie));
+                    return;
+                }
+                if (shouldSkipStarlightRegistrar) {
+                    console.log(`Skipping E04 test for Starlight version ${specVersion}`);
+                    await checkCallIsFiltered(
+                        context,
+                        polkadotJs,
+                        await polkadotJs.tx.registrar.reserve().signAsync(charlie)
+                    );
                     return;
                 }
 


### PR DESCRIPTION
Enable the following pallets in starlight runtime 1301:

*    RuntimeCall::Balances
*    RuntimeCall::Proxy
*    RuntimeCall::Identity
*    RuntimeCall::EthereumBeaconClient