### PR TITLE
Install locked twiggy version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,7 +271,7 @@ jobs:
                   rustup override unset
                   rustup show
             - name: Download Twiggy
-              run: cargo install twiggy
+              run: cargo install twiggy --locked
             - name: Lookup for latest target branch build
               id: latest-target-build
               run: |


### PR DESCRIPTION
Fixes error of incompatible dependency:

error: failed to compile `twiggy v0.7.0`, intermediate artifacts can be found at `/tmp/cargo-install7pqDs1`. To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.

Caused by:
  rustc 1.81.0 is not supported by the following package:
    backtrace@0.3.75 requires rustc 1.82.0