### PR TITLE
modify overweight of 4MB in service_task_fetched

### DIFF
--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_scheduler.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_scheduler.rs
@@ -96,9 +96,8 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	fn service_task_fetched(s: u32, ) -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `179 + s * (1 ±0)`
-		//  Estimated: `4197809`
 		// Minimum execution time: 28_954_000 picoseconds.
-		Weight::from_parts(29_211_000, 4197809)
+		Weight::from_parts(29_211_000, 0)
 			// Standard Error: 13
 			.saturating_add(Weight::from_parts(1_445, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(3_u64))

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_scheduler.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_scheduler.rs
@@ -96,9 +96,9 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for SubstrateWeight<T
 	fn service_task_fetched(s: u32, ) -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `179 + s * (1 ±0)`
-		//  Estimated: `4197809`
+		//  Estimated: `0`
 		// Minimum execution time: 28_830_000 picoseconds.
-		Weight::from_parts(29_462_000, 4197809)
+		Weight::from_parts(29_462_000, 0)
 			// Standard Error: 7
 			.saturating_add(Weight::from_parts(1_319, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(3_u64))


### PR DESCRIPTION
Modify the weight associated to service_task_fetched yielding 4MB pov

Context: https://github.com/paritytech/polkadot-sdk/pull/7785#issuecomment-2879712055