### PR TITLE
fix check key a couple of sessions before

### DIFF
--- a/test/suites/smoke-test-dancelight/test-babe.ts
+++ b/test/suites/smoke-test-dancelight/test-babe.ts
@@ -106,7 +106,7 @@ describeSuite({
                 expect(babeConsensusLog[1].eq(babeAuthoritiesFromPallet)).toBe(true);
 
                 const keyOwnersArray: string[] = [];
-                const keyOwnersInPalletSession = await keyOwners(babeAuthoritiesFromPallet, api);
+                const keyOwnersInPalletSession = await keyOwners(babeAuthoritiesFromPallet, apiAtSessionChange);
 
                 for (const keyOwner of keyOwnersInPalletSession) {
                     keyOwnersArray.push(keyOwner[0]);


### PR DESCRIPTION
The smoke test for babe keys was checking current validator keys against current owners, which obvioiusly if you have changed your key 2 sessions ago it wont work. This PR compares current validator keys against key owners 2 sessions ago, to make it consistent