### PR TITLE
chore: Update rust tools to 1.87

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.87.0"
 components = [ "rustfmt", "clippy", "rust-src" ]
 targets = [ "wasm32-unknown-unknown" ]
 profile = "minimal"


### PR DESCRIPTION
# Description

Bump rust version to 1.87.0 since its a requirement to upgrade polkadot-sdk to 2503
This is a small PR but I want to ensure all CI checks are ok