### PR TITLE
Increment spec version to 1302 for light chains

### DIFF
--- a/chains/orchestrator-relays/runtime/dancelight/src/lib.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/lib.rs
@@ -191,7 +191,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: Cow::Borrowed("dancelight"),
     impl_name: Cow::Borrowed("tanssi-dancelight-v2.0"),
     authoring_version: 0,
-    spec_version: 1301,
+    spec_version: 1302,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 26,

--- a/chains/orchestrator-relays/runtime/starlight/src/lib.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/lib.rs
@@ -188,7 +188,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: Cow::Borrowed("starlight"),
     impl_name: Cow::Borrowed("tanssi-starlight-v2.0"),
     authoring_version: 0,
-    spec_version: 1301,
+    spec_version: 1302,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 26,


### PR DESCRIPTION
# Description
This PR increment runtime spec version to 1302 for *light chains.