### PR TITLE
Allow to spawn the node with Tanssi specs

### DIFF
--- a/chains/orchestrator-relays/client/cli/src/command.rs
+++ b/chains/orchestrator-relays/client/cli/src/command.rs
@@ -518,6 +518,8 @@ fn load_spec(
             )
         }
         #[cfg(feature = "starlight-native")]
+        "tanssi" => Box::new(tanssi_relay_service::chain_spec::tanssi_config()?),
+        #[cfg(feature = "starlight-native")]
         "starlight-dev" => {
             // Default invulnerables for dev mode, used in dev_tanssi_relay tests
             let invulnerables = invulnerables.unwrap_or(vec![

--- a/chains/orchestrator-relays/node/tanssi-relay-service/src/chain_spec.rs
+++ b/chains/orchestrator-relays/node/tanssi-relay-service/src/chain_spec.rs
@@ -96,6 +96,12 @@ pub fn dancelight_config() -> Result<DancelightChainSpec, String> {
     )
 }
 
+pub fn tanssi_config() -> Result<StarlightChainSpec, String> {
+    StarlightChainSpec::from_json_bytes(
+        &include_bytes!("../chain-specs/starlight-raw-specs.json")[..],
+    )
+}
+
 /// Dancelight staging testnet config.
 #[cfg(feature = "dancelight-native")]
 pub fn dancelight_staging_testnet_config() -> Result<DancelightChainSpec, String> {


### PR DESCRIPTION
## Description

Add Tanssi chain spec configurations to allow spawning the node with `--chain=tanssi` option using the proper mainnet specification and bootnodes.