### PR TITLE
Fix for forEach issue

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,8 +208,8 @@ importers:
         specifier: ^17.0.33
         version: 17.0.33
       '@vitest/ui':
-        specifier: ^3.1.3
-        version: 3.2.3(vitest@3.1.3)
+        specifier: 3.1.3
+        version: 3.1.3(vitest@3.1.3)
       '@zombienet/utils':
         specifier: ^0.0.28
         version: 0.0.28(@types/node@22.10.5)(chokidar@3.6.0)(typescript@5.5.4)
@@ -248,7 +248,7 @@ importers:
         version: 2.29.4(typescript@5.5.4)(zod@3.24.2)
       vitest:
         specifier: 3.1.3
-        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.10.5)(@vitest/ui@3.2.3)(jsdom@23.2.0)
+        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.10.5)(@vitest/ui@3.1.3)(jsdom@23.2.0)
       web3:
         specifier: 4.15.0
         version: 4.15.0(encoding@0.1.13)(typescript@5.5.4)(zod@3.24.2)
@@ -2372,16 +2372,13 @@ packages:
   '@vitest/spy@3.1.3':
     resolution: {integrity: sha512-x6w+ctOEmEXdWaa6TO4ilb7l9DxPR5bwEb6hILKuxfU1NqWT2mpJD9NJN7t3OTfxmVlOMrvtoFJGdgyzZ605lQ==}
 
-  '@vitest/ui@3.2.3':
-    resolution: {integrity: sha512-9aR2tY/WT7GRHGEH/9sSIipJqeA21Eh3C6xmiOVmfyBCFmezUSUFLalpaSmRHlRzWCKQU10yz3AHhKuYcdnZGQ==}
+  '@vitest/ui@3.1.3':
+    resolution: {integrity: sha512-IipSzX+8DptUdXN/GWq3hq5z18MwnpphYdOMm0WndkRGYELzfq7NDP8dMpZT7JGW1uXFrIGxOW2D0Xi++ulByg==}
     peerDependencies:
-      vitest: 3.2.3
+      vitest: 3.1.3
 
   '@vitest/utils@3.1.3':
     resolution: {integrity: sha512-2Ltrpht4OmHO9+c/nmHtF09HWiyWdworqnHIwjfvDyWjuwKbdkcS9AnhsDn+8E2RM4x++foD1/tNuLPVvWG1Rg==}
-
-  '@vitest/utils@3.2.3':
-    resolution: {integrity: sha512-4zFBCU5Pf+4Z6v+rwnZ1HU1yzOKKvDkMXZrymE2PBlbjKJRlrOxbvpfPSvJTGRIwGoahaOGvp+kbCoxifhzJ1Q==}
 
   '@zombienet/orchestrator@0.0.105':
     resolution: {integrity: sha512-vw+Pt1N9oChdA+2WHgwygG4wpXaKnPJPIRbm3OWbhscCwHbWlmcVVZhZN3khC4+WMo+kvFt3XhzV6hZrZI5Bug==}
@@ -2942,6 +2939,15 @@ packages:
 
   debug@4.4.0:
     resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.4.1:
+    resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -7030,7 +7036,7 @@ snapshots:
       '@acala-network/chopsticks': 1.0.5(debug@4.3.7)(ts-node@10.9.2(@types/node@22.10.5)(typescript@5.5.4))
       '@inquirer/prompts': 7.5.3(@types/node@22.10.5)
       '@moonbeam-network/api-augment': 0.3600.0(postcss@8.4.49)(yaml@2.8.0)
-      '@moonwall/types': 5.13.0(@types/debug@4.1.12)(@vitest/ui@3.2.3)(chokidar@3.6.0)(encoding@0.1.13)(jsdom@23.2.0)(postcss@8.4.49)(rxjs@7.8.2)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.8.0)(zod@3.24.2)
+      '@moonwall/types': 5.13.0(@types/debug@4.1.12)(@vitest/ui@3.1.3)(chokidar@3.6.0)(encoding@0.1.13)(jsdom@23.2.0)(postcss@8.4.49)(rxjs@7.8.2)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.8.0)(zod@3.24.2)
       '@moonwall/util': 5.13.0(@types/debug@4.1.12)(@types/node@22.10.5)(chokidar@3.6.0)(encoding@0.1.13)(jsdom@23.2.0)(postcss@8.4.49)(rxjs@7.8.2)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.8.0)(zod@3.24.2)
       '@octokit/rest': 21.1.1
       '@polkadot/api': 15.10.2
@@ -7043,7 +7049,7 @@ snapshots:
       '@polkadot/util-crypto': 13.3.1(@polkadot/util@13.3.1)
       '@types/react': 19.1.4
       '@types/tmp': 0.2.6
-      '@vitest/ui': 3.2.3(vitest@3.1.3)
+      '@vitest/ui': 3.1.3(vitest@3.1.3)
       '@zombienet/orchestrator': 0.0.105(@polkadot/util@13.3.1)(@types/node@22.10.5)(chokidar@3.6.0)
       '@zombienet/utils': 0.0.28(@types/node@22.10.5)(chokidar@3.6.0)(typescript@5.5.4)
       bottleneck: 2.19.5
@@ -7066,7 +7072,7 @@ snapshots:
       tiny-invariant: 1.3.3
       tmp: 0.2.3
       viem: 2.29.4(typescript@5.5.4)(zod@3.24.2)
-      vitest: 3.1.3(@types/debug@4.1.12)(@types/node@22.10.5)(@vitest/ui@3.2.3)(jsdom@23.2.0)
+      vitest: 3.1.3(@types/debug@4.1.12)(@types/node@22.10.5)(@vitest/ui@3.1.3)(jsdom@23.2.0)
       web3: 4.16.0(encoding@0.1.13)(typescript@5.5.4)(zod@3.24.2)
       web3-providers-ws: 4.0.8
       ws: 8.18.2
@@ -7122,7 +7128,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@moonwall/types@5.13.0(@types/debug@4.1.12)(@vitest/ui@3.2.3)(chokidar@3.6.0)(encoding@0.1.13)(jsdom@23.2.0)(postcss@8.4.49)(rxjs@7.8.2)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.8.0)(zod@3.24.2)':
+  '@moonwall/types@5.13.0(@types/debug@4.1.12)(@vitest/ui@3.1.3)(chokidar@3.6.0)(encoding@0.1.13)(jsdom@23.2.0)(postcss@8.4.49)(rxjs@7.8.2)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.8.0)(zod@3.24.2)':
     dependencies:
       '@polkadot/api': 15.10.2
       '@polkadot/api-base': 15.10.2
@@ -7137,7 +7143,7 @@ snapshots:
       pino: 9.7.0
       polkadot-api: 1.11.1(postcss@8.4.49)(rxjs@7.8.2)(tsx@4.19.2)(yaml@2.8.0)
       viem: 2.29.4(typescript@5.5.4)(zod@3.24.2)
-      vitest: 3.1.3(@types/debug@4.1.12)(@types/node@22.15.31)(@vitest/ui@3.2.3)(jsdom@23.2.0)
+      vitest: 3.1.3(@types/debug@4.1.12)(@types/node@22.15.31)(@vitest/ui@3.1.3)(jsdom@23.2.0)
       web3: 4.16.0(encoding@0.1.13)(typescript@5.5.4)(zod@3.24.2)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -7174,7 +7180,7 @@ snapshots:
     dependencies:
       '@inquirer/prompts': 7.5.3(@types/node@22.10.5)
       '@moonbeam-network/api-augment': 0.3600.0(postcss@8.4.49)(yaml@2.8.0)
-      '@moonwall/types': 5.13.0(@types/debug@4.1.12)(@vitest/ui@3.2.3)(chokidar@3.6.0)(encoding@0.1.13)(jsdom@23.2.0)(postcss@8.4.49)(rxjs@7.8.2)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.8.0)(zod@3.24.2)
+      '@moonwall/types': 5.13.0(@types/debug@4.1.12)(@vitest/ui@3.1.3)(chokidar@3.6.0)(encoding@0.1.13)(jsdom@23.2.0)(postcss@8.4.49)(rxjs@7.8.2)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.8.0)(zod@3.24.2)
       '@polkadot/api': 15.10.2
       '@polkadot/api-derive': 15.10.2
       '@polkadot/keyring': 13.3.1(@polkadot/util-crypto@13.3.1(@polkadot/util@13.3.1))(@polkadot/util@13.3.1)
@@ -7183,7 +7189,7 @@ snapshots:
       '@polkadot/types-codec': 15.10.2
       '@polkadot/util': 13.3.1
       '@polkadot/util-crypto': 13.3.1(@polkadot/util@13.3.1)
-      '@vitest/ui': 3.2.3(vitest@3.1.3)
+      '@vitest/ui': 3.1.3(vitest@3.1.3)
       bottleneck: 2.19.5
       chalk: 5.4.1
       clear: 0.1.0
@@ -7196,7 +7202,7 @@ snapshots:
       semver: 7.7.2
       tiny-invariant: 1.3.3
       viem: 2.29.4(typescript@5.5.4)(zod@3.24.2)
-      vitest: 3.1.3(@types/debug@4.1.12)(@types/node@22.10.5)(@vitest/ui@3.2.3)(jsdom@23.2.0)
+      vitest: 3.1.3(@types/debug@4.1.12)(@types/node@22.10.5)(@vitest/ui@3.1.3)(jsdom@23.2.0)
       web3: 4.16.0(encoding@0.1.13)(typescript@5.5.4)(zod@3.24.2)
       ws: 8.18.2
       yargs: 17.7.2
@@ -8226,26 +8232,20 @@ snapshots:
     dependencies:
       tinyspy: 3.0.2
 
-  '@vitest/ui@3.2.3(vitest@3.1.3)':
+  '@vitest/ui@3.1.3(vitest@3.1.3)':
     dependencies:
-      '@vitest/utils': 3.2.3
+      '@vitest/utils': 3.1.3
       fflate: 0.8.2
       flatted: 3.3.3
       pathe: 2.0.3
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.1.3(@types/debug@4.1.12)(@types/node@22.10.5)(@vitest/ui@3.2.3)(jsdom@23.2.0)
+      vitest: 3.1.3(@types/debug@4.1.12)(@types/node@22.10.5)(@vitest/ui@3.1.3)(jsdom@23.2.0)
 
   '@vitest/utils@3.1.3':
     dependencies:
       '@vitest/pretty-format': 3.1.3
-      loupe: 3.1.3
-      tinyrainbow: 2.0.0
-
-  '@vitest/utils@3.2.3':
-    dependencies:
-      '@vitest/pretty-format': 3.2.3
       loupe: 3.1.3
       tinyrainbow: 2.0.0
 
@@ -8852,6 +8852,10 @@ snapshots:
       supports-color: 8.1.1
 
   debug@4.4.0:
+    dependencies:
+      ms: 2.1.3
+
+  debug@4.4.1:
     dependencies:
       ms: 2.1.3
 
@@ -11311,7 +11315,7 @@ snapshots:
   vite-node@3.1.3(@types/node@22.10.5):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.0
+      debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 5.4.11(@types/node@22.10.5)
@@ -11329,7 +11333,7 @@ snapshots:
   vite-node@3.1.3(@types/node@22.15.31):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.0
+      debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 5.4.11(@types/node@22.15.31)
@@ -11362,7 +11366,7 @@ snapshots:
       '@types/node': 22.15.31
       fsevents: 2.3.3
 
-  vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.10.5)(@vitest/ui@3.2.3)(jsdom@23.2.0):
+  vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.10.5)(@vitest/ui@3.1.3)(jsdom@23.2.0):
     dependencies:
       '@vitest/expect': 3.1.3
       '@vitest/mocker': 3.1.3(vite@5.4.11(@types/node@22.10.5))
@@ -11372,7 +11376,7 @@ snapshots:
       '@vitest/spy': 3.1.3
       '@vitest/utils': 3.1.3
       chai: 5.2.0
-      debug: 4.4.0
+      debug: 4.4.1
       expect-type: 1.2.1
       magic-string: 0.30.17
       pathe: 2.0.3
@@ -11388,7 +11392,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 22.10.5
-      '@vitest/ui': 3.2.3(vitest@3.1.3)
+      '@vitest/ui': 3.1.3(vitest@3.1.3)
       jsdom: 23.2.0
     transitivePeerDependencies:
       - less
@@ -11401,7 +11405,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.15.31)(@vitest/ui@3.2.3)(jsdom@23.2.0):
+  vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.15.31)(@vitest/ui@3.1.3)(jsdom@23.2.0):
     dependencies:
       '@vitest/expect': 3.1.3
       '@vitest/mocker': 3.1.3(vite@5.4.11(@types/node@22.15.31))
@@ -11411,7 +11415,7 @@ snapshots:
       '@vitest/spy': 3.1.3
       '@vitest/utils': 3.1.3
       chai: 5.2.0
-      debug: 4.4.0
+      debug: 4.4.1
       expect-type: 1.2.1
       magic-string: 0.30.17
       pathe: 2.0.3
@@ -11427,7 +11431,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 22.15.31
-      '@vitest/ui': 3.2.3(vitest@3.1.3)
+      '@vitest/ui': 3.1.3(vitest@3.1.3)
       jsdom: 23.2.0
     transitivePeerDependencies:
       - less

--- a/test/package.json
+++ b/test/package.json
@@ -67,7 +67,7 @@
         "@types/node": "*",
         "@types/ps-node": "0.1.3",
         "@types/yargs": "^17.0.33",
-        "@vitest/ui": "^3.1.3",
+        "@vitest/ui": "3.1.3",
         "@zombienet/utils": "^0.0.28",
         "bottleneck": "2.19.5",
         "chalk": "^5.4.0",


### PR DESCRIPTION
**Summary**:
Vitest [introduced](https://vitest.dev/blog/vitest-3-2.html#annotation-api) annotation API in 3.2.*, but we use:
"vitest": "3.1.3",
"@vitest/ui": "^3.1.3",

`vitest/ui` -> resolved to `3.2.3`, but vitest knows nothing about annotations, this is why it [fails](https://github.com/vitest-dev/vitest/blob/657e83f9faf869ee9bed98f606a4dd46d5bba978/packages/vitest/src/node/reporters/tap.ts#L87).

So we need to downgrade to 3.1.3 to be consistent with [moonwall](https://github.com/Moonsong-Labs/moonwall/blob/%40moonwall/cli%405.13.0/test/package.json) at version 5.13.0.