### PR TITLE
Return collator randomness test if < 1400

### DIFF
--- a/test/suites/smoke-test-common-solo/test-randomness-consistency.ts
+++ b/test/suites/smoke-test-common-solo/test-randomness-consistency.ts
@@ -19,52 +19,32 @@ describeSuite({
         it({
             id: "C01",
             title: "Randomness storage is empty because on-finalize cleans it, unless on session change boundaries",
-            test: async () => {
+            test: async ({ skip }) => {
+                if (runtimeVersion < 1400) {
+                    // We know there exists a bug prior to 1400. so let's skip this
+                    skip();
+                }
                 // After runtime upgrade, randomness in storage is always empty, this test can be removed
-                if (runtimeVersion >= 1400) {
-                    const randomness = await api.query.tanssiCollatorAssignment.randomness();
-                    expect(randomness.isEmpty).to.be.true;
-                    return;
-                }
-
                 const randomness = await api.query.tanssiCollatorAssignment.randomness();
-
-                // take the most recent
-                const blockBabeEpochStart = (await api.query.babe.epochStart())[1].toNumber();
-                const currentSlot = await api.query.babe.currentSlot();
-
-                const apiAtSessionChange = await api.at(await api.rpc.chain.getBlockHash(blockBabeEpochStart));
-
-                const slotAtEpochStart = await apiAtSessionChange.query.babe.currentSlot();
-                const sessionLength = await api.consts.babe.epochDuration;
-
-                // if the next block is a session change, then this storage will be populated
-                if (currentSlot.toBigInt() - slotAtEpochStart.toBigInt() > sessionLength.toBigInt()) {
-                    expect(randomness.isEmpty).to.not.be.true;
-                } else {
-                    expect(randomness.isEmpty).to.be.true;
-                }
+                expect(randomness.isEmpty).to.be.true;
+                return;
             },
         });
 
         it({
             id: "C02",
             title: "Rotation happened at previous session boundary",
-            test: async () => {
+            test: async ({ skip }) => {
+                if (runtimeVersion < 1400) {
+                    // We know there exists a bug prior to 1400. so let's skip this
+                    skip();
+                }
+
                 const blockBabeEpochStart = (await api.query.babe.epochStart())[1].toNumber();
                 const apiAtNewSession = await api.at(await api.rpc.chain.getBlockHash(blockBabeEpochStart));
 
                 const blockToCheck = blockBabeEpochStart - 1;
                 const apiBeforeNewSession = await api.at(await api.rpc.chain.getBlockHash(blockToCheck));
-
-                // After runtime upgrade, randomness in storage is always empty
-                if (runtimeVersion < 1400) {
-                    // Just before, the randomness was not empty
-                    const randomnessBeforeSession =
-                        await apiBeforeNewSession.query.tanssiCollatorAssignment.randomness();
-                    expect(randomnessBeforeSession.isEmpty).to.not.be.true;
-                }
-
                 // After, the randomness gets cleaned
                 const randomnessAfterSession = await apiAtNewSession.query.tanssiCollatorAssignment.randomness();
                 expect(randomnessAfterSession.isEmpty).to.be.true;


### PR DESCRIPTION
Early return the randomness check at session-boundaries if less than rt 1400 in tanssi solo. we know there is a bug so I dont think it's worth checking