### PR TITLE
Add test to check if root can send raw xcm message to ethereum

### DIFF
--- a/chains/orchestrator-relays/runtime/dancelight/src/tests/ethereum_token_transfers.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/tests/ethereum_token_transfers.rs
@@ -2359,6 +2359,114 @@ fn test_user_cannot_send_raw_message() {
         })
 }
 
+#[test]
+fn test_root_can_send_raw_message() {
+    ExtBuilder::default()
+        .with_balances(vec![
+            (EthereumSovereignAccount::get(), 100_000 * UNIT),
+            (SnowbridgeFeesAccount::get(), 100_000 * UNIT),
+            (AccountId::from(ALICE), 100_000 * UNIT),
+            (AccountId::from(BOB), 100_000 * UNIT),
+        ])
+        .build()
+        .execute_with(|| {
+            // Setup bridge and token
+            let channel_id: ChannelId = ChannelId::new(hex!(
+                "00000000000000000000006e61746976655f746f6b656e5f7472616e73666572"
+            ));
+            let agent_id = AgentId::from_low_u64_be(10);
+            let para_id: ParaId = 2000u32.into();
+            let amount_to_transfer = 10_000u128;
+            let topic = hex!("deadbeafdeadbeafdeadbeafdeadbeafdeadbeafdeadbeafdeadbeafdeadbeaf");
+
+            assert_ok!(EthereumTokenTransfers::set_token_transfer_channel(
+                root_origin(),
+                channel_id,
+                agent_id,
+                para_id
+            ));
+
+            // Define a mock ERC20 token address
+            let token_address = H160(hex!("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"));
+
+            // Relative to ethereum consensus
+            let erc20_asset_location = Location {
+                parents: 0,
+                interior: X1([
+                    AccountKey20 {
+                        network: Some(EthereumNetwork::get()),
+                        key: token_address.into(),
+                    },
+                ]
+                    .into()),
+            };
+
+            let asset_id = 42u16;
+
+            assert_ok!(ForeignAssetsCreator::create_foreign_asset(
+                root_origin(),
+                erc20_asset_location.clone(), // Use the ERC20 location
+                asset_id,
+                AccountId::from(ALICE),
+                true,
+                1
+            ));
+
+            // Give tokens to user as if tokens were bridged before + extra to check the correct
+            // amount is sent
+            ForeignAssets::mint_into(asset_id, &AccountId::from(BOB), amount_to_transfer + 10)
+                .expect("to mint amount");
+
+            // User tries to send tokens
+            let beneficiary_address = H160(hex!("0123456789abcdef0123456789abcdef01234567"));
+
+            // Beneficiary location
+            let mut beneficiary_location = Location {
+                parents: 0,
+                interior: X1([AccountKey20 {
+                    network: Some(EthereumNetwork::get()),
+                    key: beneficiary_address.into(),
+                }]
+                    .into()),
+            };
+
+            println!("Beneficiary location: {:?}", beneficiary_location);
+
+            let eth_asset = AssetId(erc20_asset_location.clone())
+                .into_asset(Fungibility::Fungible(amount_to_transfer));
+
+            let mut assets = Assets::new();
+            assets.push(eth_asset);
+
+            let xcm_message = Xcm(vec![
+                Instruction::WithdrawAsset(assets),
+                Instruction::DepositAsset {
+                    assets: AssetFilter::Wild(WildAsset::All),
+                    beneficiary: beneficiary_location.clone(),
+                },
+                Instruction::SetTopic(topic),
+            ]);
+
+            assert_ok!(
+                XcmPallet::send(
+                    RuntimeOrigin::root(),
+                    Box::new(EthereumLocation::get().into()),
+                    Box::new(VersionedXcm::V5(xcm_message)),
+                )
+            );
+
+            assert_eq!(
+                filter_events!(RuntimeEvent::EthereumOutboundQueue(
+                    snowbridge_pallet_outbound_queue::Event::MessageQueued { .. },
+                ))
+                    .count(),
+                1,
+                "MessageQueued event should be emitted!"
+            );
+        })
+}
+
+
 fn create_valid_payload() -> Vec<u8> {
     let token_location = TokenLocationReanchored::get();
     let token_id = EthereumSystem::convert_back(&token_location).unwrap_or_default();

--- a/chains/orchestrator-relays/runtime/dancelight/src/tests/ethereum_token_transfers.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/tests/ethereum_token_transfers.rs
@@ -2389,8 +2389,8 @@ fn test_root_can_send_raw_message() {
             // Define a mock ERC20 token address
             let token_address = H160(hex!("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"));
 
-            // Relative to ethereum consensus
-            let erc20_asset_location = Location {
+            // Relative to ethereum asset location (pallet_xcm::transfer_assets does the reanchor internally)
+            let erc20_asset_location_relative_to_eth = Location {
                 parents: 0,
                 interior: X1([
                     AccountKey20 {
@@ -2403,24 +2403,10 @@ fn test_root_can_send_raw_message() {
 
             let asset_id = 42u16;
 
-            assert_ok!(ForeignAssetsCreator::create_foreign_asset(
-                root_origin(),
-                erc20_asset_location.clone(), // Use the ERC20 location
-                asset_id,
-                AccountId::from(ALICE),
-                true,
-                1
-            ));
-
-            // Give tokens to user as if tokens were bridged before + extra to check the correct
-            // amount is sent
-            ForeignAssets::mint_into(asset_id, &AccountId::from(BOB), amount_to_transfer + 10)
-                .expect("to mint amount");
-
             // User tries to send tokens
             let beneficiary_address = H160(hex!("0123456789abcdef0123456789abcdef01234567"));
 
-            // Beneficiary location
+            // Beneficiary location relative to ethereum
             let mut beneficiary_location = Location {
                 parents: 0,
                 interior: X1([AccountKey20 {
@@ -2430,9 +2416,7 @@ fn test_root_can_send_raw_message() {
                     .into()),
             };
 
-            println!("Beneficiary location: {:?}", beneficiary_location);
-
-            let eth_asset = AssetId(erc20_asset_location.clone())
+            let eth_asset = AssetId(erc20_asset_location_relative_to_eth.clone())
                 .into_asset(Fungibility::Fungible(amount_to_transfer));
 
             let mut assets = Assets::new();


### PR DESCRIPTION
# Description
This PR builds on top of #1054 and adds a test that root origin can send a raw xcm to ethereum and instructing agent to deposit *ANY* asset to any ethereum address.