### PR TITLE
Script that cancels other PR-s besides the specific one

### DIFF
--- a/scripts/cancel_all_but.sh
+++ b/scripts/cancel_all_but.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -euo pipefail
+
+REPO="moondance-labs/tanssi"
+KEEP_PR_NUMBER="$1"
+
+echo "🚨 Canceling all workflows except for PR #$KEEP_PR_NUMBER"
+
+# Get all open PRs
+gh pr list -R "$REPO" --state open --json number,headRefName | jq -c '.[]' | while read -r pr; do
+  pr_number=$(echo "$pr" | jq -r '.number')
+  branch=$(echo "$pr" | jq -r '.headRefName')
+
+  if [[ "$pr_number" == "$KEEP_PR_NUMBER" ]]; then
+    echo "✅ Keeping PR #$pr_number — branch: $branch"
+    continue
+  fi
+
+  echo "🔍 Checking workflows for PR #$pr_number — branch: $branch"
+
+  # Find all active runs for this branch
+  gh run list -R "$REPO" --limit 100 \
+    --json databaseId,headBranch,status,conclusion \
+    | jq -c ".[] | select(.headBranch == \"$branch\" and (.status == \"queued\" or .status == \"in_progress\"))" \
+    | while read -r run; do
+        run_id=$(echo "$run" | jq -r '.databaseId')
+        echo "❌ Canceling run ID $run_id"
+        gh run cancel "$run_id" -R "$REPO"
+    done
+done
+
+echo "✅ Done. Only PR #$KEEP_PR_NUMBER workflows remain active."


### PR DESCRIPTION
**Description**:
Sometimes we need to speed up the specific PR merge. 
Using this script, we can cancel all the other PR jobs except the specified one. 
<img width="846" height="465" alt="image" src="https://github.com/user-attachments/assets/ff4fb65b-0674-4dd3-abc1-ac037f903d8a" />
