### PR TITLE
Remove usage of sp_std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2439,7 +2439,6 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-std",
  "sp-transaction-pool",
  "sp-trie",
  "sp-version",
@@ -2522,7 +2521,6 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-std",
  "sp-transaction-pool",
  "sp-trie",
  "sp-version",
@@ -3685,7 +3683,6 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-std",
  "sp-transaction-pool",
  "sp-trie",
  "sp-version",
@@ -3738,7 +3735,6 @@ dependencies = [
  "sp-consensus-slots",
  "sp-core",
  "sp-runtime",
- "sp-std",
  "tp-data-preservers-common",
 ]
 
@@ -3902,7 +3898,6 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std",
  "sp-storage",
  "sp-tracing",
  "sp-transaction-pool",
@@ -5368,7 +5363,6 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-std",
  "sp-transaction-pool",
  "sp-trie",
  "sp-version",
@@ -9598,7 +9592,6 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-state-machine",
- "sp-std",
  "sp-trie",
  "sp-version",
  "test-relay-sproof-builder",
@@ -9628,7 +9621,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
  "tp-traits",
 ]
 
@@ -9658,7 +9650,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
 ]
 
 [[package]]
@@ -9910,7 +9901,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
  "tp-traits",
  "tracing",
  "tracing-subscriber",
@@ -9975,7 +9965,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
  "tp-traits",
 ]
 
@@ -10014,7 +10003,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
  "tp-traits",
 ]
 
@@ -10159,7 +10147,6 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-staking",
- "sp-std",
  "staging-xcm",
  "tp-bridge",
  "tp-traits",
@@ -10406,7 +10393,6 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-staking",
- "sp-std",
  "tp-bridge",
  "tp-traits",
 ]
@@ -10429,7 +10415,6 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-staking",
- "sp-std",
  "tp-traits",
 ]
 
@@ -10456,7 +10441,6 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-staking",
- "sp-std",
  "staging-xcm",
  "tp-bridge",
  "tp-traits",
@@ -10581,7 +10565,6 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-staking",
- "sp-std",
  "tp-traits",
 ]
 
@@ -10619,7 +10602,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
  "tp-traits",
 ]
 
@@ -10635,7 +10617,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
 ]
 
 [[package]]
@@ -10655,7 +10636,6 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-staking",
- "sp-std",
  "tp-traits",
 ]
 
@@ -10859,7 +10839,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
 ]
 
 [[package]]
@@ -10947,7 +10926,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
  "tp-maths",
  "tp-traits",
 ]
@@ -11050,7 +11028,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
  "sp-trie",
  "tp-traits",
 ]
@@ -11138,7 +11115,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
  "tp-traits",
 ]
 
@@ -11290,7 +11266,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
  "tap",
  "tp-maths",
  "tp-traits",
@@ -11594,7 +11569,6 @@ dependencies = [
  "sp-io",
  "sp-keystore",
  "sp-runtime",
- "sp-std",
  "staging-xcm",
  "tp-traits",
  "tp-xcm-core-buyer",
@@ -11612,7 +11586,6 @@ dependencies = [
  "sp-api",
  "sp-consensus-slots",
  "sp-runtime",
- "sp-std",
  "thiserror 1.0.69",
  "tp-xcm-core-buyer",
 ]
@@ -18709,7 +18682,6 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std",
  "sp-storage",
  "sp-tracing",
  "sp-transaction-pool",
@@ -19411,7 +19383,6 @@ dependencies = [
  "sp-core",
  "sp-keyring",
  "sp-runtime",
- "sp-std",
  "sp-weights",
  "staging-xcm",
  "xcm-emulator",
@@ -19760,7 +19731,6 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-staking",
- "sp-std",
  "staging-xcm",
 ]
 
@@ -20482,7 +20452,6 @@ dependencies = [
  "snowbridge-pallet-system",
  "sp-core",
  "sp-runtime",
- "sp-std",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -20504,7 +20473,6 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-runtime",
- "sp-std",
  "tp-stream-payment-common",
  "tp-traits",
 ]
@@ -20515,7 +20483,6 @@ version = "0.1.0"
 dependencies = [
  "pallet-invulnerables",
  "polkadot-primitives",
- "sp-std",
  "tp-traits",
 ]
 
@@ -20533,7 +20500,6 @@ version = "0.1.0"
 dependencies = [
  "pallet-registrar",
  "pallet-session",
- "sp-std",
  "tp-traits",
 ]
 
@@ -20552,7 +20518,6 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-runtime",
- "sp-std",
  "tp-traits",
 ]
 
@@ -20571,7 +20536,6 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-runtime",
- "sp-std",
 ]
 
 [[package]]
@@ -20580,7 +20544,6 @@ version = "0.1.0"
 dependencies = [
  "frame-support",
  "log",
- "sp-std",
  "staging-xcm",
 ]
 
@@ -20593,7 +20556,6 @@ dependencies = [
  "scale-info",
  "sp-keystore",
  "sp-runtime",
- "sp-std",
  "tp-traits",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -240,7 +240,6 @@ sp-panic-handler = { git = "https://github.com/moondance-labs/polkadot-sdk", bra
 sp-runtime = { git = "https://github.com/moondance-labs/polkadot-sdk", branch = "tanssi-polkadot-stable2503", default-features = false }
 sp-session = { git = "https://github.com/moondance-labs/polkadot-sdk", branch = "tanssi-polkadot-stable2503", default-features = false }
 sp-state-machine = { git = "https://github.com/moondance-labs/polkadot-sdk", branch = "tanssi-polkadot-stable2503", default-features = false }
-sp-std = { git = "https://github.com/moondance-labs/polkadot-sdk", branch = "tanssi-polkadot-stable2503", default-features = false }
 sp-transaction-pool = { git = "https://github.com/moondance-labs/polkadot-sdk", branch = "tanssi-polkadot-stable2503", default-features = false }
 sp-trie = { git = "https://github.com/moondance-labs/polkadot-sdk", branch = "tanssi-polkadot-stable2503", default-features = false }
 sp-version = { git = "https://github.com/moondance-labs/polkadot-sdk", branch = "tanssi-polkadot-stable2503", default-features = false }

--- a/benchmarking/frame-weight-pallet-template.hbs
+++ b/benchmarking/frame-weight-pallet-template.hbs
@@ -33,7 +33,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weight functions needed for {{pallet}}.
 pub trait WeightInfo {

--- a/benchmarking/frame-weight-runtime-template-xcm.hbs
+++ b/benchmarking/frame-weight-runtime-template-xcm.hbs
@@ -33,7 +33,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for {{pallet}} using the Substrate node and recommended hardware.
 pub struct WeightInfo<T>(PhantomData<T>);

--- a/benchmarking/frame-weight-runtime-template.hbs
+++ b/benchmarking/frame-weight-runtime-template.hbs
@@ -33,7 +33,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for {{pallet}} using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/frontier/Cargo.toml
+++ b/chains/container-chains/runtime-templates/frontier/Cargo.toml
@@ -81,7 +81,6 @@ sp-inherents = { workspace = true }
 sp-offchain = { workspace = true }
 sp-runtime = { workspace = true }
 sp-session = { workspace = true }
-sp-std = { workspace = true }
 sp-transaction-pool = { workspace = true }
 sp-trie = { workspace = true }
 
@@ -218,7 +217,6 @@ std = [
 	"sp-offchain/std",
 	"sp-runtime/std",
 	"sp-session/std",
-	"sp-std/std",
 	"sp-transaction-pool/std",
 	"sp-trie/std",
 	"sp-version/std",

--- a/chains/container-chains/runtime-templates/frontier/src/impl_on_charge_evm_transaction.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/impl_on_charge_evm_transaction.rs
@@ -17,7 +17,7 @@
 #[macro_export]
 macro_rules! impl_on_charge_evm_transaction {
 	{} => {
-		pub struct OnChargeEVMTransaction<OU>(sp_std::marker::PhantomData<OU>);
+		pub struct OnChargeEVMTransaction<OU>(core::marker::PhantomData<OU>);
 		impl<T, OU> OnChargeEVMTransactionT<T> for OnChargeEVMTransaction<OU>
 		where
 			T: pallet_evm::Config,

--- a/chains/container-chains/runtime-templates/frontier/src/lib.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/lib.rs
@@ -38,6 +38,7 @@ pub mod xcm_config;
 
 use {
     crate::precompiles::TemplatePrecompiles,
+    alloc::{vec, vec::Vec},
     cumulus_primitives_core::AggregateMessageOrigin,
     dp_impl_tanssi_pallets_config::impl_tanssi_pallets_config,
     fp_account::EthereumSignature,

--- a/chains/container-chains/runtime-templates/frontier/src/lib.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/lib.rs
@@ -94,7 +94,6 @@ use {
         },
         ApplyExtrinsicResult, BoundedVec, Cow,
     },
-    sp_std::prelude::*,
     sp_version::RuntimeVersion,
     xcm::Version as XcmVersion,
     xcm::{IntoVersion, VersionedAssetId, VersionedAssets, VersionedLocation, VersionedXcm},
@@ -832,7 +831,7 @@ pub enum DeployFilter {
     Whitelisted(BoundedVec<H160, ConstU32<100>>),
 }
 
-pub struct AddressFilter<Runtime, AddressList>(sp_std::marker::PhantomData<(Runtime, AddressList)>);
+pub struct AddressFilter<Runtime, AddressList>(core::marker::PhantomData<(Runtime, AddressList)>);
 impl<Runtime, AddressList> EnsureCreateOrigin<Runtime> for AddressFilter<Runtime, AddressList>
 where
     Runtime: pallet_evm::Config,
@@ -1277,7 +1276,7 @@ impl_runtime_apis! {
             use sp_core::storage::TrackedStorageKey;
             use xcm::latest::prelude::*;
             impl frame_system_benchmarking::Config for Runtime {
-                fn setup_set_code_requirements(code: &sp_std::vec::Vec<u8>) -> Result<(), BenchmarkError> {
+                fn setup_set_code_requirements(code: &alloc::vec::Vec<u8>) -> Result<(), BenchmarkError> {
                     ParachainSystem::initialize_for_set_code_benchmark(code.len() as u32);
                     Ok(())
                 }
@@ -1708,7 +1707,7 @@ impl_runtime_apis! {
 
         fn gas_limit_multiplier_support() {}
 
-        fn pending_block(xts: Vec<<Block as BlockT>::Extrinsic>) -> (Option<pallet_ethereum::Block>, Option<sp_std::prelude::Vec<TransactionStatus>>) {
+        fn pending_block(xts: Vec<<Block as BlockT>::Extrinsic>) -> (Option<pallet_ethereum::Block>, Option<alloc::vec::Vec<TransactionStatus>>) {
             for ext in xts.into_iter() {
                 let _ = Executive::apply_extrinsic(ext);
             }
@@ -1864,7 +1863,7 @@ impl cumulus_pallet_parachain_system::CheckInherents<Block> for CheckInherents {
         let inherent_data =
             cumulus_primitives_timestamp::InherentDataProvider::from_relay_chain_slot_and_duration(
                 relay_chain_slot,
-                sp_std::time::Duration::from_secs(6),
+                core::time::Duration::from_secs(6),
             )
             .create_inherent_data()
             .expect("Could not create the timestamp inherent data");

--- a/chains/container-chains/runtime-templates/frontier/src/lib.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/lib.rs
@@ -1276,6 +1276,8 @@ impl_runtime_apis! {
             use frame_benchmarking::{BenchmarkBatch, BenchmarkError};
             use sp_core::storage::TrackedStorageKey;
             use xcm::latest::prelude::*;
+            use alloc::boxed::Box;
+
             impl frame_system_benchmarking::Config for Runtime {
                 fn setup_set_code_requirements(code: &alloc::vec::Vec<u8>) -> Result<(), BenchmarkError> {
                     ParachainSystem::initialize_for_set_code_benchmark(code.len() as u32);

--- a/chains/container-chains/runtime-templates/frontier/src/migrations.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/migrations.rs
@@ -20,6 +20,7 @@
 //! the "Migration" trait declared in the pallet-migrations crate.
 
 use {
+    alloc::{boxed::Box, vec, vec::Vec},
     core::marker::PhantomData,
     frame_support::{
         pallet_prelude::GetStorageVersion,

--- a/chains/container-chains/runtime-templates/frontier/src/migrations.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/migrations.rs
@@ -20,6 +20,7 @@
 //! the "Migration" trait declared in the pallet-migrations crate.
 
 use {
+    core::marker::PhantomData,
     frame_support::{
         pallet_prelude::GetStorageVersion,
         traits::{OnRuntimeUpgrade, PalletInfoAccess},
@@ -27,7 +28,6 @@ use {
     },
     pallet_migrations::{GetMigrations, Migration},
     sp_core::{Get, H160},
-    sp_std::{marker::PhantomData, prelude::*},
 };
 
 pub struct MigratePrecompileXcmDummyCode<T>(pub PhantomData<T>);

--- a/chains/container-chains/runtime-templates/frontier/src/weights/cumulus_pallet_parachain_system.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/weights/cumulus_pallet_parachain_system.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for cumulus_pallet_parachain_system using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/frontier/src/weights/cumulus_pallet_weight_reclaim.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/weights/cumulus_pallet_weight_reclaim.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for cumulus_pallet_weight_reclaim using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/frontier/src/weights/cumulus_pallet_xcmp_queue.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/weights/cumulus_pallet_xcmp_queue.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for cumulus_pallet_xcmp_queue using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/frontier/src/weights/frame_system.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/weights/frame_system.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for frame_system using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/frontier/src/weights/frame_system_extensions.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/weights/frame_system_extensions.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for frame_system_extensions using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/frontier/src/weights/pallet_asset_rate.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/weights/pallet_asset_rate.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_asset_rate using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/frontier/src/weights/pallet_assets.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/weights/pallet_assets.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_assets using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/frontier/src/weights/pallet_author_inherent.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/weights/pallet_author_inherent.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_author_inherent using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/frontier/src/weights/pallet_balances.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/weights/pallet_balances.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_balances using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/frontier/src/weights/pallet_cc_authorities_noting.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/weights/pallet_cc_authorities_noting.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_cc_authorities_noting using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/frontier/src/weights/pallet_foreign_asset_creator.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/weights/pallet_foreign_asset_creator.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_foreign_asset_creator using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/frontier/src/weights/pallet_message_queue.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/weights/pallet_message_queue.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_message_queue using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/frontier/src/weights/pallet_multiblock_migrations.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/weights/pallet_multiblock_migrations.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_multiblock_migrations using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/frontier/src/weights/pallet_multisig.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/weights/pallet_multisig.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_multisig using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/frontier/src/weights/pallet_parameters.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/weights/pallet_parameters.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_parameters using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/frontier/src/weights/pallet_proxy.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/weights/pallet_proxy.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_proxy using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/frontier/src/weights/pallet_sudo.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/weights/pallet_sudo.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_sudo using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/frontier/src/weights/pallet_timestamp.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/weights/pallet_timestamp.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_timestamp using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/frontier/src/weights/pallet_transaction_payment.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/weights/pallet_transaction_payment.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_transaction_payment using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/frontier/src/weights/pallet_tx_pause.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/weights/pallet_tx_pause.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_tx_pause using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/frontier/src/weights/pallet_utility.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/weights/pallet_utility.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_utility using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/frontier/src/weights/pallet_xcm.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/weights/pallet_xcm.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_xcm using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/frontier/src/weights/pallet_xcm_executor_utils.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/weights/pallet_xcm_executor_utils.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_xcm_executor_utils using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/frontier/src/weights/xcm/mod.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/weights/xcm/mod.rs
@@ -20,7 +20,6 @@ use {
     crate::Runtime,
     frame_support::{weights::Weight, BoundedVec},
     pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric,
-    sp_std::prelude::*,
     xcm::{
         latest::{prelude::*, AssetTransferFilter, Weight as XCMWeight},
         DoubleEncoded,

--- a/chains/container-chains/runtime-templates/frontier/src/weights/xcm/mod.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/weights/xcm/mod.rs
@@ -18,6 +18,7 @@ pub mod pallet_xcm_benchmarks_generic;
 
 use {
     crate::Runtime,
+    alloc::vec::Vec,
     frame_support::{weights::Weight, BoundedVec},
     pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric,
     xcm::{

--- a/chains/container-chains/runtime-templates/frontier/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_xcm_benchmarks::generic using the Substrate node and recommended hardware.
 pub struct WeightInfo<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/frontier/src/xcm_config.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/xcm_config.rs
@@ -24,6 +24,7 @@ use {
         RuntimeBlockWeights, RuntimeCall, RuntimeEvent, RuntimeOrigin, TransactionByteFee,
         WeightToFee, XcmpQueue,
     },
+    alloc::vec::Vec,
     ccp_xcm::SignedToAccountKey20,
     cumulus_primitives_core::{AggregateMessageOrigin, ParaId},
     frame_support::{
@@ -47,7 +48,6 @@ use {
     polkadot_runtime_common::xcm_sender::ExponentialPrice,
     sp_core::{ConstU32, H160},
     sp_runtime::Perbill,
-    sp_std::vec::Vec,
     xcm::latest::prelude::*,
     xcm_builder::{
         AccountKey20Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom,

--- a/chains/container-chains/runtime-templates/simple/Cargo.toml
+++ b/chains/container-chains/runtime-templates/simple/Cargo.toml
@@ -71,7 +71,6 @@ sp-inherents = { workspace = true }
 sp-offchain = { workspace = true }
 sp-runtime = { workspace = true }
 sp-session = { workspace = true }
-sp-std = { workspace = true }
 sp-transaction-pool = { workspace = true }
 sp-trie = { workspace = true }
 
@@ -177,7 +176,6 @@ std = [
 	"sp-offchain/std",
 	"sp-runtime/std",
 	"sp-session/std",
-	"sp-std/std",
 	"sp-transaction-pool/std",
 	"sp-trie/std",
 	"sp-version/std",

--- a/chains/container-chains/runtime-templates/simple/src/lib.rs
+++ b/chains/container-chains/runtime-templates/simple/src/lib.rs
@@ -36,6 +36,8 @@ pub mod weights;
 
 pub use sp_runtime::{traits::ExtrinsicLike, MultiAddress, Perbill, Permill};
 use {
+    alloc::vec,
+    alloc::vec::Vec,
     cumulus_primitives_core::AggregateMessageOrigin,
     dp_impl_tanssi_pallets_config::impl_tanssi_pallets_config,
     frame_support::{

--- a/chains/container-chains/runtime-templates/simple/src/lib.rs
+++ b/chains/container-chains/runtime-templates/simple/src/lib.rs
@@ -79,7 +79,6 @@ use {
         transaction_validity::{TransactionSource, TransactionValidity},
         ApplyExtrinsicResult, Cow, MultiSignature, SaturatedConversion,
     },
-    sp_std::prelude::*,
     sp_version::RuntimeVersion,
     xcm::Version as XcmVersion,
     xcm::{IntoVersion, VersionedAssetId, VersionedAssets, VersionedLocation, VersionedXcm},
@@ -994,7 +993,7 @@ impl_runtime_apis! {
             use sp_core::storage::TrackedStorageKey;
             use xcm::latest::prelude::*;
             impl frame_system_benchmarking::Config for Runtime {
-                fn setup_set_code_requirements(code: &sp_std::vec::Vec<u8>) -> Result<(), BenchmarkError> {
+                fn setup_set_code_requirements(code: &alloc::vec::Vec<u8>) -> Result<(), BenchmarkError> {
                     ParachainSystem::initialize_for_set_code_benchmark(code.len() as u32);
                     Ok(())
                 }
@@ -1366,7 +1365,7 @@ impl cumulus_pallet_parachain_system::CheckInherents<Block> for CheckInherents {
         let inherent_data =
             cumulus_primitives_timestamp::InherentDataProvider::from_relay_chain_slot_and_duration(
                 relay_chain_slot,
-                sp_std::time::Duration::from_secs(6),
+                core::time::Duration::from_secs(6),
             )
             .create_inherent_data()
             .expect("Could not create the timestamp inherent data");

--- a/chains/container-chains/runtime-templates/simple/src/lib.rs
+++ b/chains/container-chains/runtime-templates/simple/src/lib.rs
@@ -994,6 +994,8 @@ impl_runtime_apis! {
             use frame_benchmarking::{BenchmarkBatch, BenchmarkError};
             use sp_core::storage::TrackedStorageKey;
             use xcm::latest::prelude::*;
+            use alloc::boxed::Box;
+
             impl frame_system_benchmarking::Config for Runtime {
                 fn setup_set_code_requirements(code: &alloc::vec::Vec<u8>) -> Result<(), BenchmarkError> {
                     ParachainSystem::initialize_for_set_code_benchmark(code.len() as u32);

--- a/chains/container-chains/runtime-templates/simple/src/migrations.rs
+++ b/chains/container-chains/runtime-templates/simple/src/migrations.rs
@@ -20,6 +20,7 @@
 //! the "Migration" trait declared in the pallet-migrations crate.
 
 use {
+    alloc::{boxed::Box, vec, vec::Vec},
     core::marker::PhantomData,
     frame_support::{
         pallet_prelude::GetStorageVersion,

--- a/chains/container-chains/runtime-templates/simple/src/migrations.rs
+++ b/chains/container-chains/runtime-templates/simple/src/migrations.rs
@@ -20,13 +20,13 @@
 //! the "Migration" trait declared in the pallet-migrations crate.
 
 use {
+    core::marker::PhantomData,
     frame_support::{
         pallet_prelude::GetStorageVersion,
         traits::{OnRuntimeUpgrade, PalletInfoAccess},
         weights::Weight,
     },
     pallet_migrations::{GetMigrations, Migration},
-    sp_std::{marker::PhantomData, prelude::*},
 };
 
 pub struct TemplateMigrations<Runtime, XcmpQueue, PolkadotXcm>(

--- a/chains/container-chains/runtime-templates/simple/src/weights/cumulus_pallet_parachain_system.rs
+++ b/chains/container-chains/runtime-templates/simple/src/weights/cumulus_pallet_parachain_system.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for cumulus_pallet_parachain_system using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/simple/src/weights/cumulus_pallet_weight_reclaim.rs
+++ b/chains/container-chains/runtime-templates/simple/src/weights/cumulus_pallet_weight_reclaim.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for cumulus_pallet_weight_reclaim using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/simple/src/weights/cumulus_pallet_xcmp_queue.rs
+++ b/chains/container-chains/runtime-templates/simple/src/weights/cumulus_pallet_xcmp_queue.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for cumulus_pallet_xcmp_queue using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/simple/src/weights/frame_system.rs
+++ b/chains/container-chains/runtime-templates/simple/src/weights/frame_system.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for frame_system using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/simple/src/weights/frame_system_extensions.rs
+++ b/chains/container-chains/runtime-templates/simple/src/weights/frame_system_extensions.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for frame_system_extensions using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/simple/src/weights/pallet_asset_rate.rs
+++ b/chains/container-chains/runtime-templates/simple/src/weights/pallet_asset_rate.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_asset_rate using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/simple/src/weights/pallet_assets.rs
+++ b/chains/container-chains/runtime-templates/simple/src/weights/pallet_assets.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_assets using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/simple/src/weights/pallet_author_inherent.rs
+++ b/chains/container-chains/runtime-templates/simple/src/weights/pallet_author_inherent.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_author_inherent using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/simple/src/weights/pallet_balances.rs
+++ b/chains/container-chains/runtime-templates/simple/src/weights/pallet_balances.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_balances using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/simple/src/weights/pallet_cc_authorities_noting.rs
+++ b/chains/container-chains/runtime-templates/simple/src/weights/pallet_cc_authorities_noting.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_cc_authorities_noting using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/simple/src/weights/pallet_foreign_asset_creator.rs
+++ b/chains/container-chains/runtime-templates/simple/src/weights/pallet_foreign_asset_creator.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_foreign_asset_creator using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/simple/src/weights/pallet_message_queue.rs
+++ b/chains/container-chains/runtime-templates/simple/src/weights/pallet_message_queue.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_message_queue using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/simple/src/weights/pallet_multiblock_migrations.rs
+++ b/chains/container-chains/runtime-templates/simple/src/weights/pallet_multiblock_migrations.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_multiblock_migrations using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/simple/src/weights/pallet_multisig.rs
+++ b/chains/container-chains/runtime-templates/simple/src/weights/pallet_multisig.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_multisig using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/simple/src/weights/pallet_proxy.rs
+++ b/chains/container-chains/runtime-templates/simple/src/weights/pallet_proxy.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_proxy using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/simple/src/weights/pallet_sudo.rs
+++ b/chains/container-chains/runtime-templates/simple/src/weights/pallet_sudo.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_sudo using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/simple/src/weights/pallet_timestamp.rs
+++ b/chains/container-chains/runtime-templates/simple/src/weights/pallet_timestamp.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_timestamp using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/simple/src/weights/pallet_transaction_payment.rs
+++ b/chains/container-chains/runtime-templates/simple/src/weights/pallet_transaction_payment.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_transaction_payment using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/simple/src/weights/pallet_tx_pause.rs
+++ b/chains/container-chains/runtime-templates/simple/src/weights/pallet_tx_pause.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_tx_pause using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/simple/src/weights/pallet_utility.rs
+++ b/chains/container-chains/runtime-templates/simple/src/weights/pallet_utility.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_utility using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/simple/src/weights/pallet_xcm.rs
+++ b/chains/container-chains/runtime-templates/simple/src/weights/pallet_xcm.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_xcm using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/simple/src/weights/pallet_xcm_executor_utils.rs
+++ b/chains/container-chains/runtime-templates/simple/src/weights/pallet_xcm_executor_utils.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_xcm_executor_utils using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/container-chains/runtime-templates/simple/src/weights/xcm/mod.rs
+++ b/chains/container-chains/runtime-templates/simple/src/weights/xcm/mod.rs
@@ -20,6 +20,7 @@ use frame_support::BoundedVec;
 use xcm::latest::AssetTransferFilter;
 use {
     crate::Runtime,
+    alloc::vec::Vec,
     frame_support::weights::Weight,
     pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric,
     xcm::{

--- a/chains/container-chains/runtime-templates/simple/src/weights/xcm/mod.rs
+++ b/chains/container-chains/runtime-templates/simple/src/weights/xcm/mod.rs
@@ -22,7 +22,6 @@ use {
     crate::Runtime,
     frame_support::weights::Weight,
     pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric,
-    sp_std::prelude::*,
     xcm::{
         latest::{prelude::*, Weight as XCMWeight},
         DoubleEncoded,

--- a/chains/container-chains/runtime-templates/simple/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
+++ b/chains/container-chains/runtime-templates/simple/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_xcm_benchmarks::generic using the Substrate node and recommended hardware.
 pub struct WeightInfo<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/Cargo.toml
+++ b/chains/orchestrator-paras/runtime/dancebox/Cargo.toml
@@ -98,7 +98,6 @@ sp-keyring = { workspace = true }
 sp-offchain = { workspace = true }
 sp-runtime = { workspace = true }
 sp-session = { workspace = true }
-sp-std = { workspace = true }
 sp-transaction-pool = { workspace = true }
 sp-trie = { workspace = true }
 
@@ -272,7 +271,6 @@ std = [
 	"sp-offchain/std",
 	"sp-runtime/std",
 	"sp-session/std",
-	"sp-std/std",
 	"sp-transaction-pool/std",
 	"sp-trie/std",
 	"sp-version/std",

--- a/chains/orchestrator-paras/runtime/dancebox/src/lib.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/lib.rs
@@ -46,6 +46,8 @@ pub mod weights;
 mod tests;
 
 use {
+    alloc::collections::{btree_map::BTreeMap, btree_set::BTreeSet},
+    core::marker::PhantomData,
     cumulus_pallet_parachain_system::{
         RelayChainStateProof, RelayNumberMonotonicallyIncreases, RelaychainDataProvider,
         RelaychainStateProvider,
@@ -109,11 +111,6 @@ use {
         },
         transaction_validity::{TransactionSource, TransactionValidity},
         AccountId32, ApplyExtrinsicResult, Cow,
-    },
-    sp_std::{
-        collections::{btree_map::BTreeMap, btree_set::BTreeSet},
-        marker::PhantomData,
-        prelude::*,
     },
     sp_version::RuntimeVersion,
     tp_stream_payment_common::StreamId,
@@ -750,7 +747,7 @@ impl GetRandomnessForNextBlock<u32> for BabeGetRandomnessForNextBlock {
             {
                 // Return random_hash as a [u8; 32] instead of a Hash
                 let mut buf = [0u8; 32];
-                let len = sp_std::cmp::min(32, random_hash.as_ref().len());
+                let len = core::cmp::min(32, random_hash.as_ref().len());
                 buf[..len].copy_from_slice(&random_hash.as_ref()[..len]);
 
                 buf
@@ -2043,7 +2040,7 @@ impl_runtime_apis! {
             impl cumulus_pallet_session_benchmarking::Config for Runtime {}
 
             impl frame_system_benchmarking::Config for Runtime {
-                fn setup_set_code_requirements(code: &sp_std::vec::Vec<u8>) -> Result<(), BenchmarkError> {
+                fn setup_set_code_requirements(code: &alloc::vec::Vec<u8>) -> Result<(), BenchmarkError> {
                     ParachainSystem::initialize_for_set_code_benchmark(code.len() as u32);
                     Ok(())
                 }
@@ -2699,7 +2696,7 @@ impl cumulus_pallet_parachain_system::CheckInherents<Block> for CheckInherents {
         let inherent_data =
             cumulus_primitives_timestamp::InherentDataProvider::from_relay_chain_slot_and_duration(
                 relay_chain_slot,
-                sp_std::time::Duration::from_secs(6),
+                core::time::Duration::from_secs(6),
             )
             .create_inherent_data()
             .expect("Could not create the timestamp inherent data");

--- a/chains/orchestrator-paras/runtime/dancebox/src/lib.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/lib.rs
@@ -39,7 +39,12 @@ pub mod weights;
 mod tests;
 
 use {
-    alloc::collections::{btree_map::BTreeMap, btree_set::BTreeSet},
+    alloc::{
+        boxed::Box,
+        collections::{btree_map::BTreeMap, btree_set::BTreeSet},
+        vec,
+        vec::Vec,
+    },
     core::marker::PhantomData,
     cumulus_pallet_parachain_system::{
         RelayChainStateProof, RelayNumberMonotonicallyIncreases, RelaychainDataProvider,

--- a/chains/orchestrator-paras/runtime/dancebox/src/tests/common/mod.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/tests/common/mod.rs
@@ -16,6 +16,7 @@
 
 use {
     crate::{AuthorInherent, BlockProductionCost, CollatorAssignmentCost, RuntimeOrigin},
+    alloc::collections::btree_map::BTreeMap,
     cumulus_primitives_core::{ParaId, PersistedValidationData},
     cumulus_primitives_parachain_inherent::ParachainInherentData,
     dp_consensus::runtime_decl_for_tanssi_authority_assignment_api::TanssiAuthorityAssignmentApi,
@@ -33,7 +34,6 @@ use {
     sp_consensus_slots::Slot,
     sp_core::{Get, Pair},
     sp_runtime::{traits::Dispatchable, BuildStorage, Digest, DigestItem},
-    sp_std::collections::btree_map::BTreeMap,
     test_relay_sproof_builder::ParaHeaderSproofBuilder,
 };
 

--- a/chains/orchestrator-paras/runtime/dancebox/src/tests/inactivity_tracking.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/tests/inactivity_tracking.rs
@@ -17,6 +17,7 @@
 #![cfg(test)]
 use {
     crate::tests::common::*,
+    alloc::collections::btree_set::BTreeSet,
     frame_support::{assert_ok, BoundedBTreeSet},
     pallet_inactivity_tracking::pallet::{
         ActiveCollatorsForCurrentSession, ActiveContainerChainsForCurrentSession, InactiveCollators,
@@ -24,7 +25,6 @@ use {
     parity_scale_codec::Encode,
     sp_consensus_aura::AURA_ENGINE_ID,
     sp_runtime::{traits::BlakeTwo256, DigestItem},
-    sp_std::collections::btree_set::BTreeSet,
     test_relay_sproof_builder::{HeaderAs, ParaHeaderSproofBuilder, ParaHeaderSproofBuilderItem},
     tp_traits::{
         ForSession, GetContainerChainsWithCollators, MaybeSelfChainBlockAuthor,

--- a/chains/orchestrator-paras/runtime/dancebox/src/tests/integration_test.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/tests/integration_test.rs
@@ -18,6 +18,7 @@
 
 use {
     crate::{tests::common::*, RewardsCollatorCommission, StreamPayment, TransactionPayment},
+    alloc::vec,
     cumulus_primitives_core::ParaId,
     dp_consensus::runtime_decl_for_tanssi_authority_assignment_api::TanssiAuthorityAssignmentApiV1,
     dp_core::well_known_keys,
@@ -47,7 +48,6 @@ use {
         traits::{BadOrigin, BlakeTwo256, OpaqueKeys},
         DigestItem, FixedU128,
     },
-    sp_std::vec,
     tanssi_runtime_common::migrations::{
         HostConfigurationV3, MigrateConfigurationAddFullRotationMode,
         MigrateServicesPaymentAddCollatorAssignmentCredits, RegistrarPendingVerificationValueToMap,
@@ -5900,13 +5900,13 @@ fn test_migration_data_preservers_assignments() {
     ExtBuilder::default().build().execute_with(|| {
         use {
             crate::{MaxAssignmentsPerParaId, MaxNodeUrlLen},
+            alloc::collections::btree_set::BTreeSet,
             frame_support::{
                 migration::{have_storage_value, put_storage_value},
                 Blake2_128Concat, StorageHasher,
             },
             pallet_data_preservers::{ParaIdsFilter, Profile, ProfileMode, RegisteredProfile},
             sp_runtime::BoundedBTreeSet,
-            sp_std::collections::btree_set::BTreeSet,
             tanssi_runtime_common::migrations::DataPreserversAssignmentsMigration,
         };
 

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/cumulus_pallet_parachain_system.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/cumulus_pallet_parachain_system.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for cumulus_pallet_parachain_system using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/cumulus_pallet_weight_reclaim.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/cumulus_pallet_weight_reclaim.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for cumulus_pallet_weight_reclaim using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/cumulus_pallet_xcmp_queue.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/cumulus_pallet_xcmp_queue.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for cumulus_pallet_xcmp_queue using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/frame_system.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/frame_system.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for frame_system using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/frame_system_extensions.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/frame_system_extensions.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for frame_system_extensions using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_asset_rate.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_asset_rate.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_asset_rate using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_assets.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_assets.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_assets using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_author_inherent.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_author_inherent.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_author_inherent using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_author_noting.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_author_noting.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_author_noting using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_balances.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_balances.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_balances using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_collator_assignment.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_collator_assignment.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_collator_assignment using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_configuration.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_configuration.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_configuration using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_data_preservers.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_data_preservers.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_data_preservers using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_foreign_asset_creator.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_foreign_asset_creator.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_foreign_asset_creator using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_identity.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_identity.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_identity using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_inactivity_tracking.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_inactivity_tracking.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_inactivity_tracking using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_invulnerables.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_invulnerables.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_invulnerables using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_message_queue.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_message_queue.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_message_queue using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_multiblock_migrations.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_multiblock_migrations.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_multiblock_migrations using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_multisig.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_multisig.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_multisig using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_pooled_staking.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_pooled_staking.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_pooled_staking using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_proxy.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_proxy.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_proxy using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_registrar.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_registrar.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_registrar using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_relay_storage_roots.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_relay_storage_roots.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_relay_storage_roots using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_services_payment.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_services_payment.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_services_payment using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_session.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_session.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_session using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_stream_payment.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_stream_payment.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_stream_payment using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_sudo.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_sudo.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_sudo using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_timestamp.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_timestamp.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_timestamp using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_transaction_payment.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_transaction_payment.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_transaction_payment using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_treasury.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_treasury.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_treasury using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_tx_pause.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_tx_pause.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_tx_pause using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_utility.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_utility.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_utility using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_xcm.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_xcm.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_xcm using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_xcm_core_buyer.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/pallet_xcm_core_buyer.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_xcm_core_buyer using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/xcm/mod.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/xcm/mod.rs
@@ -19,6 +19,7 @@ pub mod pallet_xcm_benchmarks_generic;
 
 use {
     crate::Runtime,
+    alloc::vec::Vec,
     frame_support::{weights::Weight, BoundedVec},
     pallet_xcm_benchmarks_fungible::WeightInfo as XcmBalancesWeight,
     pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric,

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/xcm/mod.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/xcm/mod.rs
@@ -22,7 +22,6 @@ use {
     frame_support::{weights::Weight, BoundedVec},
     pallet_xcm_benchmarks_fungible::WeightInfo as XcmBalancesWeight,
     pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric,
-    sp_std::prelude::*,
     xcm::{
         latest::{prelude::*, AssetTransferFilter, Weight as XCMWeight},
         DoubleEncoded,

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/xcm/pallet_xcm_benchmarks_fungible.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/xcm/pallet_xcm_benchmarks_fungible.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_xcm_benchmarks::fungible using the Substrate node and recommended hardware.
 pub struct WeightInfo<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_xcm_benchmarks::generic using the Substrate node and recommended hardware.
 pub struct WeightInfo<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/dancebox/src/xcm_config.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/xcm_config.rs
@@ -15,14 +15,13 @@
 // along with Tanssi.  If not, see <http://www.gnu.org/licenses/>
 
 #[cfg(feature = "runtime-benchmarks")]
-use crate::{CollatorAssignment, Session, System};
-#[cfg(feature = "runtime-benchmarks")]
-use alloc::{collections::btree_map::BTreeMap, vec};
-#[cfg(feature = "runtime-benchmarks")]
-use pallet_session::ShouldEndSession;
-#[cfg(feature = "runtime-benchmarks")]
-use tp_traits::GetContainerChainAuthor;
-use xcm::latest::WESTEND_GENESIS_HASH;
+use {
+    crate::{CollatorAssignment, Session, System},
+    alloc::{collections::btree_map::BTreeMap, vec},
+    pallet_session::ShouldEndSession,
+    tp_traits::GetContainerChainAuthor,
+};
+
 use {
     super::{
         currency::MICRODANCE, weights::xcm::XcmWeight as XcmGenericWeights, AccountId,
@@ -56,6 +55,7 @@ use {
     tp_traits::ParathreadParams,
     tp_xcm_commons::NativeAssetReserve,
     xcm::latest::prelude::*,
+    xcm::latest::WESTEND_GENESIS_HASH,
     xcm_builder::{
         AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom,
         AllowTopLevelPaidExecutionFrom, ConvertedConcreteId, EnsureXcmOrigin, FungibleAdapter,

--- a/chains/orchestrator-paras/runtime/dancebox/src/xcm_config.rs
+++ b/chains/orchestrator-paras/runtime/dancebox/src/xcm_config.rs
@@ -17,9 +17,9 @@
 #[cfg(feature = "runtime-benchmarks")]
 use crate::{CollatorAssignment, Session, System};
 #[cfg(feature = "runtime-benchmarks")]
-use pallet_session::ShouldEndSession;
+use alloc::{collections::btree_map::BTreeMap, vec};
 #[cfg(feature = "runtime-benchmarks")]
-use sp_std::{collections::btree_map::BTreeMap, vec};
+use pallet_session::ShouldEndSession;
 #[cfg(feature = "runtime-benchmarks")]
 use tp_traits::GetContainerChainAuthor;
 use xcm::latest::WESTEND_GENESIS_HASH;
@@ -32,6 +32,7 @@ use {
         RuntimeOrigin, TransactionByteFee, WeightToFee, XcmpQueue,
     },
     crate::{get_para_id_authorities, weights, AuthorNoting},
+    alloc::vec::Vec,
     cumulus_primitives_core::{AggregateMessageOrigin, ParaId},
     frame_support::{
         parameter_types,
@@ -52,7 +53,6 @@ use {
     sp_consensus_slots::Slot,
     sp_core::{ConstU32, MaxEncodedLen},
     sp_runtime::{transaction_validity::TransactionPriority, Perbill},
-    sp_std::vec::Vec,
     tp_traits::ParathreadParams,
     tp_xcm_commons::NativeAssetReserve,
     xcm::latest::prelude::*,

--- a/chains/orchestrator-paras/runtime/flashbox/Cargo.toml
+++ b/chains/orchestrator-paras/runtime/flashbox/Cargo.toml
@@ -83,7 +83,6 @@ sp-inherents = { workspace = true }
 sp-offchain = { workspace = true }
 sp-runtime = { workspace = true }
 sp-session = { workspace = true }
-sp-std = { workspace = true }
 sp-transaction-pool = { workspace = true }
 sp-trie = { workspace = true }
 
@@ -213,7 +212,6 @@ std = [
 	"sp-offchain/std",
 	"sp-runtime/std",
 	"sp-session/std",
-	"sp-std/std",
 	"sp-transaction-pool/std",
 	"sp-trie/std",
 	"sp-version/std",

--- a/chains/orchestrator-paras/runtime/flashbox/src/lib.rs
+++ b/chains/orchestrator-paras/runtime/flashbox/src/lib.rs
@@ -46,6 +46,8 @@ pub mod weights;
 mod tests;
 
 use {
+    alloc::collections::{btree_map::BTreeMap, btree_set::BTreeSet},
+    core::marker::PhantomData,
     cumulus_pallet_parachain_system::RelayNumberMonotonicallyIncreases,
     cumulus_primitives_core::{relay_chain::SessionIndex, BodyId, ParaId},
     frame_support::{
@@ -96,11 +98,6 @@ use {
         },
         transaction_validity::{TransactionSource, TransactionValidity},
         AccountId32, ApplyExtrinsicResult, Cow,
-    },
-    sp_std::{
-        collections::{btree_map::BTreeMap, btree_set::BTreeSet},
-        marker::PhantomData,
-        prelude::*,
     },
     sp_version::RuntimeVersion,
     tp_stream_payment_common::StreamId,
@@ -1697,7 +1694,7 @@ impl_runtime_apis! {
             use sp_core::storage::TrackedStorageKey;
 
             impl frame_system_benchmarking::Config for Runtime {
-                fn setup_set_code_requirements(code: &sp_std::vec::Vec<u8>) -> Result<(), BenchmarkError> {
+                fn setup_set_code_requirements(code: &alloc::vec::Vec<u8>) -> Result<(), BenchmarkError> {
                     ParachainSystem::initialize_for_set_code_benchmark(code.len() as u32);
                     Ok(())
                 }
@@ -2059,7 +2056,7 @@ impl cumulus_pallet_parachain_system::CheckInherents<Block> for CheckInherents {
         let inherent_data =
             cumulus_primitives_timestamp::InherentDataProvider::from_relay_chain_slot_and_duration(
                 relay_chain_slot,
-                sp_std::time::Duration::from_secs(6),
+                core::time::Duration::from_secs(6),
             )
             .create_inherent_data()
             .expect("Could not create the timestamp inherent data");

--- a/chains/orchestrator-paras/runtime/flashbox/src/lib.rs
+++ b/chains/orchestrator-paras/runtime/flashbox/src/lib.rs
@@ -46,7 +46,11 @@ pub mod weights;
 mod tests;
 
 use {
-    alloc::collections::{btree_map::BTreeMap, btree_set::BTreeSet},
+    alloc::{
+        collections::{btree_map::BTreeMap, btree_set::BTreeSet},
+        vec,
+        vec::Vec,
+    },
     core::marker::PhantomData,
     cumulus_pallet_parachain_system::RelayNumberMonotonicallyIncreases,
     cumulus_primitives_core::{relay_chain::SessionIndex, BodyId, ParaId},

--- a/chains/orchestrator-paras/runtime/flashbox/src/tests/common/mod.rs
+++ b/chains/orchestrator-paras/runtime/flashbox/src/tests/common/mod.rs
@@ -16,6 +16,7 @@
 
 use {
     crate::{AuthorInherent, BlockProductionCost, CollatorAssignmentCost},
+    alloc::collections::btree_map::BTreeMap,
     cumulus_primitives_core::{ParaId, PersistedValidationData},
     cumulus_primitives_parachain_inherent::ParachainInherentData,
     dp_consensus::runtime_decl_for_tanssi_authority_assignment_api::TanssiAuthorityAssignmentApi,
@@ -33,7 +34,6 @@ use {
     sp_consensus_slots::Slot,
     sp_core::{Get, Pair},
     sp_runtime::{traits::Dispatchable, BuildStorage, Digest, DigestItem},
-    sp_std::collections::btree_map::BTreeMap,
     test_relay_sproof_builder::ParaHeaderSproofBuilder,
 };
 

--- a/chains/orchestrator-paras/runtime/flashbox/src/tests/integration_test.rs
+++ b/chains/orchestrator-paras/runtime/flashbox/src/tests/integration_test.rs
@@ -18,6 +18,7 @@
 
 use {
     crate::{tests::common::*, RuntimeOrigin},
+    alloc::vec,
     cumulus_primitives_core::{ParaId, Weight},
     dp_consensus::runtime_decl_for_tanssi_authority_assignment_api::TanssiAuthorityAssignmentApiV1,
     dp_core::well_known_keys,
@@ -38,7 +39,6 @@ use {
         traits::{BadOrigin, BlakeTwo256, Dispatchable, OpaqueKeys},
         DigestItem,
     },
-    sp_std::vec,
     tanssi_runtime_common::migrations::MigrateServicesPaymentAddCollatorAssignmentCredits,
     test_relay_sproof_builder::{HeaderAs, ParaHeaderSproofBuilder, ParaHeaderSproofBuilderItem},
     tp_stream_payment_common::{
@@ -3912,13 +3912,13 @@ fn test_migration_data_preservers_assignments() {
     ExtBuilder::default().build().execute_with(|| {
         use {
             crate::{MaxAssignmentsPerParaId, MaxNodeUrlLen},
+            alloc::collections::btree_set::BTreeSet,
             frame_support::{
                 migration::{have_storage_value, put_storage_value},
                 Blake2_128Concat, StorageHasher,
             },
             pallet_data_preservers::{ParaIdsFilter, Profile, ProfileMode, RegisteredProfile},
             sp_runtime::BoundedBTreeSet,
-            sp_std::collections::btree_set::BTreeSet,
             tanssi_runtime_common::migrations::DataPreserversAssignmentsMigration,
         };
 

--- a/chains/orchestrator-paras/runtime/flashbox/src/weights/cumulus_pallet_parachain_system.rs
+++ b/chains/orchestrator-paras/runtime/flashbox/src/weights/cumulus_pallet_parachain_system.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for cumulus_pallet_parachain_system using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/flashbox/src/weights/cumulus_pallet_weight_reclaim.rs
+++ b/chains/orchestrator-paras/runtime/flashbox/src/weights/cumulus_pallet_weight_reclaim.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for cumulus_pallet_weight_reclaim using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/flashbox/src/weights/frame_system.rs
+++ b/chains/orchestrator-paras/runtime/flashbox/src/weights/frame_system.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for frame_system using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/flashbox/src/weights/frame_system_extensions.rs
+++ b/chains/orchestrator-paras/runtime/flashbox/src/weights/frame_system_extensions.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for frame_system_extensions using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_author_inherent.rs
+++ b/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_author_inherent.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_author_inherent using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_author_noting.rs
+++ b/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_author_noting.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_author_noting using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_balances.rs
+++ b/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_balances.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_balances using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_collator_assignment.rs
+++ b/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_collator_assignment.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_collator_assignment using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_configuration.rs
+++ b/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_configuration.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_configuration using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_data_preservers.rs
+++ b/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_data_preservers.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_data_preservers using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_identity.rs
+++ b/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_identity.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_identity using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_invulnerables.rs
+++ b/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_invulnerables.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_invulnerables using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_multiblock_migrations.rs
+++ b/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_multiblock_migrations.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_multiblock_migrations using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_multisig.rs
+++ b/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_multisig.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_multisig using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_proxy.rs
+++ b/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_proxy.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_proxy using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_registrar.rs
+++ b/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_registrar.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_registrar using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_relay_storage_roots.rs
+++ b/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_relay_storage_roots.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_relay_storage_roots using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_services_payment.rs
+++ b/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_services_payment.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_services_payment using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_session.rs
+++ b/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_session.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_session using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_stream_payment.rs
+++ b/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_stream_payment.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_stream_payment using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_sudo.rs
+++ b/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_sudo.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_sudo using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_timestamp.rs
+++ b/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_timestamp.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_timestamp using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_transaction_payment.rs
+++ b/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_transaction_payment.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_transaction_payment using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_treasury.rs
+++ b/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_treasury.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_treasury using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_tx_pause.rs
+++ b/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_tx_pause.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_tx_pause using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_utility.rs
+++ b/chains/orchestrator-paras/runtime/flashbox/src/weights/pallet_utility.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_utility using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/Cargo.toml
+++ b/chains/orchestrator-relays/runtime/dancelight/Cargo.toml
@@ -45,7 +45,6 @@ sp-mmr-primitives = { workspace = true }
 sp-runtime = { workspace = true }
 sp-session = { workspace = true }
 sp-staking = { workspace = true }
-sp-std = { workspace = true }
 sp-storage = { workspace = true }
 sp-trie = { workspace = true }
 sp-version = { workspace = true }
@@ -340,7 +339,6 @@ std = [
 	"sp-runtime/std",
 	"sp-session/std",
 	"sp-staking/std",
-	"sp-std/std",
 	"sp-storage/std",
 	"sp-tracing/std",
 	"sp-trie/std",

--- a/chains/orchestrator-relays/runtime/dancelight/src/bridge_to_ethereum_config.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/bridge_to_ethereum_config.rs
@@ -34,6 +34,8 @@ use {
         OutboundMessageCommitmentRecorder, Runtime, RuntimeEvent, SnowbridgeFeesAccount,
         TokenLocationReanchored, TransactionByteFee, TreasuryAccount, WeightToFee, UNITS,
     },
+    alloc::vec,
+    core::marker::PhantomData,
     frame_support::{
         dispatch::DispatchClass,
         traits::{
@@ -54,7 +56,6 @@ use {
     snowbridge_pallet_outbound_queue::OnNewCommitment,
     sp_core::{ConstU32, ConstU8, Get, H160, H256},
     sp_runtime::{traits::Zero, DispatchError, DispatchResult},
-    sp_std::{marker::PhantomData, vec},
     tanssi_runtime_common::processors::NativeTokenTransferMessageProcessor,
     tp_bridge::{DoNothingConvertMessage, DoNothingRouter, EthereumSystemHandler},
     xcm::latest::{
@@ -411,7 +412,7 @@ mod test_helpers {
 
 /// Rewards the relayer that processed a native token transfer message
 /// using the FeesAccount configured in pallet_ethereum_token_transfers
-pub struct RewardThroughFeesAccount<T>(sp_std::marker::PhantomData<T>);
+pub struct RewardThroughFeesAccount<T>(core::marker::PhantomData<T>);
 
 impl<T> RewardProcessor<T> for RewardThroughFeesAccount<T>
 where

--- a/chains/orchestrator-relays/runtime/dancelight/src/genesis_config_presets.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/genesis_config_presets.rs
@@ -18,7 +18,7 @@
 
 use {
     crate::{SessionKeys, BABE_GENESIS_EPOCH_CONFIG},
-    alloc::vec::Vec,
+    alloc::{format, vec::Vec},
     authority_discovery_primitives::AuthorityId as AuthorityDiscoveryId,
     babe_primitives::AuthorityId as BabeId,
     beefy_primitives::ecdsa_crypto::AuthorityId as BeefyId,

--- a/chains/orchestrator-relays/runtime/dancelight/src/genesis_config_presets.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/genesis_config_presets.rs
@@ -16,13 +16,13 @@
 
 //! Genesis configs presets for the Dancelight runtime
 
-#[cfg(not(feature = "std"))]
-use sp_std::alloc::format;
 use {
     crate::{SessionKeys, BABE_GENESIS_EPOCH_CONFIG},
+    alloc::vec::Vec,
     authority_discovery_primitives::AuthorityId as AuthorityDiscoveryId,
     babe_primitives::AuthorityId as BabeId,
     beefy_primitives::ecdsa_crypto::AuthorityId as BeefyId,
+    core::cmp::max,
     cumulus_primitives_core::relay_chain::{
         SchedulerParams, ASSIGNMENT_KEY_TYPE_ID, PARACHAIN_KEY_TYPE_ID,
     },
@@ -40,7 +40,6 @@ use {
     },
     sp_keystore::{Keystore, KeystorePtr},
     sp_runtime::traits::AccountIdConversion,
-    sp_std::{cmp::max, vec::Vec},
     tp_traits::ParaId,
 };
 
@@ -48,7 +47,7 @@ use keyring::Sr25519Keyring;
 
 // import macro, separate due to rustfmt thinking it's the module with the
 // same name ^^'
-use sp_std::vec;
+use alloc::vec;
 
 use sp_core::crypto::{get_public_from_string_or_panic, AccountId32};
 
@@ -727,7 +726,7 @@ pub fn dancelight_local_testnet_genesis(
 }
 
 /// Provides the JSON representation of predefined genesis config for given `id`.
-pub fn get_preset(id: &sp_genesis_builder::PresetId) -> Option<sp_std::vec::Vec<u8>> {
+pub fn get_preset(id: &sp_genesis_builder::PresetId) -> Option<alloc::vec::Vec<u8>> {
     let patch = match id.as_ref() {
         "local_testnet" => dancelight_local_testnet_genesis(vec![], vec![]),
         "development" => dancelight_development_config_genesis(vec![], vec![]),

--- a/chains/orchestrator-relays/runtime/dancelight/src/lib.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/lib.rs
@@ -3122,6 +3122,7 @@ sp_api::impl_runtime_apis! {
             use xcm_config::{
                 AssetHub, LocalCheckAccount, LocationConverter, TokenLocation, XcmConfig,
             };
+            use alloc::boxed::Box;
 
             parameter_types! {
                 pub ExistentialDepositAsset: Option<Asset> = Some((

--- a/chains/orchestrator-relays/runtime/dancelight/src/lib.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/lib.rs
@@ -26,7 +26,11 @@ extern crate alloc;
 use sp_version::NativeVersion;
 
 use {
-    alloc::collections::{btree_map::BTreeMap, btree_set::BTreeSet, vec_deque::VecDeque},
+    alloc::{
+        collections::{btree_map::BTreeMap, btree_set::BTreeSet, vec_deque::VecDeque},
+        vec,
+        vec::Vec,
+    },
     authority_discovery_primitives::AuthorityId as AuthorityDiscoveryId,
     beefy_primitives::{
         ecdsa_crypto::{AuthorityId as BeefyId, Signature as BeefySignature},

--- a/chains/orchestrator-relays/runtime/dancelight/src/lib.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/lib.rs
@@ -25,11 +25,13 @@ extern crate alloc;
 use frame_support::storage::{with_storage_layer, with_transaction};
 // Fix compile error in impl_runtime_weights! macro
 use {
+    alloc::collections::{btree_map::BTreeMap, btree_set::BTreeSet, vec_deque::VecDeque},
     authority_discovery_primitives::AuthorityId as AuthorityDiscoveryId,
     beefy_primitives::{
         ecdsa_crypto::{AuthorityId as BeefyId, Signature as BeefySignature},
         mmr::{BeefyDataProvider, MmrLeafVersion},
     },
+    core::{cmp::Ordering, marker::PhantomData},
     cumulus_primitives_core::relay_chain::{HeadData, ValidationCode},
     dp_container_chain_genesis_data::ContainerChainGenesisDataItem,
     frame_support::{
@@ -90,12 +92,6 @@ use {
         AccountId32,
     },
     sp_staking::offence::OffenceSeverity,
-    sp_std::{
-        cmp::Ordering,
-        collections::{btree_map::BTreeMap, btree_set::BTreeSet, vec_deque::VecDeque},
-        marker::PhantomData,
-        prelude::*,
-    },
     tp_bridge::ConvertLocation,
     tp_traits::{
         prod_or_fast_parameter_types, EraIndex, GetHostConfiguration, GetSessionContainerChains,
@@ -2494,7 +2490,7 @@ sp_api::impl_runtime_apis! {
             Runtime::metadata_at_version(version)
         }
 
-        fn metadata_versions() -> sp_std::vec::Vec<u32> {
+        fn metadata_versions() -> alloc::vec::Vec<u32> {
             Runtime::metadata_versions()
         }
     }
@@ -3570,7 +3566,7 @@ impl Get<[u8; 32]> for BabeGetCollatorAssignmentRandomness {
             } {
                 // Return random_hash as a [u8; 32] instead of a Hash
                 let mut buf = [0u8; 32];
-                let len = sp_std::cmp::min(32, random_hash.as_ref().len());
+                let len = core::cmp::min(32, random_hash.as_ref().len());
                 buf[..len].copy_from_slice(&random_hash.as_ref()[..len]);
 
                 buf

--- a/chains/orchestrator-relays/runtime/dancelight/src/tests/author_noting_tests.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/tests/author_noting_tests.rs
@@ -18,12 +18,12 @@
 
 use {
     crate::tests::common::*,
+    alloc::vec,
     frame_support::{assert_noop, assert_ok, error::BadOrigin},
     pallet_author_noting_runtime_api::runtime_decl_for_author_noting_api::AuthorNotingApi,
     parity_scale_codec::Encode,
     sp_consensus_aura::AURA_ENGINE_ID,
     sp_runtime::{generic::DigestItem, traits::BlakeTwo256},
-    sp_std::vec,
     test_relay_sproof_builder::{HeaderAs, ParaHeaderSproofBuilder, ParaHeaderSproofBuilderItem},
     tp_traits::{ContainerChainBlockInfo, ParaId},
 };

--- a/chains/orchestrator-relays/runtime/dancelight/src/tests/beefy.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/tests/beefy.rs
@@ -18,6 +18,7 @@
 
 use {
     crate::{tests::common::*, Beefy, Historical},
+    alloc::vec,
     beefy_primitives::{
         check_double_voting_proof,
         ecdsa_crypto::{
@@ -34,7 +35,6 @@ use {
     parity_scale_codec::{Decode, Encode},
     sp_application_crypto::{AppCrypto, Pair, RuntimeAppPublic},
     sp_runtime::{traits::Keccak256, DigestItem},
-    sp_std::vec,
 };
 
 /// Create a new `VoteMessage` from commitment primitives and key pair.

--- a/chains/orchestrator-relays/runtime/dancelight/src/tests/collator_assignment_tests.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/tests/collator_assignment_tests.rs
@@ -22,6 +22,7 @@ use {
         Configuration, ContainerRegistrar, GetCoreAllocationConfigurationImpl, Paras, Registrar,
         RuntimeEvent, ServicesPayment, TanssiAuthorityMapping, TanssiInvulnerables,
     },
+    alloc::vec,
     cumulus_primitives_core::{
         relay_chain::{HeadData, SchedulerParams},
         ParaId,
@@ -32,7 +33,6 @@ use {
     sp_consensus_aura::AURA_ENGINE_ID,
     sp_core::Get,
     sp_runtime::{traits::BlakeTwo256, DigestItem},
-    sp_std::vec,
     test_relay_sproof_builder::{HeaderAs, ParaHeaderSproofBuilder, ParaHeaderSproofBuilderItem},
 };
 

--- a/chains/orchestrator-relays/runtime/dancelight/src/tests/common/mod.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/tests/common/mod.rs
@@ -21,6 +21,7 @@ use {
         Authorship, BlockProductionCost, CollatorAssignmentCost, ExternalValidatorSlashes,
         MessageQueue, RuntimeCall,
     },
+    alloc::collections::btree_map::BTreeMap,
     babe_primitives::{
         digests::{PreDigest, SecondaryPlainPreDigest},
         BABE_ENGINE_ID,
@@ -61,7 +62,6 @@ use {
         traits::{Dispatchable, Header, One, SaturatedConversion, Zero},
         BuildStorage, Digest, DigestItem,
     },
-    sp_std::collections::btree_map::BTreeMap,
     sp_storage::well_known_keys,
     std::collections::BTreeSet,
     test_relay_sproof_builder::ParaHeaderSproofBuilder,

--- a/chains/orchestrator-relays/runtime/dancelight/src/tests/core_scheduling_tests.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/tests/core_scheduling_tests.rs
@@ -20,6 +20,7 @@ use {
     crate::{
         tests::common::*, ContainerRegistrar, OnDemandAssignmentProvider, Paras, Registrar, Session,
     },
+    alloc::{collections::btree_map::BTreeMap, vec},
     cumulus_primitives_core::relay_chain::{
         AsyncBackingParams, CoreIndex, HeadData, SchedulerParams,
     },
@@ -32,7 +33,6 @@ use {
     runtime_parachains::scheduler::common::Assignment,
     sp_core::{Decode, Encode},
     sp_keystore::testing::MemoryKeystore,
-    sp_std::{collections::btree_map::BTreeMap, vec},
     std::sync::Arc,
     tp_traits::SlotFrequency,
 };

--- a/chains/orchestrator-relays/runtime/dancelight/src/tests/ethereum_client.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/tests/ethereum_client.rs
@@ -18,10 +18,10 @@
 
 use {
     crate::{tests::common::*, EthereumBeaconClient},
+    alloc::vec,
     frame_support::{assert_noop, assert_ok},
     snowbridge_pallet_ethereum_client::{functions::*, mock_electra::*},
     sp_core::H256,
-    sp_std::vec,
 };
 #[test]
 fn test_ethereum_force_checkpoint() {

--- a/chains/orchestrator-relays/runtime/dancelight/src/tests/ethereum_token_transfers.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/tests/ethereum_token_transfers.rs
@@ -23,6 +23,7 @@ use {
         EthereumTokenTransfers, ForeignAssets, ForeignAssetsCreator, RuntimeEvent,
         SnowbridgeFeesAccount, TokenLocationReanchored, XcmPallet,
     },
+    alloc::vec,
     alloy_sol_types::SolEvent,
     dancelight_runtime_constants::snowbridge::EthereumNetwork,
     frame_support::{
@@ -39,7 +40,6 @@ use {
     snowbridge_inbound_queue_primitives::{EventProof, Log},
     sp_core::{H160, H256},
     sp_runtime::{traits::MaybeEquivalence, FixedU128, TokenError},
-    sp_std::vec,
     tanssi_runtime_common::processors::NativeTokenTransferMessageProcessor,
     xcm::{
         latest::{prelude::*, Junctions::*, Location},

--- a/chains/orchestrator-relays/runtime/dancelight/src/tests/inflation_rewards.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/tests/inflation_rewards.rs
@@ -18,11 +18,11 @@
 
 use {
     crate::{tests::common::*, AuthorNoting, RewardsPortion},
+    alloc::vec,
     cumulus_primitives_core::ParaId,
     parity_scale_codec::Encode,
     sp_consensus_aura::AURA_ENGINE_ID,
     sp_runtime::{generic::DigestItem, traits::BlakeTwo256},
-    sp_std::vec,
     test_relay_sproof_builder::{HeaderAs, ParaHeaderSproofBuilder, ParaHeaderSproofBuilderItem},
     tp_traits::ContainerChainBlockInfo,
 };

--- a/chains/orchestrator-relays/runtime/dancelight/src/tests/integration_test.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/tests/integration_test.rs
@@ -22,6 +22,7 @@ use {
         tests::common::*, Balances, CollatorConfiguration, ContainerRegistrar, DataPreservers,
         ForeignAssetsCreator, Registrar, RuntimeEvent, StreamPayment,
     },
+    alloc::vec,
     cumulus_primitives_core::{relay_chain::HeadData, ParaId},
     dancelight_runtime_constants::currency::EXISTENTIAL_DEPOSIT,
     frame_support::{assert_err, assert_noop, assert_ok, BoundedVec},
@@ -30,7 +31,6 @@ use {
         runtime_decl_for_registrar_api::RegistrarApi, ContainerChainGenesisData,
     },
     pallet_stream_payment::StreamConfig,
-    sp_std::vec,
     tp_stream_payment_common::{
         AssetId as StreamPaymentAssetId, TimeUnit as StreamPaymentTimeUnit,
     },

--- a/chains/orchestrator-relays/runtime/dancelight/src/tests/relay_registrar.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/tests/relay_registrar.rs
@@ -20,6 +20,7 @@ use {
     crate::{
         tests::common::*, ContainerRegistrar, Paras, Registrar, RuntimeCall, SlotFrequency, System,
     },
+    alloc::vec,
     cumulus_primitives_core::relay_chain::HeadData,
     frame_support::{assert_noop, assert_ok, BoundedVec},
     pallet_registrar::Event as ContainerRegistrarEvent,
@@ -29,7 +30,6 @@ use {
     runtime_common::paras_registrar,
     runtime_parachains::configuration as parachains_configuration,
     sp_runtime::traits::Dispatchable,
-    sp_std::vec,
     tp_traits::ParaId,
 };
 

--- a/chains/orchestrator-relays/runtime/dancelight/src/tests/services_payment.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/tests/services_payment.rs
@@ -18,10 +18,10 @@
 
 use {
     crate::{tests::common::*, ContainerRegistrar, Paras, Registrar, ServicesPayment},
+    alloc::vec,
     cumulus_primitives_core::{relay_chain::HeadData, ParaId},
     frame_support::{assert_noop, assert_ok, pallet_prelude::DispatchResultWithPostInfo},
     sp_runtime::DispatchError,
-    sp_std::vec,
 };
 
 #[test]

--- a/chains/orchestrator-relays/runtime/dancelight/src/tests/session_keys.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/tests/session_keys.rs
@@ -16,7 +16,7 @@
 
 #![cfg(test)]
 
-use {crate::tests::common::*, frame_support::assert_ok, sp_std::vec};
+use {crate::tests::common::*, alloc::vec, frame_support::assert_ok};
 
 #[test]
 fn session_key_changes_are_reflected_after_two_sessions() {

--- a/chains/orchestrator-relays/runtime/dancelight/src/tests/slashes.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/tests/slashes.rs
@@ -19,11 +19,11 @@ use {
         tests::common::*, BondingDuration, EthereumSystem, ExternalValidatorSlashes,
         ExternalValidators, Grandpa, Historical, RuntimeEvent, SessionsPerEra, SlashDeferDuration,
     },
+    alloc::vec,
     frame_support::{assert_noop, assert_ok, traits::KeyOwnerProofSystem},
     parity_scale_codec::Encode,
     sp_core::{Pair, H256},
     sp_runtime::Perbill,
-    sp_std::vec,
     tp_bridge::Command,
     xcm::{latest::prelude::*, VersionedLocation},
 };

--- a/chains/orchestrator-relays/runtime/dancelight/src/tests/staking.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/tests/staking.rs
@@ -18,12 +18,12 @@
 
 use {
     crate::{tests::common::*, MinimumSelfDelegation, PooledStaking},
+    alloc::vec,
     frame_support::{assert_noop, assert_ok, error::BadOrigin},
     pallet_pooled_staking::{
         traits::IsCandidateEligible, ActivePoolKind, EligibleCandidate, PendingOperationKey,
         PendingOperationQuery, PoolKind, PoolsKey, SharesOrStake,
     },
-    sp_std::vec,
 };
 
 #[test]

--- a/chains/orchestrator-relays/runtime/dancelight/src/tests/sudo.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/tests/sudo.rs
@@ -18,8 +18,8 @@
 
 use {
     crate::{tests::common::*, Sudo},
+    alloc::vec,
     frame_support::{assert_noop, assert_ok},
-    sp_std::vec,
 };
 
 #[test]

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/frame_benchmarking::baseline.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/frame_benchmarking::baseline.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for frame_benchmarking::baseline using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/frame_system.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/frame_system.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for frame_system using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/frame_system_extensions.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/frame_system_extensions.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for frame_system_extensions using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_asset_rate.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_asset_rate.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_asset_rate using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_assets.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_assets.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_assets using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_author_noting.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_author_noting.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_author_noting using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_balances.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_balances.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_balances using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_beefy_mmr.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_beefy_mmr.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_beefy_mmr using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_collator_assignment.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_collator_assignment.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_collator_assignment using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_configuration.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_configuration.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_configuration using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_conviction_voting.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_conviction_voting.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_conviction_voting using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_data_preservers.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_data_preservers.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_data_preservers using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_ethereum_token_transfers.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_ethereum_token_transfers.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_ethereum_token_transfers using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_external_validator_slashes.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_external_validator_slashes.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_external_validator_slashes using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_external_validators.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_external_validators.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_external_validators using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_external_validators_rewards.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_external_validators_rewards.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_external_validators_rewards using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_foreign_asset_creator.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_foreign_asset_creator.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_foreign_asset_creator using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_identity.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_identity.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_identity using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_inactivity_tracking.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_inactivity_tracking.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_inactivity_tracking using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_invulnerables.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_invulnerables.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_invulnerables using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_message_queue.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_message_queue.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_message_queue using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_mmr.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_mmr.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_mmr using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_multiblock_migrations.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_multiblock_migrations.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_multiblock_migrations using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_multisig.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_multisig.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_multisig using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_parameters.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_parameters.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_parameters using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_pooled_staking.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_pooled_staking.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_pooled_staking using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_preimage.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_preimage.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_preimage using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_proxy.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_proxy.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_proxy using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_ranked_collective.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_ranked_collective.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_ranked_collective using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_referenda.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_referenda.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_referenda using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_registrar.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_registrar.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_registrar using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_scheduler.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_scheduler.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_scheduler using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_services_payment.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_services_payment.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_services_payment using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_session.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_session.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_session using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_stream_payment.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_stream_payment.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_stream_payment using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_sudo.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_sudo.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_sudo using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_timestamp.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_timestamp.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_timestamp using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_transaction_payment.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_transaction_payment.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_transaction_payment using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_treasury.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_treasury.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_treasury using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_utility.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_utility.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_utility using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_whitelist.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_whitelist.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_whitelist using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_xcm.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/pallet_xcm.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_xcm using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/runtime_common_paras_registrar.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/runtime_common_paras_registrar.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for runtime_common::paras_registrar using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/runtime_parachains_assigner_on_demand.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/runtime_parachains_assigner_on_demand.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for runtime_parachains::assigner_on_demand using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/runtime_parachains_configuration.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/runtime_parachains_configuration.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for runtime_parachains::configuration using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/runtime_parachains_disputes.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/runtime_parachains_disputes.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for runtime_parachains::disputes using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/runtime_parachains_disputes::slashing.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/runtime_parachains_disputes::slashing.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for runtime_parachains::disputes::slashing using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/runtime_parachains_disputes_slashing.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/runtime_parachains_disputes_slashing.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 use runtime_parachains::initializer::ValidatorSetCount;
 
 /// Weights for runtime_parachains::disputes::slashing using the Substrate node and recommended hardware.

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/runtime_parachains_hrmp.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/runtime_parachains_hrmp.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for runtime_parachains::hrmp using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/runtime_parachains_inclusion.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/runtime_parachains_inclusion.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for runtime_parachains::inclusion using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/runtime_parachains_initializer.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/runtime_parachains_initializer.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for runtime_parachains::initializer using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/runtime_parachains_paras.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/runtime_parachains_paras.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for runtime_parachains::paras using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/runtime_parachains_paras_inherent.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/runtime_parachains_paras_inherent.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for runtime_parachains::paras_inherent using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/snowbridge_pallet_ethereum_client.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/snowbridge_pallet_ethereum_client.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for snowbridge_pallet_ethereum_client using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/snowbridge_pallet_inbound_queue.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/snowbridge_pallet_inbound_queue.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for snowbridge_pallet_inbound_queue using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/snowbridge_pallet_outbound_queue.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/snowbridge_pallet_outbound_queue.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for snowbridge_pallet_outbound_queue using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/snowbridge_pallet_system.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/snowbridge_pallet_system.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for snowbridge_pallet_system using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/xcm/mod.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/xcm/mod.rs
@@ -23,7 +23,6 @@ use {
     frame_support::weights::Weight,
     pallet_xcm_benchmarks_fungible::WeightInfo as XcmBalancesWeight,
     pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric,
-    sp_std::prelude::*,
     xcm::{
         latest::{prelude::*, AssetTransferFilter, Weight as XCMWeight},
         DoubleEncoded,

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/xcm/mod.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/xcm/mod.rs
@@ -17,10 +17,11 @@
 mod pallet_xcm_benchmarks_fungible;
 mod pallet_xcm_benchmarks_generic;
 
-use frame_support::BoundedVec;
 use {
     crate::Runtime,
+    alloc::vec::Vec,
     frame_support::weights::Weight,
+    frame_support::BoundedVec,
     pallet_xcm_benchmarks_fungible::WeightInfo as XcmBalancesWeight,
     pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric,
     xcm::{

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/xcm/pallet_xcm_benchmarks_fungible.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/xcm/pallet_xcm_benchmarks_fungible.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_xcm_benchmarks::fungible using the Substrate node and recommended hardware.
 pub struct WeightInfo<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/dancelight/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_xcm_benchmarks::generic using the Substrate node and recommended hardware.
 pub struct WeightInfo<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/Cargo.toml
+++ b/chains/orchestrator-relays/runtime/starlight/Cargo.toml
@@ -44,7 +44,6 @@ sp-mmr-primitives = { workspace = true }
 sp-runtime = { workspace = true }
 sp-session = { workspace = true }
 sp-staking = { workspace = true }
-sp-std = { workspace = true }
 sp-storage = { workspace = true }
 sp-trie = { workspace = true }
 sp-version = { workspace = true }
@@ -331,7 +330,6 @@ std = [
 	"sp-runtime/std",
 	"sp-session/std",
 	"sp-staking/std",
-	"sp-std/std",
 	"sp-storage/std",
 	"sp-tracing/std",
 	"sp-trie/std",

--- a/chains/orchestrator-relays/runtime/starlight/src/bridge_to_ethereum_config.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/bridge_to_ethereum_config.rs
@@ -216,7 +216,7 @@ mod test_helpers {
 
 /// Rewards the relayer that processed a native token transfer message
 /// using the FeesAccount configured in pallet_ethereum_token_transfers
-pub struct RewardThroughFeesAccount<T>(sp_std::marker::PhantomData<T>);
+pub struct RewardThroughFeesAccount<T>(core::marker::PhantomData<T>);
 
 impl<T> RewardProcessor<T> for RewardThroughFeesAccount<T>
 where

--- a/chains/orchestrator-relays/runtime/starlight/src/genesis_config_presets.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/genesis_config_presets.rs
@@ -16,13 +16,13 @@
 
 //! Genesis configs presets for the Starlight runtime
 
-#[cfg(not(feature = "std"))]
-use sp_std::alloc::format;
 use {
     crate::{SessionKeys, BABE_GENESIS_EPOCH_CONFIG},
+    alloc::vec::Vec,
     authority_discovery_primitives::AuthorityId as AuthorityDiscoveryId,
     babe_primitives::AuthorityId as BabeId,
     beefy_primitives::ecdsa_crypto::AuthorityId as BeefyId,
+    core::cmp::max,
     cumulus_primitives_core::relay_chain::{
         SchedulerParams, ASSIGNMENT_KEY_TYPE_ID, PARACHAIN_KEY_TYPE_ID,
     },
@@ -39,7 +39,6 @@ use {
     },
     sp_keystore::{Keystore, KeystorePtr},
     sp_runtime::traits::AccountIdConversion,
-    sp_std::{cmp::max, vec::Vec},
     starlight_runtime_constants::currency::UNITS as STAR,
     tp_traits::ParaId,
 };
@@ -48,7 +47,7 @@ use keyring::Sr25519Keyring;
 
 // import macro, separate due to rustfmt thinking it's the module with the
 // same name ^^'
-use sp_std::vec;
+use alloc::vec;
 
 use sp_core::crypto::{get_public_from_string_or_panic, AccountId32};
 
@@ -723,7 +722,7 @@ pub fn starlight_local_testnet_genesis(
 }
 
 /// Provides the JSON representation of predefined genesis config for given `id`.
-pub fn get_preset(id: &sp_genesis_builder::PresetId) -> Option<sp_std::vec::Vec<u8>> {
+pub fn get_preset(id: &sp_genesis_builder::PresetId) -> Option<alloc::vec::Vec<u8>> {
     let patch = match id.as_ref() {
         "local_testnet" => starlight_local_testnet_genesis(vec![], vec![]),
         "development" => starlight_development_config_genesis(vec![], vec![]),

--- a/chains/orchestrator-relays/runtime/starlight/src/genesis_config_presets.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/genesis_config_presets.rs
@@ -18,7 +18,7 @@
 
 use {
     crate::{SessionKeys, BABE_GENESIS_EPOCH_CONFIG},
-    alloc::vec::Vec,
+    alloc::{format, vec, vec::Vec},
     authority_discovery_primitives::AuthorityId as AuthorityDiscoveryId,
     babe_primitives::AuthorityId as BabeId,
     beefy_primitives::ecdsa_crypto::AuthorityId as BeefyId,
@@ -28,13 +28,14 @@ use {
     },
     dp_container_chain_genesis_data::ContainerChainGenesisData,
     grandpa_primitives::AuthorityId as GrandpaId,
+    keyring::Sr25519Keyring,
     nimbus_primitives::NimbusId,
     pallet_configuration::HostConfiguration,
     primitives::{AccountId, AssignmentId, ValidatorId},
     scale_info::prelude::string::String,
     sp_arithmetic::{traits::Saturating, Perbill},
     sp_core::{
-        crypto::{key_types, KeyTypeId},
+        crypto::{get_public_from_string_or_panic, key_types, AccountId32, KeyTypeId},
         sr25519, ByteArray, Pair, Public,
     },
     sp_keystore::{Keystore, KeystorePtr},
@@ -42,14 +43,6 @@ use {
     starlight_runtime_constants::currency::UNITS as STAR,
     tp_traits::ParaId,
 };
-
-use keyring::Sr25519Keyring;
-
-// import macro, separate due to rustfmt thinking it's the module with the
-// same name ^^'
-use alloc::vec;
-
-use sp_core::crypto::{get_public_from_string_or_panic, AccountId32};
 
 pub fn insert_authority_keys_into_keystore(seed: &str, keystore: &KeystorePtr) {
     insert_into_keystore::<BabeId>(seed, keystore, key_types::BABE);

--- a/chains/orchestrator-relays/runtime/starlight/src/lib.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/lib.rs
@@ -3110,6 +3110,7 @@ sp_api::impl_runtime_apis! {
             use xcm_config::{
                 AssetHub, LocalCheckAccount, LocationConverter, TokenLocation, XcmConfig,
             };
+            use alloc::boxed::Box;
 
             parameter_types! {
                 pub ExistentialDepositAsset: Option<Asset> = Some((

--- a/chains/orchestrator-relays/runtime/starlight/src/lib.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/lib.rs
@@ -25,11 +25,13 @@ extern crate alloc;
 use frame_support::storage::{with_storage_layer, with_transaction};
 // Fix compile error in impl_runtime_weights! macro
 use {
+    alloc::collections::{btree_map::BTreeMap, btree_set::BTreeSet, vec_deque::VecDeque},
     authority_discovery_primitives::AuthorityId as AuthorityDiscoveryId,
     beefy_primitives::{
         ecdsa_crypto::{AuthorityId as BeefyId, Signature as BeefySignature},
         mmr::{BeefyDataProvider, MmrLeafVersion},
     },
+    core::{cmp::Ordering, marker::PhantomData},
     cumulus_primitives_core::relay_chain::{HeadData, ValidationCode},
     dp_container_chain_genesis_data::ContainerChainGenesisDataItem,
     frame_support::{
@@ -88,12 +90,6 @@ use {
     sp_runtime::{
         traits::{BlockNumberProvider, ConvertInto},
         AccountId32,
-    },
-    sp_std::{
-        cmp::Ordering,
-        collections::{btree_map::BTreeMap, btree_set::BTreeSet, vec_deque::VecDeque},
-        marker::PhantomData,
-        prelude::*,
     },
     tp_bridge::ConvertLocation,
     tp_traits::{
@@ -2477,7 +2473,7 @@ sp_api::impl_runtime_apis! {
             Runtime::metadata_at_version(version)
         }
 
-        fn metadata_versions() -> sp_std::vec::Vec<u32> {
+        fn metadata_versions() -> alloc::vec::Vec<u32> {
             Runtime::metadata_versions()
         }
     }
@@ -3543,7 +3539,7 @@ impl Get<[u8; 32]> for BabeGetCollatorAssignmentRandomness {
             } {
                 // Return random_hash as a [u8; 32] instead of a Hash
                 let mut buf = [0u8; 32];
-                let len = sp_std::cmp::min(32, random_hash.as_ref().len());
+                let len = core::cmp::min(32, random_hash.as_ref().len());
                 buf[..len].copy_from_slice(&random_hash.as_ref()[..len]);
 
                 buf

--- a/chains/orchestrator-relays/runtime/starlight/src/lib.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/lib.rs
@@ -25,7 +25,11 @@ extern crate alloc;
 use frame_support::storage::{with_storage_layer, with_transaction};
 // Fix compile error in impl_runtime_weights! macro
 use {
-    alloc::collections::{btree_map::BTreeMap, btree_set::BTreeSet, vec_deque::VecDeque},
+    alloc::{
+        collections::{btree_map::BTreeMap, btree_set::BTreeSet, vec_deque::VecDeque},
+        vec,
+        vec::Vec,
+    },
     authority_discovery_primitives::AuthorityId as AuthorityDiscoveryId,
     beefy_primitives::{
         ecdsa_crypto::{AuthorityId as BeefyId, Signature as BeefySignature},

--- a/chains/orchestrator-relays/runtime/starlight/src/tests/author_noting_tests.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/tests/author_noting_tests.rs
@@ -18,12 +18,12 @@
 
 use {
     crate::tests::common::*,
+    alloc::vec,
     frame_support::{assert_noop, assert_ok, error::BadOrigin},
     pallet_author_noting_runtime_api::runtime_decl_for_author_noting_api::AuthorNotingApi,
     parity_scale_codec::Encode,
     sp_consensus_aura::AURA_ENGINE_ID,
     sp_runtime::{generic::DigestItem, traits::BlakeTwo256},
-    sp_std::vec,
     test_relay_sproof_builder::{HeaderAs, ParaHeaderSproofBuilder, ParaHeaderSproofBuilderItem},
     tp_traits::{ContainerChainBlockInfo, ParaId},
 };

--- a/chains/orchestrator-relays/runtime/starlight/src/tests/beefy.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/tests/beefy.rs
@@ -18,6 +18,7 @@
 
 use {
     crate::{tests::common::*, Beefy, Historical},
+    alloc::vec,
     beefy_primitives::{
         check_double_voting_proof,
         ecdsa_crypto::{
@@ -34,7 +35,6 @@ use {
     parity_scale_codec::{Decode, Encode},
     sp_application_crypto::{AppCrypto, Pair, RuntimeAppPublic},
     sp_runtime::{traits::Keccak256, DigestItem},
-    sp_std::vec,
 };
 
 /// Create a new `VoteMessage` from commitment primitives and key pair.

--- a/chains/orchestrator-relays/runtime/starlight/src/tests/collator_assignment_tests.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/tests/collator_assignment_tests.rs
@@ -22,6 +22,7 @@ use {
         Configuration, ContainerRegistrar, GetCoreAllocationConfigurationImpl, Paras, Registrar,
         RuntimeEvent, ServicesPayment, TanssiAuthorityMapping, TanssiInvulnerables,
     },
+    alloc::vec,
     cumulus_primitives_core::{
         relay_chain::{HeadData, SchedulerParams},
         ParaId,
@@ -32,7 +33,6 @@ use {
     sp_consensus_aura::AURA_ENGINE_ID,
     sp_core::Get,
     sp_runtime::{traits::BlakeTwo256, DigestItem},
-    sp_std::vec,
     test_relay_sproof_builder::{HeaderAs, ParaHeaderSproofBuilder, ParaHeaderSproofBuilderItem},
 };
 

--- a/chains/orchestrator-relays/runtime/starlight/src/tests/common/mod.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/tests/common/mod.rs
@@ -21,6 +21,7 @@ use {
         Authorship, BlockProductionCost, CollatorAssignmentCost, ExternalValidatorSlashes,
         MessageQueue, RuntimeCall,
     },
+    alloc::collections::btree_map::BTreeMap,
     babe_primitives::{
         digests::{PreDigest, SecondaryPlainPreDigest},
         BABE_ENGINE_ID,
@@ -61,7 +62,6 @@ use {
         traits::{Dispatchable, Header, One, SaturatedConversion, Zero},
         BuildStorage, Digest, DigestItem,
     },
-    sp_std::collections::btree_map::BTreeMap,
     sp_storage::well_known_keys,
     std::collections::BTreeSet,
     test_relay_sproof_builder::ParaHeaderSproofBuilder,

--- a/chains/orchestrator-relays/runtime/starlight/src/tests/core_scheduling_tests.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/tests/core_scheduling_tests.rs
@@ -20,6 +20,7 @@ use {
     crate::{
         tests::common::*, ContainerRegistrar, OnDemandAssignmentProvider, Paras, Registrar, Session,
     },
+    alloc::{collections::btree_map::BTreeMap, vec},
     cumulus_primitives_core::relay_chain::{
         AsyncBackingParams, CoreIndex, HeadData, SchedulerParams,
     },
@@ -31,7 +32,6 @@ use {
     runtime_parachains::scheduler::common::Assignment,
     sp_core::{Decode, Encode},
     sp_keystore::testing::MemoryKeystore,
-    sp_std::{collections::btree_map::BTreeMap, vec},
     starlight_runtime_constants::time::EpochDurationInBlocks,
     std::sync::Arc,
     tp_traits::SlotFrequency,

--- a/chains/orchestrator-relays/runtime/starlight/src/tests/ethereum_client.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/tests/ethereum_client.rs
@@ -21,7 +21,7 @@ use {
     frame_support::{assert_noop, assert_ok},
     snowbridge_pallet_ethereum_client::{functions::*, mock_electra::*},
     sp_core::H256,
-    sp_std::vec,
+    alloc::vec,
 };
 #[test]
 fn test_ethereum_force_checkpoint() {

--- a/chains/orchestrator-relays/runtime/starlight/src/tests/ethereum_token_transfers.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/tests/ethereum_token_transfers.rs
@@ -22,6 +22,7 @@ use {
         EthereumInboundQueue, EthereumSovereignAccount, EthereumSystem, EthereumTokenTransfers,
         RuntimeEvent, SnowbridgeFeesAccount, TokenLocationReanchored,
     },
+    alloc::vec,
     alloy_sol_types::SolEvent,
     frame_support::{assert_noop, assert_ok},
     hex_literal::hex,
@@ -34,7 +35,6 @@ use {
     snowbridge_verification_primitives::{EventProof, Log},
     sp_core::{H160, H256},
     sp_runtime::{traits::MaybeEquivalence, FixedU128, TokenError},
-    sp_std::vec,
     tanssi_runtime_common::processors::NativeTokenTransferMessageProcessor,
     xcm::{latest::Location, VersionedLocation},
 };

--- a/chains/orchestrator-relays/runtime/starlight/src/tests/inflation_rewards.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/tests/inflation_rewards.rs
@@ -18,11 +18,11 @@
 
 use {
     crate::{tests::common::*, AuthorNoting, RewardsPortion},
+    alloc::vec,
     cumulus_primitives_core::ParaId,
     parity_scale_codec::Encode,
     sp_consensus_aura::AURA_ENGINE_ID,
     sp_runtime::{generic::DigestItem, traits::BlakeTwo256},
-    sp_std::vec,
     test_relay_sproof_builder::{HeaderAs, ParaHeaderSproofBuilder, ParaHeaderSproofBuilderItem},
     tp_traits::ContainerChainBlockInfo,
 };

--- a/chains/orchestrator-relays/runtime/starlight/src/tests/integration_test.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/tests/integration_test.rs
@@ -22,13 +22,13 @@ use {
         tests::common::*, Balances, CollatorConfiguration, ContainerRegistrar, DataPreservers,
         Registrar, StreamPayment,
     },
+    alloc::vec,
     cumulus_primitives_core::{relay_chain::HeadData, ParaId},
     frame_support::{assert_err, assert_noop, assert_ok, BoundedVec},
     pallet_registrar_runtime_api::{
         runtime_decl_for_registrar_api::RegistrarApi, ContainerChainGenesisData,
     },
     pallet_stream_payment::StreamConfig,
-    sp_std::vec,
     starlight_runtime_constants::currency::EXISTENTIAL_DEPOSIT,
     tp_stream_payment_common::{
         AssetId as StreamPaymentAssetId, TimeUnit as StreamPaymentTimeUnit,

--- a/chains/orchestrator-relays/runtime/starlight/src/tests/relay_registrar.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/tests/relay_registrar.rs
@@ -20,6 +20,7 @@ use {
     crate::{
         tests::common::*, ContainerRegistrar, Paras, Registrar, RuntimeCall, SlotFrequency, System,
     },
+    alloc::vec,
     cumulus_primitives_core::relay_chain::HeadData,
     frame_support::{assert_noop, assert_ok, BoundedVec},
     pallet_registrar::Event as ContainerRegistrarEvent,
@@ -29,7 +30,6 @@ use {
     runtime_common::paras_registrar,
     runtime_parachains::configuration as parachains_configuration,
     sp_runtime::traits::Dispatchable,
-    sp_std::vec,
     tp_traits::ParaId,
 };
 

--- a/chains/orchestrator-relays/runtime/starlight/src/tests/services_payment.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/tests/services_payment.rs
@@ -18,10 +18,10 @@
 
 use {
     crate::{tests::common::*, ContainerRegistrar, Paras, Registrar, ServicesPayment},
+    alloc::vec,
     cumulus_primitives_core::{relay_chain::HeadData, ParaId},
     frame_support::{assert_noop, assert_ok, pallet_prelude::DispatchResultWithPostInfo},
     sp_runtime::DispatchError,
-    sp_std::vec,
 };
 
 #[test]

--- a/chains/orchestrator-relays/runtime/starlight/src/tests/session_keys.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/tests/session_keys.rs
@@ -16,7 +16,7 @@
 
 #![cfg(test)]
 
-use {crate::tests::common::*, frame_support::assert_ok, sp_std::vec};
+use {crate::tests::common::*, alloc::vec, frame_support::assert_ok};
 
 #[test]
 fn session_key_changes_are_reflected_after_two_sessions() {

--- a/chains/orchestrator-relays/runtime/starlight/src/tests/slashes.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/tests/slashes.rs
@@ -19,11 +19,11 @@ use {
         tests::common::*, BondingDuration, EthereumSystem, ExternalValidatorSlashes,
         ExternalValidators, Grandpa, Historical, RuntimeEvent, SessionsPerEra, SlashDeferDuration,
     },
+    alloc::vec,
     frame_support::{assert_noop, assert_ok, traits::KeyOwnerProofSystem},
     parity_scale_codec::Encode,
     sp_core::{Pair, H256},
     sp_runtime::Perbill,
-    sp_std::vec,
     tp_bridge::Command,
     xcm::{latest::prelude::*, VersionedLocation},
 };

--- a/chains/orchestrator-relays/runtime/starlight/src/tests/staking.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/tests/staking.rs
@@ -18,12 +18,12 @@
 
 use {
     crate::{tests::common::*, MinimumSelfDelegation, PooledStaking},
+    alloc::vec,
     frame_support::{assert_noop, assert_ok, error::BadOrigin},
     pallet_pooled_staking::{
         traits::IsCandidateEligible, ActivePoolKind, EligibleCandidate, PendingOperationKey,
         PendingOperationQuery, PoolKind, PoolsKey, SharesOrStake,
     },
-    sp_std::vec,
 };
 
 #[test]

--- a/chains/orchestrator-relays/runtime/starlight/src/tests/sudo.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/tests/sudo.rs
@@ -18,8 +18,8 @@
 
 use {
     crate::{tests::common::*, Sudo},
+    alloc::vec,
     frame_support::{assert_noop, assert_ok},
-    sp_std::vec,
 };
 
 #[test]

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/frame_benchmarking::baseline.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/frame_benchmarking::baseline.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for frame_benchmarking::baseline using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/frame_system.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/frame_system.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for frame_system using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/frame_system_extensions.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/frame_system_extensions.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for frame_system_extensions using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_asset_rate.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_asset_rate.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_asset_rate using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_author_noting.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_author_noting.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_author_noting using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_balances.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_balances.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_balances using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_beefy_mmr.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_beefy_mmr.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_beefy_mmr using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_collator_assignment.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_collator_assignment.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_collator_assignment using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_configuration.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_configuration.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_configuration using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_conviction_voting.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_conviction_voting.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_conviction_voting using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_data_preservers.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_data_preservers.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_data_preservers using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_ethereum_token_transfers.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_ethereum_token_transfers.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_ethereum_token_transfers using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_external_validator_slashes.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_external_validator_slashes.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_external_validator_slashes using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_external_validators.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_external_validators.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_external_validators using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_external_validators_rewards.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_external_validators_rewards.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_external_validators_rewards using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_identity.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_identity.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_identity using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_invulnerables.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_invulnerables.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_invulnerables using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_message_queue.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_message_queue.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_message_queue using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_mmr.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_mmr.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_mmr using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_multiblock_migrations.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_multiblock_migrations.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_multiblock_migrations using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_multisig.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_multisig.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_multisig using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_parameters.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_parameters.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_parameters using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_pooled_staking.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_pooled_staking.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_pooled_staking using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_preimage.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_preimage.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_preimage using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_proxy.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_proxy.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_proxy using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_ranked_collective.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_ranked_collective.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_ranked_collective using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_referenda.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_referenda.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_referenda using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_registrar.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_registrar.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_registrar using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_scheduler.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_scheduler.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_scheduler using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_services_payment.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_services_payment.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_services_payment using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_session.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_session.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_session using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_stream_payment.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_stream_payment.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_stream_payment using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_sudo.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_sudo.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_sudo using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_timestamp.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_timestamp.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_timestamp using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_transaction_payment.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_transaction_payment.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_transaction_payment using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_treasury.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_treasury.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_treasury using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_utility.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_utility.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_utility using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_whitelist.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_whitelist.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_whitelist using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_xcm.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/pallet_xcm.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_xcm using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/runtime_common_paras_registrar.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/runtime_common_paras_registrar.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for runtime_common::paras_registrar using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/runtime_parachains_assigner_on_demand.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/runtime_parachains_assigner_on_demand.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for runtime_parachains::assigner_on_demand using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/runtime_parachains_configuration.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/runtime_parachains_configuration.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for runtime_parachains::configuration using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/runtime_parachains_disputes.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/runtime_parachains_disputes.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for runtime_parachains::disputes using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/runtime_parachains_disputes::slashing.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/runtime_parachains_disputes::slashing.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for runtime_parachains::disputes::slashing using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/runtime_parachains_disputes_slashing.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/runtime_parachains_disputes_slashing.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for runtime_parachains::disputes::slashing using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/runtime_parachains_hrmp.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/runtime_parachains_hrmp.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for runtime_parachains::hrmp using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/runtime_parachains_inclusion.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/runtime_parachains_inclusion.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for runtime_parachains::inclusion using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/runtime_parachains_initializer.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/runtime_parachains_initializer.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for runtime_parachains::initializer using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/runtime_parachains_paras.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/runtime_parachains_paras.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for runtime_parachains::paras using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/runtime_parachains_paras_inherent.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/runtime_parachains_paras_inherent.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for runtime_parachains::paras_inherent using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/snowbridge_pallet_ethereum_client.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/snowbridge_pallet_ethereum_client.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for snowbridge_pallet_ethereum_client using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/snowbridge_pallet_inbound_queue.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/snowbridge_pallet_inbound_queue.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for snowbridge_pallet_inbound_queue using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/snowbridge_pallet_outbound_queue.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/snowbridge_pallet_outbound_queue.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for snowbridge_pallet_outbound_queue using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/snowbridge_pallet_system.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/snowbridge_pallet_system.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for snowbridge_pallet_system using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/xcm/mod.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/xcm/mod.rs
@@ -21,6 +21,7 @@ use frame_support::BoundedVec;
 use xcm::latest::AssetTransferFilter;
 use {
     crate::Runtime,
+    alloc::vec::Vec,
     frame_support::weights::Weight,
     pallet_xcm_benchmarks_fungible::WeightInfo as XcmBalancesWeight,
     pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric,

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/xcm/mod.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/xcm/mod.rs
@@ -24,7 +24,6 @@ use {
     frame_support::weights::Weight,
     pallet_xcm_benchmarks_fungible::WeightInfo as XcmBalancesWeight,
     pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric,
-    sp_std::prelude::*,
     xcm::{
         latest::{prelude::*, Weight as XCMWeight},
         DoubleEncoded,

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/xcm/pallet_xcm_benchmarks_fungible.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/xcm/pallet_xcm_benchmarks_fungible.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_xcm_benchmarks::fungible using the Substrate node and recommended hardware.
 pub struct WeightInfo<T>(PhantomData<T>);

--- a/chains/orchestrator-relays/runtime/starlight/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weights for pallet_xcm_benchmarks::generic using the Substrate node and recommended hardware.
 pub struct WeightInfo<T>(PhantomData<T>);

--- a/chains/runtime-common/Cargo.toml
+++ b/chains/runtime-common/Cargo.toml
@@ -57,7 +57,6 @@ snowbridge-pallet-system = { workspace = true }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
 sp-staking = { workspace = true }
-sp-std = { workspace = true }
 xcm = { workspace = true }
 
 # Cumulus
@@ -101,7 +100,6 @@ std = [
 	"sp-core/std",
 	"sp-runtime/std",
 	"sp-staking/std",
-	"sp-std/std",
 	"xcm/std",
 ]
 

--- a/chains/runtime-common/src/benchmarking.rs
+++ b/chains/runtime-common/src/benchmarking.rs
@@ -15,7 +15,7 @@
 // along with Tanssi.  If not, see <http://www.gnu.org/licenses/>
 
 use {
-    frame_support::traits::Currency, pallet_treasury::ArgumentsFactory, sp_std::marker::PhantomData,
+    core::marker::PhantomData, frame_support::traits::Currency, pallet_treasury::ArgumentsFactory,
 };
 pub struct TreasuryBenchmarkHelper<T>(PhantomData<T>);
 

--- a/chains/runtime-common/src/lib.rs
+++ b/chains/runtime-common/src/lib.rs
@@ -22,7 +22,7 @@ pub mod benchmarking;
 pub mod migrations;
 pub mod processors;
 
-pub struct DealWithFees<R>(sp_std::marker::PhantomData<R>);
+pub struct DealWithFees<R>(core::marker::PhantomData<R>);
 impl<R> OnUnbalanced<Credit<R::AccountId, pallet_balances::Pallet<R>>> for DealWithFees<R>
 where
     R: pallet_balances::Config + pallet_treasury::Config + frame_system::Config,

--- a/chains/runtime-common/src/migrations.rs
+++ b/chains/runtime-common/src/migrations.rs
@@ -37,6 +37,8 @@
 extern crate alloc;
 
 use {
+    alloc::collections::btree_set::BTreeSet,
+    core::marker::PhantomData,
     cumulus_primitives_core::ParaId,
     frame_support::{
         migration::{clear_storage_prefix, move_pallet, storage_key_iter},
@@ -55,7 +57,6 @@ use {
     pallet_registrar::HoldReason,
     sp_core::Get,
     sp_runtime::Perbill,
-    sp_std::{collections::btree_set::BTreeSet, marker::PhantomData, prelude::*},
 };
 #[cfg(feature = "try-runtime")]
 use {frame_support::ensure, parity_scale_codec::DecodeAll};

--- a/chains/runtime-common/src/migrations.rs
+++ b/chains/runtime-common/src/migrations.rs
@@ -37,7 +37,7 @@
 extern crate alloc;
 
 use {
-    alloc::collections::btree_set::BTreeSet,
+    alloc::{boxed::Box, collections::btree_set::BTreeSet, vec, vec::Vec},
     core::marker::PhantomData,
     cumulus_primitives_core::ParaId,
     frame_support::{

--- a/chains/runtime-common/src/processors.rs
+++ b/chains/runtime-common/src/processors.rs
@@ -27,7 +27,7 @@ use {
 /// `NativeTokenTransferMessageProcessor` is responsible for receiving and processing the Tanssi
 /// native token sent from Ethereum. If the message is valid, it performs the token transfer
 /// from the Ethereum sovereign account to the specified destination account.
-pub struct NativeTokenTransferMessageProcessor<T>(sp_std::marker::PhantomData<T>);
+pub struct NativeTokenTransferMessageProcessor<T>(core::marker::PhantomData<T>);
 impl<T> MessageProcessor for NativeTokenTransferMessageProcessor<T>
 where
     T: snowbridge_pallet_inbound_queue::Config

--- a/chains/xcm-integration-tests/emulated/common/Cargo.toml
+++ b/chains/xcm-integration-tests/emulated/common/Cargo.toml
@@ -21,7 +21,6 @@ sc-consensus-grandpa = { workspace = true, default-features = true }
 sp-consensus-aura = { workspace = true, default-features = true }
 sp-core = { workspace = true, default-features = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 sp-weights = { workspace = true }
 
 # Polkadot

--- a/chains/xcm-integration-tests/emulated/common/src/impls.rs
+++ b/chains/xcm-integration-tests/emulated/common/src/impls.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Tanssi.  If not, see <http://www.gnu.org/licenses/>.
 
-use {snowbridge_pallet_outbound_queue::CommittedMessage, sp_std::cell::RefCell};
+use {core::cell::RefCell, snowbridge_pallet_outbound_queue::CommittedMessage};
 
 pub fn eth_bridge_sent_msgs() -> Vec<CommittedMessage> {
     ETH_BRIDGE_SENT_MSGS.with(|q| (*q.borrow()).clone())

--- a/chains/xcm-integration-tests/emulated/common/src/lib.rs
+++ b/chains/xcm-integration-tests/emulated/common/src/lib.rs
@@ -16,6 +16,7 @@
 
 use {
     babe_primitives::AuthorityId as BabeId,
+    core::marker::PhantomData,
     cumulus_primitives_core::relay_chain::{
         AccountId, AssignmentId, AuthorityDiscoveryId, ValidatorId,
     },
@@ -29,7 +30,6 @@ use {
     sp_runtime::generic::DigestItem,
     sp_runtime::traits::Convert,
     sp_runtime::Digest,
-    sp_std::marker::PhantomData,
     sp_weights::Weight,
     xcm_emulator::{HeaderT, Network, Parachain, RelayChain},
 };

--- a/chains/xcm-integration-tests/emulated/dancebox-runtime-test-utils/Cargo.toml
+++ b/chains/xcm-integration-tests/emulated/dancebox-runtime-test-utils/Cargo.toml
@@ -34,5 +34,4 @@ sp-consensus-aura = { workspace = true }
 sp-consensus-slots = { workspace = true }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 tp-data-preservers-common = { workspace = true }

--- a/chains/xcm-integration-tests/emulated/dancebox-runtime-test-utils/src/lib.rs
+++ b/chains/xcm-integration-tests/emulated/dancebox-runtime-test-utils/src/lib.rs
@@ -30,7 +30,7 @@ use {
     sp_consensus_aura::AURA_ENGINE_ID,
     sp_core::Get,
     sp_runtime::{traits::Dispatchable, Digest, DigestItem},
-    sp_std::collections::btree_map::BTreeMap,
+    std::collections::btree_map::BTreeMap,
 };
 
 pub use dancebox_runtime::{

--- a/pallets/author-noting/Cargo.toml
+++ b/pallets/author-noting/Cargo.toml
@@ -26,7 +26,6 @@ sp-core = { workspace = true }
 sp-inherents = { workspace = true }
 sp-runtime = { workspace = true }
 sp-state-machine = { workspace = true }
-sp-std = { workspace = true }
 sp-trie = { workspace = true }
 
 cumulus-pallet-parachain-system = { workspace = true }
@@ -72,7 +71,6 @@ std = [
 	"sp-io/std",
 	"sp-runtime/std",
 	"sp-state-machine/std",
-	"sp-std/std",
 	"sp-trie/std",
 	"sp-version/std",
 	"test-relay-sproof-builder/std",

--- a/pallets/author-noting/src/benchmarks.rs
+++ b/pallets/author-noting/src/benchmarks.rs
@@ -19,12 +19,12 @@
 //! Benchmarking
 use {
     crate::{AuthorNotingInfo, Call, Config, HeadData, Pallet, ParaId, RelayOrPara},
+    alloc::{boxed::Box, vec},
     core::any::{Any, TypeId},
     frame_benchmarking::{account, v2::*},
     frame_support::{assert_ok, Hashable},
     frame_system::RawOrigin,
     parity_scale_codec::Encode,
-    sp_std::{boxed::Box, vec},
     tp_traits::{
         AuthorNotingHook, ForSession, GetContainerChainAuthor, GetContainerChainsWithCollators,
     },

--- a/pallets/author-noting/src/lib.rs
+++ b/pallets/author-noting/src/lib.rs
@@ -29,8 +29,11 @@
 //! to that containerChain, by simply assigning the slot position.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
 
 use {
+    alloc::borrow::Cow,
+    alloc::vec::Vec,
     cumulus_pallet_parachain_system::RelaychainStateProvider,
     cumulus_primitives_core::{
         relay_chain::{BlakeTwo256, BlockNumber, HeadData},
@@ -44,8 +47,6 @@ use {
     sp_consensus_aura::{inherents::InherentType, Slot, AURA_ENGINE_ID},
     sp_inherents::{InherentIdentifier, IsFatalError},
     sp_runtime::{traits::Header, DigestItem, DispatchResult},
-    sp_std::borrow::Cow,
-    sp_std::vec::Vec,
     tp_author_noting_inherent::INHERENT_IDENTIFIER,
     tp_traits::{
         AuthorNotingHook, AuthorNotingInfo, ContainerChainBlockInfo, ForSession, GenericStateProof,

--- a/pallets/author-noting/src/mock.rs
+++ b/pallets/author-noting/src/mock.rs
@@ -173,8 +173,8 @@ impl tp_traits::GetContainerChainsWithCollators<AccountId> for MockContainerChai
 
     fn get_all_collators_assigned_to_chains(
         _for_session: tp_traits::ForSession,
-    ) -> sp_std::collections::btree_set::BTreeSet<AccountId> {
-        sp_std::collections::btree_set::BTreeSet::new()
+    ) -> alloc::collections::btree_set::BTreeSet<AccountId> {
+        alloc::collections::btree_set::BTreeSet::new()
     }
 
     #[cfg(feature = "runtime-benchmarks")]

--- a/pallets/author-noting/src/weights.rs
+++ b/pallets/author-noting/src/weights.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weight functions needed for pallet_author_noting.
 pub trait WeightInfo {

--- a/pallets/authority-assignment/Cargo.toml
+++ b/pallets/authority-assignment/Cargo.toml
@@ -22,7 +22,6 @@ scale-info = { workspace = true }
 serde = { workspace = true, features = [ "derive" ] }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 tp-traits = { workspace = true }
 
 [dev-dependencies]
@@ -41,7 +40,6 @@ std = [
 	"sp-core/std",
 	"sp-io/std",
 	"sp-runtime/std",
-	"sp-std/std",
 	"tp-traits/std",
 ]
 try-runtime = [

--- a/pallets/authority-assignment/src/lib.rs
+++ b/pallets/authority-assignment/src/lib.rs
@@ -17,16 +17,17 @@
 //! # Nimbus Collator Assignment Pallet
 
 #![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
 
 pub use pallet::*;
 use {
+    alloc::{collections::btree_map::BTreeMap, vec},
     dp_collator_assignment::AssignedCollators,
     frame_support::pallet_prelude::*,
     sp_runtime::{
         traits::{AtLeast32BitUnsigned, One, Zero},
         Saturating,
     },
-    sp_std::{collections::btree_map::BTreeMap, prelude::*, vec},
 };
 
 #[cfg(test)]

--- a/pallets/authority-assignment/src/mock.rs
+++ b/pallets/authority-assignment/src/mock.rs
@@ -18,6 +18,7 @@ use dp_collator_assignment::AssignedCollators;
 
 use {
     crate::{self as pallet_authority_assignment},
+    alloc::collections::btree_map::BTreeMap,
     frame_support::traits::{ConstU16, ConstU64},
     frame_system as system,
     parity_scale_codec::{Decode, Encode},
@@ -26,7 +27,6 @@ use {
         traits::{BlakeTwo256, IdentityLookup},
         BuildStorage,
     },
-    sp_std::collections::btree_map::BTreeMap,
 };
 
 type Block = frame_system::mocking::MockBlock<Test>;

--- a/pallets/authority-mapping/Cargo.toml
+++ b/pallets/authority-mapping/Cargo.toml
@@ -19,7 +19,6 @@ parity-scale-codec = { workspace = true, features = [ "derive", "max-encoded-len
 scale-info = { workspace = true }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 
 [dev-dependencies]
 sp-io = { workspace = true }
@@ -34,7 +33,6 @@ std = [
 	"sp-core/std",
 	"sp-io/std",
 	"sp-runtime/std",
-	"sp-std/std",
 ]
 try-runtime = [
 	"frame-support/try-runtime",

--- a/pallets/authority-mapping/src/lib.rs
+++ b/pallets/authority-mapping/src/lib.rs
@@ -22,15 +22,16 @@
 //! block proposals or blocks that have been proposed in the past-session
 
 #![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
 
 pub use pallet::*;
 use {
+    alloc::{collections::btree_map::BTreeMap, vec},
     frame_support::pallet_prelude::*,
     sp_runtime::{
         traits::{AtLeast32BitUnsigned, CheckedSub},
         RuntimeAppPublic,
     },
-    sp_std::{collections::btree_map::BTreeMap, vec},
 };
 
 #[cfg(test)]

--- a/pallets/collator-assignment/Cargo.toml
+++ b/pallets/collator-assignment/Cargo.toml
@@ -25,7 +25,6 @@ scale-info = { workspace = true }
 serde = { workspace = true, features = [ "derive" ] }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 tp-traits = { workspace = true }
 
 [dev-dependencies]
@@ -49,7 +48,6 @@ std = [
 	"sp-core/std",
 	"sp-io/std",
 	"sp-runtime/std",
-	"sp-std/std",
 	"tp-traits/std",
 	"tracing/std",
 ]

--- a/pallets/collator-assignment/src/assignment.rs
+++ b/pallets/collator-assignment/src/assignment.rs
@@ -14,24 +14,22 @@
 // You should have received a copy of the GNU General Public License
 // along with Tanssi.  If not, see <http://www.gnu.org/licenses/>
 use {
+    alloc::{
+        collections::{btree_map::BTreeMap, btree_set::BTreeSet},
+        vec::Vec,
+    },
+    core::{cmp, marker::PhantomData, mem},
     dp_collator_assignment::AssignedCollators,
     frame_support::traits::Get,
     sp_runtime::Saturating,
-    sp_std::{
-        cmp,
-        collections::{btree_map::BTreeMap, btree_set::BTreeSet},
-        marker::PhantomData,
-        mem,
-        vec::Vec,
-    },
     tp_traits::{
         FullRotationMode, FullRotationModes, ParaId, RemoveInvulnerables as RemoveInvulnerablesT,
     },
 };
 
-// Separate import of `sp_std::vec!` macro, which cause issues with rustfmt if grouped
-// with `sp_std::vec::Vec`.
-use sp_std::vec;
+// Separate import of `alloc::vec!` macro, which cause issues with rustfmt if grouped
+// with `alloc::vec::Vec`.
+use alloc::vec;
 
 /// Helper methods to implement collator assignment algorithm
 pub struct Assignment<T>(PhantomData<T>);

--- a/pallets/collator-assignment/src/benchmarking.rs
+++ b/pallets/collator-assignment/src/benchmarking.rs
@@ -20,6 +20,7 @@
 use {
     super::*,
     crate::Pallet,
+    alloc::collections::btree_map::BTreeMap,
     core::any::TypeId,
     frame_benchmarking::{account, impl_benchmark_test_suite, v2::*, BenchmarkError},
     frame_support::{
@@ -27,8 +28,6 @@ use {
         traits::{Currency, EnsureOrigin, Get},
     },
     frame_system::{EventRecord, RawOrigin},
-    sp_std::collections::btree_map::BTreeMap,
-    sp_std::prelude::*,
 };
 
 const SEED: u32 = 0;

--- a/pallets/collator-assignment/src/lib.rs
+++ b/pallets/collator-assignment/src/lib.rs
@@ -40,9 +40,11 @@
 //! are assigned to.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
 
 use {
     crate::assignment::{Assignment, ChainNumCollators},
+    alloc::{collections::btree_set::BTreeSet, fmt::Debug, vec},
     core::ops::Mul,
     frame_support::{pallet_prelude::*, traits::Currency},
     frame_system::pallet_prelude::BlockNumberFor,
@@ -52,7 +54,6 @@ use {
         traits::{AtLeast32BitUnsigned, One, Zero},
         Perbill, Saturating,
     },
-    sp_std::{collections::btree_set::BTreeSet, fmt::Debug, prelude::*, vec},
     tp_traits::{
         CollatorAssignmentTip, ForSession, FullRotationModes, GetContainerChainAuthor,
         GetContainerChainsWithCollators, GetHostConfiguration, GetSessionContainerChains, ParaId,

--- a/pallets/collator-assignment/src/lib.rs
+++ b/pallets/collator-assignment/src/lib.rs
@@ -44,7 +44,7 @@ extern crate alloc;
 
 use {
     crate::assignment::{Assignment, ChainNumCollators},
-    alloc::{collections::btree_set::BTreeSet, fmt::Debug, vec},
+    alloc::{collections::btree_set::BTreeSet, fmt::Debug, vec, vec::Vec},
     core::ops::Mul,
     frame_support::{pallet_prelude::*, traits::Currency},
     frame_system::pallet_prelude::BlockNumberFor,

--- a/pallets/collator-assignment/src/mock.rs
+++ b/pallets/collator-assignment/src/mock.rs
@@ -20,6 +20,8 @@ use {
         CoreAllocationConfiguration, GetRandomnessForNextBlock, ParachainRandomness,
         RotateCollatorsEveryNSessions,
     },
+    alloc::collections::{btree_map::BTreeMap, btree_set::BTreeSet},
+    core::ops::Range,
     dp_collator_assignment::AssignedCollators,
     frame_support::{
         parameter_types,
@@ -32,10 +34,6 @@ use {
     sp_runtime::{
         traits::{BlakeTwo256, IdentityLookup},
         BuildStorage, Perbill,
-    },
-    sp_std::{
-        collections::{btree_map::BTreeMap, btree_set::BTreeSet},
-        ops::Range,
     },
     tp_traits::{
         CollatorAssignmentTip, FullRotationModes, ParaId, ParaIdAssignmentHooks, ParathreadParams,

--- a/pallets/collator-assignment/src/tests/assign_full.rs
+++ b/pallets/collator-assignment/src/tests/assign_full.rs
@@ -19,9 +19,9 @@ use {
         assignment::{Assignment, AssignmentError},
         tests::Test,
     },
+    alloc::collections::btree_map::BTreeMap,
     rand::{seq::SliceRandom, SeedableRng},
     rand_chacha::ChaCha20Rng,
-    sp_std::collections::btree_map::BTreeMap,
 };
 
 fn no_shuffle() -> Option<fn(&mut Vec<u64>)> {

--- a/pallets/collator-assignment/src/tests/prioritize_invulnerables.rs
+++ b/pallets/collator-assignment/src/tests/prioritize_invulnerables.rs
@@ -19,7 +19,7 @@ use {
         assignment::{Assignment, ChainNumCollators},
         tests::Test,
     },
-    sp_std::collections::{btree_map::BTreeMap, btree_set::BTreeSet},
+    alloc::collections::{btree_map::BTreeMap, btree_set::BTreeSet},
 };
 
 #[test]

--- a/pallets/collator-assignment/src/weights.rs
+++ b/pallets/collator-assignment/src/weights.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weight functions needed for pallet_collator_assignment.
 pub trait WeightInfo {

--- a/pallets/configuration/Cargo.toml
+++ b/pallets/configuration/Cargo.toml
@@ -22,7 +22,6 @@ scale-info = { workspace = true }
 serde = { workspace = true, features = [ "derive" ] }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 tp-traits = { workspace = true }
 
 [dev-dependencies]
@@ -41,7 +40,6 @@ std = [
 	"sp-core/std",
 	"sp-io/std",
 	"sp-runtime/std",
-	"sp-std/std",
 	"tp-traits/std",
 ]
 runtime-benchmarks = [

--- a/pallets/configuration/src/lib.rs
+++ b/pallets/configuration/src/lib.rs
@@ -44,6 +44,7 @@ mod benchmarks;
 
 pub use pallet::*;
 use {
+    alloc::{vec, vec::Vec},
     frame_support::pallet_prelude::*,
     frame_system::pallet_prelude::*,
     serde::{Deserialize, Serialize},

--- a/pallets/configuration/src/lib.rs
+++ b/pallets/configuration/src/lib.rs
@@ -28,6 +28,7 @@
 //! T::SessionDelay to apply these changes
 
 #![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
 
 #[cfg(test)]
 mod mock;
@@ -47,7 +48,6 @@ use {
     frame_system::pallet_prelude::*,
     serde::{Deserialize, Serialize},
     sp_runtime::{traits::AtLeast32BitUnsigned, Perbill, Saturating},
-    sp_std::prelude::*,
     tp_traits::{FullRotationModes, GetSessionIndex},
 };
 
@@ -225,7 +225,7 @@ pub mod pallet {
     pub struct GenesisConfig<T: Config> {
         pub config: HostConfiguration,
         #[serde(skip)]
-        pub _config: sp_std::marker::PhantomData<T>,
+        pub _config: core::marker::PhantomData<T>,
     }
 
     #[pallet::genesis_build]

--- a/pallets/configuration/src/tests.rs
+++ b/pallets/configuration/src/tests.rs
@@ -16,8 +16,8 @@
 
 use {
     crate::{mock::*, Error, HostConfiguration, PendingConfigs},
+    alloc::vec,
     frame_support::{assert_noop, assert_ok, dispatch::GetDispatchInfo},
-    sp_std::vec,
 };
 
 #[test]

--- a/pallets/configuration/src/weights.rs
+++ b/pallets/configuration/src/weights.rs
@@ -48,7 +48,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weight functions needed for pallet_configuration.
 pub trait WeightInfo {

--- a/pallets/data-preservers/Cargo.toml
+++ b/pallets/data-preservers/Cargo.toml
@@ -30,7 +30,6 @@ parity-scale-codec = { workspace = true }
 scale-info = { workspace = true }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 
 [dev-dependencies]
 num-traits = { workspace = true }
@@ -54,7 +53,6 @@ std = [
 	"sp-core/std",
 	"sp-io/std",
 	"sp-runtime/std",
-	"sp-std/std",
 	"tp-traits/std",
 ]
 runtime-benchmarks = [

--- a/pallets/data-preservers/src/benchmarks.rs
+++ b/pallets/data-preservers/src/benchmarks.rs
@@ -22,6 +22,7 @@ use {
         AssignmentProcessor, Assignments, Call, Config, Pallet, ParaIdsFilter, Profile,
         ProfileMode, Profiles, RegisteredProfile,
     },
+    alloc::{collections::btree_set::BTreeSet, vec},
     frame_benchmarking::v2::*,
     frame_support::{
         traits::{
@@ -32,7 +33,6 @@ use {
     },
     frame_system::RawOrigin,
     sp_runtime::traits::Zero,
-    sp_std::{collections::btree_set::BTreeSet, vec},
     tp_traits::{ParaId, StorageDeposit},
 };
 

--- a/pallets/data-preservers/src/lib.rs
+++ b/pallets/data-preservers/src/lib.rs
@@ -19,6 +19,7 @@
 //! This pallet allows container chains to select data preservers.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
 
 mod types;
 
@@ -37,6 +38,7 @@ pub mod weights;
 pub use weights::WeightInfo;
 
 use {
+    alloc::vec::Vec,
     core::fmt::Debug,
     dp_core::ParaId,
     frame_support::{
@@ -55,7 +57,6 @@ use {
         traits::{CheckedAdd, CheckedSub, Get, One, Zero},
         ArithmeticError, Either,
     },
-    sp_std::vec::Vec,
     tp_traits::StorageDeposit,
 };
 

--- a/pallets/data-preservers/src/mock.rs
+++ b/pallets/data-preservers/src/mock.rs
@@ -16,6 +16,7 @@
 
 use {
     crate::{self as pallet_data_preservers},
+    alloc::collections::btree_map::BTreeMap,
     dp_core::ParaId,
     frame_support::{
         dispatch::DispatchErrorWithPostInfo,
@@ -30,7 +31,6 @@ use {
         traits::{BlakeTwo256, IdentityLookup},
         BuildStorage, Either,
     },
-    sp_std::collections::btree_map::BTreeMap,
 };
 
 type Block = frame_system::mocking::MockBlock<Test>;

--- a/pallets/data-preservers/src/weights.rs
+++ b/pallets/data-preservers/src/weights.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weight functions needed for pallet_data_preservers.
 pub trait WeightInfo {

--- a/pallets/ethereum-token-transfers/Cargo.toml
+++ b/pallets/ethereum-token-transfers/Cargo.toml
@@ -22,7 +22,6 @@ frame-system = { workspace = true }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
 sp-staking = { workspace = true }
-sp-std = { workspace = true }
 tp-bridge = { workspace = true }
 tp-traits = { workspace = true }
 
@@ -64,7 +63,6 @@ std = [
 	"sp-io/std",
 	"sp-runtime/std",
 	"sp-staking/std",
-	"sp-std/std",
 	"tp-bridge/std",
 	"tp-traits/std",
 	"xcm/std",

--- a/pallets/ethereum-token-transfers/src/benchmarking.rs
+++ b/pallets/ethereum-token-transfers/src/benchmarking.rs
@@ -24,7 +24,6 @@ use {
     frame_system::RawOrigin,
     snowbridge_core::{AgentId, ChannelId, ParaId},
     sp_core::H160,
-    sp_std::prelude::*,
 };
 
 pub(crate) fn ethereum_token_transfers_events<T: Config>() -> Vec<crate::Event<T>> {

--- a/pallets/ethereum-token-transfers/src/benchmarking.rs
+++ b/pallets/ethereum-token-transfers/src/benchmarking.rs
@@ -19,6 +19,7 @@ use super::*;
 #[allow(unused)]
 use crate::Pallet as EthereumTokenTransfers;
 use {
+    alloc::vec::Vec,
     frame_benchmarking::{account, v2::*, BenchmarkError},
     frame_support::traits::Currency,
     frame_system::RawOrigin,

--- a/pallets/ethereum-token-transfers/src/lib.rs
+++ b/pallets/ethereum-token-transfers/src/lib.rs
@@ -41,6 +41,7 @@
 //! After that, the message is delivered to Ethereum through the T::OutboundQueue implementation.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
 
 #[cfg(test)]
 mod mock;
@@ -54,6 +55,7 @@ mod benchmarking;
 pub mod weights;
 
 use {
+    alloc::vec,
     frame_support::{
         pallet_prelude::*,
         traits::{
@@ -70,7 +72,6 @@ use {
     snowbridge_outbound_queue_primitives::SendError,
     sp_core::{H160, H256},
     sp_runtime::{traits::MaybeEquivalence, DispatchResult},
-    sp_std::vec,
     tp_bridge::{ChannelInfo, EthereumSystemChannelManager, TicketInfo},
     xcm::prelude::*,
 };

--- a/pallets/ethereum-token-transfers/src/mock.rs
+++ b/pallets/ethereum-token-transfers/src/mock.rs
@@ -16,6 +16,7 @@
 
 use {
     crate as pallet_ethereum_token_transfers,
+    core::cell::RefCell,
     frame_support::{
         parameter_types,
         traits::{ConstU32, ConstU64},
@@ -30,7 +31,6 @@ use {
         traits::{BlakeTwo256, IdentityLookup, MaybeEquivalence},
         BuildStorage,
     },
-    sp_std::cell::RefCell,
     tp_bridge::{ChannelInfo, EthereumSystemChannelManager, TicketInfo},
     xcm::prelude::*,
 };

--- a/pallets/ethereum-token-transfers/src/weights.rs
+++ b/pallets/ethereum-token-transfers/src/weights.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weight functions needed for pallet_ethereum_token_transfers.
 pub trait WeightInfo {

--- a/pallets/external-validator-slashes/Cargo.toml
+++ b/pallets/external-validator-slashes/Cargo.toml
@@ -26,7 +26,6 @@ snowbridge-outbound-queue-primitives = { workspace = true }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
 sp-staking = { workspace = true }
-sp-std = { workspace = true }
 tp-bridge = { workspace = true }
 tp-traits = { workspace = true }
 
@@ -55,7 +54,6 @@ std = [
 	"sp-io/std",
 	"sp-runtime/std",
 	"sp-staking/std",
-	"sp-std/std",
 	"tp-bridge/std",
 	"tp-traits/std",
 ]

--- a/pallets/external-validator-slashes/src/benchmarking.rs
+++ b/pallets/external-validator-slashes/src/benchmarking.rs
@@ -26,7 +26,6 @@ use {
     frame_system::RawOrigin,
     pallet_session::{self as session},
     sp_runtime::traits::TrailingZeroInput,
-    sp_std::prelude::*,
 };
 
 const MAX_SLASHES: u32 = 1000;

--- a/pallets/external-validator-slashes/src/lib.rs
+++ b/pallets/external-validator-slashes/src/lib.rs
@@ -27,8 +27,10 @@
 //! Invulnerables are not slashed and no slashing information is stored for them
 
 #![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
 
 use {
+    alloc::{collections::vec_deque::VecDeque, vec, vec::Vec},
     frame_support::{pallet_prelude::*, traits::DefensiveSaturating},
     frame_system::pallet_prelude::*,
     log::log,
@@ -43,7 +45,6 @@ use {
         offence::{OffenceDetails, OnOffenceHandler},
         EraIndex, SessionIndex,
     },
-    sp_std::{collections::vec_deque::VecDeque, vec, vec::Vec},
     tp_traits::{
         apply, derive_storage_traits, EraIndexProvider, ExternalIndexProvider,
         InvulnerablesProvider, OnEraStart,

--- a/pallets/external-validator-slashes/src/mock.rs
+++ b/pallets/external-validator-slashes/src/mock.rs
@@ -16,6 +16,7 @@
 
 use {
     crate as external_validator_slashes,
+    core::cell::RefCell,
     frame_support::{
         parameter_types,
         traits::{ConstU16, ConstU32, ConstU64, Get, Hooks},
@@ -30,7 +31,6 @@ use {
         BuildStorage,
     },
     sp_staking::SessionIndex,
-    sp_std::cell::RefCell,
     tp_traits::{ActiveEraInfo, EraIndex, EraIndexProvider, InvulnerablesProvider},
 };
 

--- a/pallets/external-validator-slashes/src/weights.rs
+++ b/pallets/external-validator-slashes/src/weights.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weight functions needed for pallet_external_validator_slashes.
 pub trait WeightInfo {

--- a/pallets/external-validators-rewards/Cargo.toml
+++ b/pallets/external-validators-rewards/Cargo.toml
@@ -22,7 +22,6 @@ frame-system = { workspace = true }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
 sp-staking = { workspace = true }
-sp-std = { workspace = true }
 tp-bridge = { workspace = true }
 tp-traits = { workspace = true }
 
@@ -67,7 +66,6 @@ std = [
 	"sp-io/std",
 	"sp-runtime/std",
 	"sp-staking/std",
-	"sp-std/std",
 	"tp-bridge/std",
 	"tp-traits/std",
 	"xcm/std",

--- a/pallets/external-validators-rewards/src/benchmarking.rs
+++ b/pallets/external-validators-rewards/src/benchmarking.rs
@@ -23,7 +23,6 @@ use crate::Pallet as ExternalValidatorsRewards;
 use {
     frame_benchmarking::{account, v2::*, BenchmarkError},
     frame_support::traits::{Currency, Get},
-    sp_std::prelude::*,
     tp_bridge::TokenChannelSetterBenchmarkHelperTrait,
     tp_traits::OnEraEnd,
 };

--- a/pallets/external-validators-rewards/src/lib.rs
+++ b/pallets/external-validators-rewards/src/lib.rs
@@ -18,6 +18,7 @@
 //! Storage will be cleared after a period of time.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
 
 #[cfg(test)]
 mod mock;
@@ -33,6 +34,7 @@ pub mod weights;
 pub use pallet::*;
 
 use {
+    alloc::{collections::btree_set::BTreeSet, vec::Vec},
     frame_support::traits::{
         fungible::{self, Mutate},
         Defensive, Get, ValidatorSet,
@@ -45,7 +47,6 @@ use {
     sp_core::H256,
     sp_runtime::traits::{Hash, MaybeEquivalence, Zero},
     sp_staking::SessionIndex,
-    sp_std::{collections::btree_set::BTreeSet, vec::Vec},
     tp_bridge::{Command, DeliverMessage, Message, TicketInfo, ValidateMessage},
     tp_traits::ExternalIndexProvider,
     xcm::prelude::*,
@@ -64,8 +65,8 @@ pub struct EraRewardsUtils {
 pub mod pallet {
     pub use crate::weights::WeightInfo;
     use {
-        super::*, frame_support::pallet_prelude::*, sp_runtime::Saturating,
-        sp_std::collections::btree_map::BTreeMap, tp_traits::EraIndexProvider,
+        super::*, alloc::collections::btree_map::BTreeMap, frame_support::pallet_prelude::*,
+        sp_runtime::Saturating, tp_traits::EraIndexProvider,
     };
 
     /// The current storage version.

--- a/pallets/external-validators-rewards/src/tests.rs
+++ b/pallets/external-validators-rewards/src/tests.rs
@@ -16,8 +16,8 @@
 
 use {
     crate::{self as pallet_external_validators_rewards, mock::*},
+    alloc::collections::btree_map::BTreeMap,
     sp_core::H256,
-    sp_std::collections::btree_map::BTreeMap,
     tp_bridge::Command,
     tp_traits::{ActiveEraInfo, OnEraEnd, OnEraStart},
     xcm::latest::prelude::*,

--- a/pallets/external-validators-rewards/src/weights.rs
+++ b/pallets/external-validators-rewards/src/weights.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weight functions needed for pallet_external_validators_rewards.
 pub trait WeightInfo {

--- a/pallets/external-validators/Cargo.toml
+++ b/pallets/external-validators/Cargo.toml
@@ -22,7 +22,6 @@ frame-support = { workspace = true }
 frame-system = { workspace = true }
 sp-runtime = { workspace = true }
 sp-staking = { workspace = true }
-sp-std = { workspace = true }
 tp-traits = { workspace = true }
 
 frame-benchmarking = { workspace = true }
@@ -52,7 +51,6 @@ std = [
 	"sp-io/std",
 	"sp-runtime/std",
 	"sp-staking/std",
-	"sp-std/std",
 	"tp-traits/std",
 ]
 runtime-benchmarks = [

--- a/pallets/external-validators/src/benchmarking.rs
+++ b/pallets/external-validators/src/benchmarking.rs
@@ -27,7 +27,6 @@ use {
     pallet_session::{self as session, SessionManager},
     rand::{RngCore, SeedableRng},
     sp_runtime::{codec, traits::Convert},
-    sp_std::prelude::*,
 };
 const SEED: u32 = 0;
 

--- a/pallets/external-validators/src/lib.rs
+++ b/pallets/external-validators/src/lib.rs
@@ -32,15 +32,18 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+extern crate alloc;
+
 pub use pallet::*;
 use {
+    alloc::{collections::btree_set::BTreeSet, vec::Vec},
+    core::cmp::Ordering,
     frame_support::pallet_prelude::Weight,
     log::log,
     parity_scale_codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen},
     scale_info::TypeInfo,
     sp_runtime::{traits::Get, RuntimeDebug},
     sp_staking::SessionIndex,
-    sp_std::{cmp::Ordering, collections::btree_set::BTreeSet, vec::Vec},
     tp_traits::{
         ActiveEraInfo, EraIndex, EraIndexProvider, ExternalIndexProvider, InvulnerablesProvider,
         OnEraEnd, OnEraStart, ValidatorProvider,
@@ -65,6 +68,7 @@ pub mod pallet {
     use frame_support::traits::Currency;
     use {
         super::*,
+        alloc::vec::Vec,
         frame_support::{
             pallet_prelude::*,
             traits::{EnsureOrigin, UnixTime, ValidatorRegistration},
@@ -72,7 +76,6 @@ pub mod pallet {
         },
         frame_system::pallet_prelude::*,
         sp_runtime::{traits::Convert, SaturatedConversion},
-        sp_std::vec::Vec,
     };
 
     /// Configure the pallet by specifying the parameters and types on which it depends.
@@ -222,7 +225,7 @@ pub mod pallet {
                 // T::ValidatorId does not impl Ord or Hash so we cannot collect into set directly,
                 // but we can check for duplicates if we encode them first.
                 .map(|x| x.encode())
-                .collect::<sp_std::collections::btree_set::BTreeSet<_>>();
+                .collect::<alloc::collections::btree_set::BTreeSet<_>>();
             assert!(
                 duplicate_validators.len() == self.whitelisted_validators.len(),
                 "duplicate validators in genesis."

--- a/pallets/external-validators/src/weights.rs
+++ b/pallets/external-validators/src/weights.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weight functions needed for pallet_external_validators.
 pub trait WeightInfo {

--- a/pallets/inactivity-tracking/Cargo.toml
+++ b/pallets/inactivity-tracking/Cargo.toml
@@ -24,7 +24,6 @@ frame-system = { workspace = true }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
 sp-staking = { workspace = true }
-sp-std = { workspace = true }
 
 tp-traits = { workspace = true }
 
@@ -47,7 +46,6 @@ std = [
 	"sp-io/std",
 	"sp-runtime/std",
 	"sp-staking/std",
-	"sp-std/std",
 	"tp-traits/std",
 ]
 runtime-benchmarks = [

--- a/pallets/inactivity-tracking/src/lib.rs
+++ b/pallets/inactivity-tracking/src/lib.rs
@@ -22,6 +22,8 @@
 //! The tracking functionality can be enabled or disabled with root privileges.
 //! By default, the tracking is enabled.
 #![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
+
 use {
     frame_support::{
         dispatch::DispatchResult, dispatch::DispatchResultWithPostInfo, ensure,
@@ -62,10 +64,10 @@ pub mod pallet {
     use {
         super::*,
         crate::weights::WeightInfo,
+        alloc::collections::btree_set::BTreeSet,
         core::marker::PhantomData,
         frame_support::{pallet_prelude::*, storage::types::StorageMap},
         frame_system::pallet_prelude::*,
-        sp_std::collections::btree_set::BTreeSet,
     };
 
     pub type Collator<T> = <T as frame_system::Config>::AccountId;

--- a/pallets/inactivity-tracking/src/mock.rs
+++ b/pallets/inactivity-tracking/src/mock.rs
@@ -15,6 +15,8 @@ use frame_support::dispatch::DispatchResultWithPostInfo;
 // along with Tanssi.  If not, see <http://www.gnu.org/licenses/>
 use {
     crate as pallet_inactivity_tracking,
+    alloc::collections::btree_set::BTreeSet,
+    core::marker::PhantomData,
     frame_support::{
         parameter_types,
         traits::{ConstU32, ConstU64, Everything, OnFinalize, OnInitialize},
@@ -26,7 +28,6 @@ use {
         BuildStorage, RuntimeAppPublic,
     },
     sp_staking::SessionIndex,
-    sp_std::{collections::btree_set::BTreeSet, marker::PhantomData},
     tp_traits::{ForSession, ParaId},
 };
 

--- a/pallets/inactivity-tracking/src/weights.rs
+++ b/pallets/inactivity-tracking/src/weights.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weight functions needed for pallet_inactivity_tracking.
 pub trait WeightInfo {

--- a/pallets/inflation-rewards/Cargo.toml
+++ b/pallets/inflation-rewards/Cargo.toml
@@ -29,7 +29,6 @@ parity-scale-codec = { workspace = true }
 scale-info = { workspace = true }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 
 [dev-dependencies]
 bounded-collections = { workspace = true }
@@ -54,7 +53,6 @@ std = [
 	"sp-core/std",
 	"sp-io/std",
 	"sp-runtime/std",
-	"sp-std/std",
 	"tp-traits/std",
 ]
 runtime-benchmarks = [

--- a/pallets/inflation-rewards/src/lib.rs
+++ b/pallets/inflation-rewards/src/lib.rs
@@ -19,6 +19,7 @@
 //! This pallet handle native token inflation and rewards distribution.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
 
 pub use pallet::*;
 
@@ -326,7 +327,7 @@ impl<T: Config> AuthorNotingHook<T::AccountId> for Pallet<T> {
         .expect("to mint tokens");
 
         ChainsToReward::<T>::put(ChainsToRewardValue {
-            para_ids: sp_std::vec![para_id].try_into().expect("to be in bound"),
+            para_ids: alloc::vec![para_id].try_into().expect("to be in bound"),
             rewards_per_chain: BalanceOf::<T>::from(reward_amount),
         });
     }

--- a/pallets/initializer/Cargo.toml
+++ b/pallets/initializer/Cargo.toml
@@ -19,7 +19,6 @@ pallet-session = { workspace = true }
 parity-scale-codec = { workspace = true }
 scale-info = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 
 [dev-dependencies]
 sp-core = { workspace = true }
@@ -36,7 +35,6 @@ std = [
 	"sp-core/std",
 	"sp-io/std",
 	"sp-runtime/std",
-	"sp-std/std",
 ]
 try-runtime = [
 	"frame-support/try-runtime",

--- a/pallets/initializer/src/lib.rs
+++ b/pallets/initializer/src/lib.rs
@@ -22,6 +22,7 @@
 //! SessionHandler config trait
 
 #![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
 
 #[cfg(test)]
 mod mock;
@@ -31,6 +32,7 @@ mod tests;
 
 pub use pallet::*;
 use {
+    alloc::vec::Vec,
     frame_support::{pallet_prelude::*, traits::OneSessionHandler},
     scale_info::TypeInfo,
     sp_runtime::{traits::AtLeast32BitUnsigned, RuntimeAppPublic},

--- a/pallets/initializer/src/lib.rs
+++ b/pallets/initializer/src/lib.rs
@@ -34,7 +34,6 @@ use {
     frame_support::{pallet_prelude::*, traits::OneSessionHandler},
     scale_info::TypeInfo,
     sp_runtime::{traits::AtLeast32BitUnsigned, RuntimeAppPublic},
-    sp_std::prelude::*,
 };
 
 #[frame_support::pallet]

--- a/pallets/initializer/src/mock.rs
+++ b/pallets/initializer/src/mock.rs
@@ -16,6 +16,7 @@
 
 use {
     crate as pallet_initializer,
+    core::cell::RefCell,
     frame_support::traits::{ConstU16, ConstU64},
     frame_system as system,
     sp_core::H256,
@@ -24,7 +25,6 @@ use {
         traits::{BlakeTwo256, IdentityLookup},
         BuildStorage,
     },
-    sp_std::cell::RefCell,
 };
 
 type Block = frame_system::mocking::MockBlock<Test>;

--- a/pallets/initializer/src/tests.rs
+++ b/pallets/initializer/src/tests.rs
@@ -14,10 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Tanssi.  If not, see <http://www.gnu.org/licenses/>
 
-use {
-    super::*,
-    crate::mock::{new_test_ext, session_change_validators, Initializer},
-};
+use crate::mock::{new_test_ext, session_change_validators, Initializer};
 
 #[test]
 fn session_0_is_instantly_applied() {

--- a/pallets/invulnerables/Cargo.toml
+++ b/pallets/invulnerables/Cargo.toml
@@ -22,7 +22,6 @@ frame-support = { workspace = true }
 frame-system = { workspace = true }
 sp-runtime = { workspace = true }
 sp-staking = { workspace = true }
-sp-std = { workspace = true }
 tp-traits = { workspace = true }
 
 frame-benchmarking = { workspace = true }
@@ -50,7 +49,6 @@ std = [
 	"sp-io/std",
 	"sp-runtime/std",
 	"sp-staking/std",
-	"sp-std/std",
 	"tp-traits/std",
 ]
 runtime-benchmarks = [

--- a/pallets/invulnerables/src/benchmarking.rs
+++ b/pallets/invulnerables/src/benchmarking.rs
@@ -30,7 +30,6 @@ use {
     pallet_session::{self as session, SessionManager},
     rand::{RngCore, SeedableRng},
     sp_runtime::{codec, traits::AtLeast32BitUnsigned},
-    sp_std::prelude::*,
     tp_traits::DistributeRewards,
 };
 const SEED: u32 = 0;

--- a/pallets/invulnerables/src/benchmarking.rs
+++ b/pallets/invulnerables/src/benchmarking.rs
@@ -21,6 +21,7 @@ use super::*;
 #[allow(unused)]
 use crate::Pallet as InvulnerablesPallet;
 use {
+    alloc::vec::Vec,
     frame_benchmarking::{account, v2::*, BenchmarkError},
     frame_support::{
         pallet_prelude::*,

--- a/pallets/invulnerables/src/lib.rs
+++ b/pallets/invulnerables/src/lib.rs
@@ -24,6 +24,7 @@
 //! - Invulnerable: An account appointed by governance and guaranteed to be in the collator set.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
 
 pub use pallet::*;
 use {
@@ -49,6 +50,7 @@ pub mod pallet {
     use frame_support::traits::Currency;
 
     use {
+        alloc::vec::Vec,
         frame_support::{
             pallet_prelude::*,
             traits::{EnsureOrigin, ValidatorRegistration},
@@ -58,7 +60,6 @@ pub mod pallet {
         pallet_session::SessionManager,
         sp_runtime::traits::Convert,
         sp_staking::SessionIndex,
-        sp_std::vec::Vec,
     };
 
     /// The current storage version.
@@ -117,7 +118,7 @@ pub mod pallet {
             let duplicate_invulnerables = self
                 .invulnerables
                 .iter()
-                .collect::<sp_std::collections::btree_set::BTreeSet<_>>();
+                .collect::<alloc::collections::btree_set::BTreeSet<_>>();
             assert!(
                 duplicate_invulnerables.len() == self.invulnerables.len(),
                 "duplicate invulnerables in genesis."

--- a/pallets/invulnerables/src/weights.rs
+++ b/pallets/invulnerables/src/weights.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weight functions needed for pallet_invulnerables.
 pub trait WeightInfo {

--- a/pallets/ocw-testing/Cargo.toml
+++ b/pallets/ocw-testing/Cargo.toml
@@ -20,7 +20,6 @@ parity-scale-codec = { workspace = true }
 scale-info = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 
 [dev-dependencies]
 sp-core = { workspace = true }
@@ -37,7 +36,6 @@ std = [
 	"sp-core/std",
 	"sp-io/std",
 	"sp-runtime/std",
-	"sp-std/std",
 ]
 try-runtime = [
 	"frame-support/try-runtime",

--- a/pallets/pooled-staking/Cargo.toml
+++ b/pallets/pooled-staking/Cargo.toml
@@ -29,7 +29,6 @@ parity-scale-codec = { workspace = true }
 scale-info = { workspace = true }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 
 [dev-dependencies]
 num-traits = { workspace = true }
@@ -52,7 +51,6 @@ std = [
 	"sp-core/std",
 	"sp-io/std",
 	"sp-runtime/std",
-	"sp-std/std",
 	"tp-maths/std",
 	"tp-traits/std",
 ]

--- a/pallets/pooled-staking/src/benchmarking.rs
+++ b/pallets/pooled-staking/src/benchmarking.rs
@@ -32,7 +32,6 @@ use {
         },
     },
     frame_system::EventRecord,
-    sp_std::prelude::*,
 };
 
 /// Minimum collator candidate stake

--- a/pallets/pooled-staking/src/benchmarking.rs
+++ b/pallets/pooled-staking/src/benchmarking.rs
@@ -22,6 +22,7 @@ use {
         HoldReason, Pallet as PooledStaking,
         PendingOperationKey::{JoiningAutoCompounding, JoiningManualRewards},
     },
+    alloc::vec,
     frame_benchmarking::{account, v2::*, BenchmarkError},
     frame_support::{
         dispatch::RawOrigin,

--- a/pallets/pooled-staking/src/calls.rs
+++ b/pallets/pooled-staking/src/calls.rs
@@ -23,6 +23,7 @@ use {
         PendingOperationKey, PendingOperationQuery, PendingOperationQueryOf, PendingOperations,
         Shares, SharesOrStake, Stake,
     },
+    alloc::vec::Vec,
     frame_support::{
         dispatch::DispatchErrorWithPostInfo,
         pallet_prelude::*,
@@ -32,7 +33,6 @@ use {
         },
     },
     sp_runtime::traits::{CheckedSub, Zero},
-    sp_std::vec::Vec,
     tp_maths::{ErrAdd, ErrSub},
 };
 

--- a/pallets/pooled-staking/src/lib.rs
+++ b/pallets/pooled-staking/src/lib.rs
@@ -32,6 +32,7 @@
 //! participate in other processes such as gouvernance.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
 
 mod calls;
 mod candidate;
@@ -70,6 +71,7 @@ pub mod pallet {
             traits::{IsCandidateEligible, Timer},
             weights::WeightInfo,
         },
+        alloc::vec::Vec,
         calls::Calls,
         core::marker::PhantomData,
         frame_support::{
@@ -84,7 +86,6 @@ pub mod pallet {
         serde::{Deserialize, Serialize},
         sp_core::Get,
         sp_runtime::{BoundedVec, Perbill},
-        sp_std::vec::Vec,
         tp_maths::MulDiv,
     };
 
@@ -559,8 +560,8 @@ pub mod pallet {
     impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
         #[cfg(feature = "try-runtime")]
         fn try_state(_n: BlockNumberFor<T>) -> Result<(), sp_runtime::TryRuntimeError> {
+            use alloc::collections::btree_set::BTreeSet;
             use frame_support::storage_alias;
-            use sp_std::collections::btree_set::BTreeSet;
 
             let mut all_candidates = BTreeSet::new();
             for (candidate, _k2) in Pools::<T>::iter_keys() {
@@ -798,7 +799,7 @@ pub mod pallet {
 
         #[cfg(feature = "runtime-benchmarks")]
         fn make_collator_eligible_candidate(collator: &Candidate<T>) {
-            use sp_std::vec;
+            use alloc::vec;
             let minimum_stake = T::MinimumSelfDelegation::get();
             T::Currency::set_balance(collator, minimum_stake + minimum_stake);
             T::EligibleCandidatesFilter::make_candidate_eligible(collator, true);

--- a/pallets/pooled-staking/src/migrations.rs
+++ b/pallets/pooled-staking/src/migrations.rs
@@ -19,7 +19,6 @@ use crate::{
     DelegatorCandidateSummaries, DelegatorCandidateSummary, Pallet, PausePoolsExtrinsics, PoolKind,
     Pools, PoolsKey,
 };
-use alloc::vec::Vec;
 use core::marker::PhantomData;
 use frame_support::{
     migrations::{MigrationId, SteppedMigration, SteppedMigrationError},
@@ -79,13 +78,13 @@ impl<T: Config> SteppedMigration for MigrationGenerateSummaries<T> {
     }
 
     #[cfg(feature = "try-runtime")]
-    fn pre_upgrade() -> Result<Vec<u8>, sp_runtime::TryRuntimeError> {
+    fn pre_upgrade() -> Result<alloc::vec::Vec<u8>, sp_runtime::TryRuntimeError> {
         // Can we test it somehow without performing the same process? (which would be useless)
         Ok(Default::default())
     }
 
     #[cfg(feature = "try-runtime")]
-    fn post_upgrade(_state: Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
+    fn post_upgrade(_state: alloc::vec::Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
         Ok(())
     }
 }

--- a/pallets/pooled-staking/src/migrations.rs
+++ b/pallets/pooled-staking/src/migrations.rs
@@ -32,9 +32,6 @@ use scale_info::TypeInfo;
 use sp_core::{ConstU32, Get, MaxEncodedLen, RuntimeDebug};
 use sp_runtime::Saturating;
 
-#[cfg(not(feature = "std"))]
-use sp_runtime::Vec;
-
 const LOG_TARGET: &str = "pallet_pooled_staking::migrations::stepped_generate_summaries";
 pub const PALLET_MIGRATIONS_ID: &[u8; 21] = b"pallet-pooled-staking";
 

--- a/pallets/pooled-staking/src/migrations.rs
+++ b/pallets/pooled-staking/src/migrations.rs
@@ -19,6 +19,7 @@ use crate::{
     DelegatorCandidateSummaries, DelegatorCandidateSummary, Pallet, PausePoolsExtrinsics, PoolKind,
     Pools, PoolsKey,
 };
+use alloc::vec::Vec;
 use core::marker::PhantomData;
 use frame_support::{
     migrations::{MigrationId, SteppedMigration, SteppedMigrationError},

--- a/pallets/pooled-staking/src/weights.rs
+++ b/pallets/pooled-staking/src/weights.rs
@@ -48,7 +48,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weight functions needed for pallet_pooled_staking.
 pub trait WeightInfo {

--- a/pallets/registrar/Cargo.toml
+++ b/pallets/registrar/Cargo.toml
@@ -28,7 +28,6 @@ scale-info = { workspace = true }
 serde = { workspace = true, features = [ "derive" ] }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 sp-trie = { workspace = true }
 tp-traits = { workspace = true }
 
@@ -59,7 +58,6 @@ std = [
 	"sp-core/std",
 	"sp-io/std",
 	"sp-runtime/std",
-	"sp-std/std",
 	"sp-trie/std",
 	"tp-traits/std",
 ]

--- a/pallets/registrar/src/benchmarks.rs
+++ b/pallets/registrar/src/benchmarks.rs
@@ -22,6 +22,7 @@ use {
         benchmark_blob::benchmark_blob, Call, Config, DepositBalanceOf, EnsureSignedByManager,
         Pallet, RegistrarHooks,
     },
+    alloc::{vec, vec::Vec},
     dp_container_chain_genesis_data::{ContainerChainGenesisData, ContainerChainGenesisDataItem},
     frame_benchmarking::{account, v2::*},
     frame_support::{
@@ -34,7 +35,6 @@ use {
     },
     frame_system::RawOrigin,
     sp_core::Get,
-    sp_std::{vec, vec::Vec},
     tp_traits::{ParaId, RegistrarHandler, RelayStorageRootProvider, SlotFrequency},
 };
 

--- a/pallets/registrar/src/lib.rs
+++ b/pallets/registrar/src/lib.rs
@@ -44,7 +44,7 @@ pub use weights::WeightInfo;
 pub use pallet::*;
 
 use {
-    alloc::collections::btree_set::BTreeSet,
+    alloc::{collections::btree_set::BTreeSet, vec, vec::Vec},
     cumulus_primitives_core::relay_chain::HeadData,
     dp_chain_state_snapshot::GenericStateProof,
     dp_container_chain_genesis_data::ContainerChainGenesisData,

--- a/pallets/registrar/src/lib.rs
+++ b/pallets/registrar/src/lib.rs
@@ -26,6 +26,7 @@
 //! storage item.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
 
 #[cfg(test)]
 mod mock;
@@ -43,6 +44,7 @@ pub use weights::WeightInfo;
 pub use pallet::*;
 
 use {
+    alloc::collections::btree_set::BTreeSet,
     cumulus_primitives_core::relay_chain::HeadData,
     dp_chain_state_snapshot::GenericStateProof,
     dp_container_chain_genesis_data::ContainerChainGenesisData,
@@ -63,7 +65,6 @@ use {
         traits::{AtLeast32BitUnsigned, Verify},
         Saturating,
     },
-    sp_std::{collections::btree_set::BTreeSet, prelude::*},
     tp_traits::{
         GetCurrentContainerChains, GetSessionContainerChains, GetSessionIndex, ParaId,
         ParathreadParams as ParathreadParamsTy, RegistrarHandler, RelayStorageRootProvider,
@@ -370,7 +371,7 @@ pub mod pallet {
 
         #[cfg(feature = "try-runtime")]
         fn try_state(_n: BlockNumberFor<T>) -> Result<(), sp_runtime::TryRuntimeError> {
-            use {scale_info::prelude::format, sp_std::collections::btree_set::BTreeSet};
+            use {alloc::collections::btree_set::BTreeSet, scale_info::prelude::format};
             // A para id can only be in 1 of [`RegisteredParaIds`, `PendingVerification`, `Paused`]
             // Get all those para ids and check for duplicates
             let mut para_ids: Vec<ParaId> = vec![];
@@ -1493,7 +1494,7 @@ pub trait RegistrarHooks {
 
 impl RegistrarHooks for () {}
 
-pub struct EnsureSignedByManager<T>(sp_std::marker::PhantomData<T>);
+pub struct EnsureSignedByManager<T>(core::marker::PhantomData<T>);
 
 impl<T> EnsureOriginWithArg<T::RuntimeOrigin, ParaId> for EnsureSignedByManager<T>
 where

--- a/pallets/registrar/src/weights.rs
+++ b/pallets/registrar/src/weights.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weight functions needed for pallet_registrar.
 pub trait WeightInfo {

--- a/pallets/services-payment/Cargo.toml
+++ b/pallets/services-payment/Cargo.toml
@@ -23,7 +23,6 @@ scale-info = { workspace = true }
 serde = { workspace = true, default-features = false, features = [ "derive" ] }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 tp-traits = { workspace = true }
 
 [dev-dependencies]
@@ -46,7 +45,6 @@ std = [
 	"sp-core/std",
 	"sp-io/std",
 	"sp-runtime/std",
-	"sp-std/std",
 	"tp-traits/std",
 ]
 runtime-benchmarks = [

--- a/pallets/services-payment/src/benchmarks.rs
+++ b/pallets/services-payment/src/benchmarks.rs
@@ -22,6 +22,7 @@ use {
         AuthorNotingInfo, BalanceOf, BlockNumberFor, Call, Config, Pallet,
         ProvideBlockProductionCost, ProvideCollatorAssignmentCost,
     },
+    alloc::vec,
     frame_benchmarking::{account, v2::*},
     frame_support::{
         assert_ok,

--- a/pallets/services-payment/src/benchmarks.rs
+++ b/pallets/services-payment/src/benchmarks.rs
@@ -29,7 +29,6 @@ use {
     },
     frame_system::RawOrigin,
     sp_runtime::Saturating,
-    sp_std::prelude::*,
     tp_traits::{AuthorNotingHook, CollatorAssignmentHook},
 };
 

--- a/pallets/services-payment/src/lib.rs
+++ b/pallets/services-payment/src/lib.rs
@@ -20,6 +20,7 @@
 //! containerChain.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
 
 #[cfg(feature = "runtime-benchmarks")]
 use tp_traits::BlockNumber;

--- a/pallets/services-payment/src/weights.rs
+++ b/pallets/services-payment/src/weights.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weight functions needed for pallet_services_payment.
 pub trait WeightInfo {

--- a/pallets/stream-payment/Cargo.toml
+++ b/pallets/stream-payment/Cargo.toml
@@ -28,7 +28,6 @@ parity-scale-codec = { workspace = true }
 scale-info = { workspace = true }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 
 [dev-dependencies]
 num-traits = { workspace = true }
@@ -53,7 +52,6 @@ std = [
 	"sp-core/std",
 	"sp-io/std",
 	"sp-runtime/std",
-	"sp-std/std",
 	"tp-maths/std",
 	"tp-traits/std",
 ]

--- a/pallets/stream-payment/src/lib.rs
+++ b/pallets/stream-payment/src/lib.rs
@@ -16,6 +16,7 @@
 
 #![doc = include_str!("../README.md")]
 #![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
 
 #[cfg(test)]
 mod mock;
@@ -33,7 +34,9 @@ pub mod weights;
 pub use weights::WeightInfo;
 
 use {
+    alloc::fmt::Debug,
     core::cmp::min,
+    core::marker::PhantomData,
     frame_support::{
         dispatch::DispatchErrorWithPostInfo,
         pallet,
@@ -53,7 +56,6 @@ use {
         traits::{AtLeast32BitUnsigned, CheckedAdd, CheckedSub, One, Saturating, Zero},
         ArithmeticError,
     },
-    sp_std::{fmt::Debug, marker::PhantomData},
 };
 
 pub use pallet::*;

--- a/pallets/stream-payment/src/weights.rs
+++ b/pallets/stream-payment/src/weights.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weight functions needed for pallet_stream_payment.
 pub trait WeightInfo {

--- a/pallets/xcm-core-buyer/Cargo.toml
+++ b/pallets/xcm-core-buyer/Cargo.toml
@@ -35,7 +35,6 @@ scale-info = { workspace = true }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 
 # Nimbus
 nimbus-primitives = { workspace = true }
@@ -65,7 +64,6 @@ std = [
 	"sp-io/std",
 	"sp-keystore/std",
 	"sp-runtime/std",
-	"sp-std/std",
 	"tp-traits/std",
 	"tp-xcm-core-buyer/std",
 	"xcm/std",

--- a/pallets/xcm-core-buyer/runtime-api/Cargo.toml
+++ b/pallets/xcm-core-buyer/runtime-api/Cargo.toml
@@ -21,7 +21,6 @@ serde = { workspace = true, optional = true, features = [ "derive" ] }
 sp-api = { workspace = true }
 sp-consensus-slots = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 thiserror = { workspace = true, optional = true }
 tp-xcm-core-buyer = { workspace = true }
 
@@ -37,7 +36,6 @@ std = [
 	"sp-api/std",
 	"sp-consensus-slots/std",
 	"sp-runtime/std",
-	"sp-std/std",
 	"thiserror",
 	"tp-xcm-core-buyer/std",
 ]

--- a/pallets/xcm-core-buyer/runtime-api/src/lib.rs
+++ b/pallets/xcm-core-buyer/runtime-api/src/lib.rs
@@ -17,13 +17,14 @@
 //! Runtime API for XCM core buyer pallet
 
 #![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
 
 pub use pallet_xcm_core_buyer::BuyingError;
 use {
+    alloc::boxed::Box,
     frame_support::sp_runtime,
     sp_consensus_slots::Slot,
     sp_runtime::{traits::Block as BlockT, RuntimeAppPublic},
-    sp_std::boxed::Box,
     tp_xcm_core_buyer::BuyCoreCollatorProof,
 };
 

--- a/pallets/xcm-core-buyer/src/lib.rs
+++ b/pallets/xcm-core-buyer/src/lib.rs
@@ -19,6 +19,7 @@
 //! This pallet allows collators to buy parathread cores on demand.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
 
 use frame_support::{Deserialize, Serialize};
 pub use pallet::*;
@@ -38,6 +39,7 @@ pub use weights::WeightInfo;
 #[cfg(feature = "runtime-benchmarks")]
 use tp_traits::BlockNumber;
 use {
+    alloc::{vec, vec::Vec},
     dp_core::ParaId,
     frame_support::{
         dispatch::GetDispatchInfo,
@@ -48,7 +50,6 @@ use {
     parity_scale_codec::EncodeLike,
     sp_consensus_slots::Slot,
     sp_runtime::traits::{AccountIdConversion, Convert, Get},
-    sp_std::{vec, vec::Vec},
     tp_traits::{
         AuthorNotingHook, AuthorNotingInfo, LatestAuthorInfoFetcher, ParathreadParams,
         SlotFrequency,
@@ -182,7 +183,7 @@ pub mod pallet {
             + EncodeLike
             + Clone
             + PartialEq
-            + sp_std::fmt::Debug
+            + alloc::fmt::Debug
             + MaxEncodedLen;
 
         /// Get the parathread params. Used to verify that the para id is a parathread.

--- a/pallets/xcm-core-buyer/src/mock.rs
+++ b/pallets/xcm-core-buyer/src/mock.rs
@@ -19,6 +19,7 @@ use {
         self as pallet_xcm_core_buyer, CheckCollatorValidity, GetPurchaseCoreCall,
         ParaIdIntoAccountTruncating, RelayXcmWeightConfigInner,
     },
+    alloc::collections::btree_map::BTreeMap,
     dp_core::ParaId,
     frame_support::{
         assert_ok,
@@ -37,7 +38,6 @@ use {
         traits::{BlakeTwo256, IdentityLookup},
         BuildStorage, RuntimeAppPublic,
     },
-    sp_std::collections::btree_map::BTreeMap,
     tp_traits::{
         ContainerChainBlockInfo, LatestAuthorInfoFetcher, ParathreadParams, SlotFrequency,
     },

--- a/pallets/xcm-core-buyer/src/weights.rs
+++ b/pallets/xcm-core-buyer/src/weights.rs
@@ -49,7 +49,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weight functions needed for pallet_xcm_core_buyer.
 pub trait WeightInfo {

--- a/primitives/bridge/Cargo.toml
+++ b/primitives/bridge/Cargo.toml
@@ -30,7 +30,6 @@ snowbridge-pallet-outbound-queue = { workspace = true }
 snowbridge-pallet-system = { workspace = true }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 xcm = { workspace = true }
 xcm-builder = { workspace = true }
 xcm-executor = { workspace = true }
@@ -63,7 +62,6 @@ std = [
 	"snowbridge-pallet-system/std",
 	"sp-core/std",
 	"sp-runtime/std",
-	"sp-std/std",
 	"xcm-builder/std",
 	"xcm-executor/std",
 	"xcm/std",

--- a/primitives/bridge/src/custom_do_process_message.rs
+++ b/primitives/bridge/src/custom_do_process_message.rs
@@ -16,6 +16,7 @@
 
 use {
     super::*,
+    alloc::boxed::Box,
     frame_support::{
         ensure,
         traits::{Defensive, ProcessMessage, ProcessMessageError},
@@ -25,7 +26,6 @@ use {
         CommittedMessage, MessageLeaves, Messages, Nonce, ProcessMessageOriginOf, WeightInfo,
     },
     sp_runtime::traits::Hash,
-    sp_std::boxed::Box,
 };
 
 /// Alternative to [snowbridge_pallet_outbound_queue::Pallet::process_message] using a different

--- a/primitives/bridge/src/custom_send_message.rs
+++ b/primitives/bridge/src/custom_send_message.rs
@@ -15,8 +15,8 @@
 // along with Tanssi.  If not, see <http://www.gnu.org/licenses/>
 
 use {
-    super::*, frame_support::traits::EnqueueMessage, snowbridge_core::PRIMARY_GOVERNANCE_CHANNEL,
-    snowbridge_outbound_queue_primitives::SendError, sp_std::marker::PhantomData,
+    super::*, core::marker::PhantomData, frame_support::traits::EnqueueMessage,
+    snowbridge_core::PRIMARY_GOVERNANCE_CHANNEL, snowbridge_outbound_queue_primitives::SendError,
 };
 
 /// Alternative to [snowbridge_pallet_outbound_queue::Pallet::deliver] using a different

--- a/primitives/bridge/src/generic_token_message_processor.rs
+++ b/primitives/bridge/src/generic_token_message_processor.rs
@@ -16,12 +16,12 @@
 
 use {
     super::*,
+    core::marker::PhantomData,
     parity_scale_codec::DecodeAll,
     snowbridge_inbound_queue_primitives::v1::{
         Command as SnowbridgeCommand, Envelope, MessageProcessor, MessageV1, VersionedXcmMessage,
     },
     sp_runtime::DispatchError,
-    sp_std::marker::PhantomData,
 };
 
 /// Generic token message processor to handle both native and foreign token commands, as well as token registration.

--- a/primitives/bridge/src/lib.rs
+++ b/primitives/bridge/src/lib.rs
@@ -18,6 +18,7 @@
 //! with each other or with mocks.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
 
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarks;
@@ -29,6 +30,7 @@ pub mod snowbridge_outbound_token_transfer;
 pub mod symbiotic_message_processor;
 
 use {
+    alloc::vec::Vec,
     core::marker::PhantomData,
     cumulus_primitives_core::{
         relay_chain::{AccountId, Balance},
@@ -52,12 +54,11 @@ use {
     snowbridge_pallet_outbound_queue::send_message_impl::Ticket,
     sp_core::{blake2_256, hashing, H256},
     sp_runtime::{app_crypto::sp_core, traits::Convert, RuntimeDebug},
-    sp_std::vec::Vec,
 };
 
-// Separate import as rustfmt wrongly change it to `sp_std::vec::self`, which is the module instead
+// Separate import as rustfmt wrongly change it to `alloc::vec::self`, which is the module instead
 // of the macro.
-use sp_std::vec;
+use alloc::vec;
 
 pub use {
     custom_do_process_message::{ConstantGasMeter, CustomProcessSnowbridgeMessage},

--- a/primitives/bridge/src/snowbridge_outbound_token_transfer.rs
+++ b/primitives/bridge/src/snowbridge_outbound_token_transfer.rs
@@ -18,6 +18,7 @@
 // Rewrite of the following code which cause issues as Tanssi is not a parachain
 // https://github.com/moondance-labs/polkadot-sdk/blob/tanssi-polkadot-stable2412/bridges/snowbridge/primitives/router/src/outbound/mod.rs#L98
 
+use core::iter::Peekable;
 use core::marker::PhantomData;
 use core::slice::Iter;
 use frame_support::{ensure, traits::Get};
@@ -26,7 +27,6 @@ use snowbridge_core::{AgentId, ChannelId, TokenId};
 use snowbridge_outbound_queue_primitives::v1::message::{Command, Message, SendMessage};
 use sp_core::H160;
 use sp_runtime::traits::{MaybeEquivalence, TryConvert};
-use sp_std::{iter::Peekable, prelude::*};
 use xcm::prelude::*;
 use xcm::{
     latest::SendError::{MissingArgument, NotApplicable},

--- a/primitives/bridge/src/snowbridge_outbound_token_transfer.rs
+++ b/primitives/bridge/src/snowbridge_outbound_token_transfer.rs
@@ -18,6 +18,7 @@
 // Rewrite of the following code which cause issues as Tanssi is not a parachain
 // https://github.com/moondance-labs/polkadot-sdk/blob/tanssi-polkadot-stable2412/bridges/snowbridge/primitives/router/src/outbound/mod.rs#L98
 
+use alloc::vec::Vec;
 use core::iter::Peekable;
 use core::marker::PhantomData;
 use core::slice::Iter;

--- a/primitives/bridge/src/symbiotic_message_processor.rs
+++ b/primitives/bridge/src/symbiotic_message_processor.rs
@@ -15,12 +15,12 @@
 // along with Tanssi.  If not, see <http://www.gnu.org/licenses/>
 
 use {
+    alloc::vec::Vec,
     frame_support::pallet_prelude::*,
     parity_scale_codec::DecodeAll,
     snowbridge_core::{Channel, PRIMARY_GOVERNANCE_CHANNEL},
     snowbridge_inbound_queue_primitives::v1::{Envelope, MessageProcessor},
     sp_runtime::DispatchError,
-    sp_std::vec::Vec,
 };
 
 /// Magic bytes are added in every payload intended for this processor to make sure

--- a/primitives/data-preservers-common/Cargo.toml
+++ b/primitives/data-preservers-common/Cargo.toml
@@ -22,7 +22,6 @@ scale-info = { workspace = true }
 serde = { workspace = true }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 tp-stream-payment-common = { workspace = true }
 tp-traits = { workspace = true }
 
@@ -41,7 +40,6 @@ std = [
 	"serde/std",
 	"sp-core/std",
 	"sp-runtime/std",
-	"sp-std/std",
 	"tp-stream-payment-common/std",
 	"tp-traits/std",
 ]

--- a/primitives/invulnerables-filter-common/Cargo.toml
+++ b/primitives/invulnerables-filter-common/Cargo.toml
@@ -12,7 +12,6 @@ workspace = true
 [dependencies]
 pallet-invulnerables = { workspace = true }
 primitives = { workspace = true }
-sp-std = { workspace = true }
 tp-traits = { workspace = true }
 
 [features]
@@ -20,7 +19,6 @@ default = [ "std" ]
 std = [
 	"pallet-invulnerables/std",
 	"primitives/std",
-	"sp-std/std",
 	"tp-traits/std",
 ]
 runtime-benchmarks = [

--- a/primitives/invulnerables-filter-common/src/lib.rs
+++ b/primitives/invulnerables-filter-common/src/lib.rs
@@ -15,7 +15,7 @@
 // along with Tanssi.  If not, see <http://www.gnu.org/licenses/>
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use {primitives::AccountId, sp_std::marker::PhantomData, tp_traits::InvulnerablesHelper};
+use {core::marker::PhantomData, primitives::AccountId, tp_traits::InvulnerablesHelper};
 
 // Common implementation of the InvulnerablesHelper trait for all chains supporting pallet_invulnerables.
 pub struct InvulnerablesFilter<Runtime>(PhantomData<Runtime>);

--- a/primitives/parathread-filter-common/Cargo.toml
+++ b/primitives/parathread-filter-common/Cargo.toml
@@ -12,7 +12,6 @@ workspace = true
 [dependencies]
 pallet-registrar = { workspace = true }
 pallet-session = { workspace = true }
-sp-std = { workspace = true }
 tp-traits = { workspace = true }
 
 [features]
@@ -20,7 +19,6 @@ default = [ "std" ]
 std = [
 	"pallet-registrar/std",
 	"pallet-session/std",
-	"sp-std/std",
 	"tp-traits/std",
 ]
 runtime-benchmarks = [

--- a/primitives/parathread-filter-common/src/lib.rs
+++ b/primitives/parathread-filter-common/src/lib.rs
@@ -14,8 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with Tanssi.  If not, see <http://www.gnu.org/licenses/>
 #![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
+
 use {
-    sp_std::{collections::btree_set::BTreeSet, marker::PhantomData},
+    alloc::collections::btree_set::BTreeSet,
+    core::marker::PhantomData,
     tp_traits::{GetSessionContainerChains, ParaId, ParathreadHelper},
 };
 

--- a/primitives/stream-payment-common/Cargo.toml
+++ b/primitives/stream-payment-common/Cargo.toml
@@ -21,7 +21,6 @@ scale-info = { workspace = true }
 serde = { workspace = true }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 tp-traits = { workspace = true }
 
 [features]
@@ -38,7 +37,6 @@ std = [
 	"serde/std",
 	"sp-core/std",
 	"sp-runtime/std",
-	"sp-std/std",
 	"tp-traits/std",
 ]
 runtime-benchmarks = [

--- a/primitives/traits/Cargo.toml
+++ b/primitives/traits/Cargo.toml
@@ -20,7 +20,6 @@ scale-info = { workspace = true }
 serde = { workspace = true }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 
 # Cumulus
 cumulus-primitives-core = { workspace = true }
@@ -37,7 +36,6 @@ std = [
 	"serde/std",
 	"sp-core/std",
 	"sp-runtime/std",
-	"sp-std/std",
 ]
 runtime-benchmarks = [
 	"cumulus-primitives-core/runtime-benchmarks",

--- a/primitives/traits/src/lib.rs
+++ b/primitives/traits/src/lib.rs
@@ -19,6 +19,8 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+extern crate alloc;
+
 pub mod alias;
 pub mod prod_or_fast;
 
@@ -31,7 +33,13 @@ pub use {
     dp_chain_state_snapshot::{GenericStateProof, ReadEntryErr},
     dp_container_chain_genesis_data::ContainerChainGenesisDataItem,
 };
+
 use {
+    alloc::{
+        collections::{btree_map::BTreeMap, btree_set::BTreeSet},
+        vec,
+        vec::Vec,
+    },
     core::marker::PhantomData,
     frame_support::{
         dispatch::DispatchErrorWithPostInfo,
@@ -49,15 +57,7 @@ use {
         traits::{CheckedAdd, CheckedMul},
         ArithmeticError, DispatchResult, Perbill, RuntimeDebug,
     },
-    sp_std::{
-        collections::{btree_map::BTreeMap, btree_set::BTreeSet},
-        vec::Vec,
-    },
 };
-
-// Separate import as rustfmt wrongly change it to `sp_std::vec::self`, which is the module instead
-// of the macro.
-use sp_std::vec;
 
 /// The collator-assignment hook to react to collators being assigned to container chains.
 pub trait CollatorAssignmentHook<Balance> {

--- a/primitives/xcm-commons/Cargo.toml
+++ b/primitives/xcm-commons/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 [dependencies]
 frame-support = { workspace = true }
 log = { workspace = true }
-sp-std = { workspace = true }
 xcm = { workspace = true }
 
 [features]
@@ -23,6 +22,5 @@ default = [
 std = [
 	"frame-support/std",
 	"log/std",
-	"sp-std/std",
 	"xcm/std",
 ]

--- a/primitives/xcm-commons/src/lib.rs
+++ b/primitives/xcm-commons/src/lib.rs
@@ -61,7 +61,7 @@ impl frame_support::traits::ContainsPair<Asset, Location> for NativeAssetReserve
 
 /// Filter to ensure an ETH asset is coming from a trusted Ethereum location.
 pub struct EthereumAssetReserve<EthereumLocation, EthereumNetwork>(
-    sp_std::marker::PhantomData<(EthereumLocation, EthereumNetwork)>,
+    core::marker::PhantomData<(EthereumLocation, EthereumNetwork)>,
 );
 impl<EthereumLocation, EthereumNetwork> frame_support::traits::ContainsPair<Asset, Location>
     for EthereumAssetReserve<EthereumLocation, EthereumNetwork>

--- a/primitives/xcm-core-buyer/Cargo.toml
+++ b/primitives/xcm-core-buyer/Cargo.toml
@@ -15,7 +15,6 @@ parity-scale-codec = { workspace = true }
 scale-info = { workspace = true }
 sp-keystore = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 tp-traits = { workspace = true }
 
 [features]
@@ -26,7 +25,6 @@ std = [
 	"scale-info/std",
 	"sp-keystore/std",
 	"sp-runtime/std",
-	"sp-std/std",
 	"tp-traits/std",
 ]
 runtime-benchmarks = [

--- a/primitives/xcm-core-buyer/src/lib.rs
+++ b/primitives/xcm-core-buyer/src/lib.rs
@@ -18,14 +18,15 @@
 //! as well as the client.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
 
 use {
+    alloc::vec::Vec,
     frame_support::{
         pallet_prelude::{Decode, DecodeWithMemTracking, Encode, TypeInfo},
         CloneNoBound, DebugNoBound,
     },
     sp_runtime::{app_crypto::AppCrypto, RuntimeAppPublic},
-    sp_std::vec::Vec,
     tp_traits::ParaId,
 };
 


### PR DESCRIPTION
Seems like parity is planning to deprecated/remove sp_std (https://github.com/paritytech/polkadot-sdk/pull/5010), so we do the same by using their equivalent core/alloc imports.