### PR TITLE
Remove unused lastest_rt from set-tags job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,18 +43,6 @@ jobs:
               uses: actions/checkout@v4
               with:
                   ref: ${{ steps.check-git-ref.outputs.git_ref }}
-            - name: Get Latest RT Release
-              id: get-latest-rt
-              run: |
-                RELEASES_JSON=$(curl -s https://api.github.com/repos/moondance-labs/tanssi/releases)
-                LATEST_RUNTIME_RELEASE=$(jq -r '.[]
-                  | select(
-                      .tag_name | test("runtime";"i")
-                    )
-                  | .tag_name' <<<"$RELEASES_JSON" | head -n1)
-                [[ -n $LATEST_RUNTIME_RELEASE ]]
-                echo $LATEST_RUNTIME_RELEASE
-                echo "latest_rt=$LATEST_RUNTIME_RELEASE" >> $GITHUB_OUTPUT
             - name: Get Sha
               id: get-sha
               run: |


### PR DESCRIPTION
It was causing errors because of the http request to fetch the list of releases. But that was not needed so we can remove it.