### PR TITLE
Fix for udeps if it is exists already.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -422,7 +422,7 @@ jobs:
             key: cargo-bin-udeps-nightly-${{ runner.os }}
 
         - name: Install cargo-udeps (nightly)
-          run: cargo +nightly install cargo-udeps
+          run: cargo +nightly install cargo-udeps --force
 
         - name: Check for unused dependencies
           run: |


### PR DESCRIPTION
**Description**:
This PR adds `--force` flag to disable the error if the package already exists.