### PR TITLE
Avoid recompiling all binaries on git commit hash change

### DIFF
--- a/.github/workflows/docker-runtime-draft.yml
+++ b/.github/workflows/docker-runtime-draft.yml
@@ -59,10 +59,10 @@ jobs:
         run: rustup show
       - name: Build Node tanssi-relay
         if:  contains(needs.set-tags.outputs.git_branch, 'starlight')
-        run: cargo build -p tanssi-relay --profile=production
+        run: cargo build -p tanssi-relay --profile=production --features=include-git-hash-in-version
       - name: Build Node parachains
         if:  contains(needs.set-tags.outputs.git_branch, 'para')
-        run: cargo build -p tanssi-node -p container-chain-frontier-node -p container-chain-simple-node --profile=production
+        run: cargo build -p tanssi-node -p container-chain-frontier-node -p container-chain-simple-node --profile=production --features=include-git-hash-in-version
       - name: Save binary (parachain)
         if: ${{ matrix.cpu == '' && contains(needs.set-tags.outputs.git_branch, 'para') }}
         uses: ./.github/workflow-templates/copy-parachain-node-binaries

--- a/.github/workflows/prepare-binary.yml
+++ b/.github/workflows/prepare-binary.yml
@@ -30,7 +30,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install protobuf-compiler
       - name: Build Node
-        run: cargo build --profile=production --all
+        run: cargo build --profile=production --all --features=include-git-hash-in-version
 
       - name: Copy parachain node binaries
         uses: ./.github/workflow-templates/copy-parachain-node-binaries

--- a/.github/workflows/prepare-tanssi-relay-binary.yml
+++ b/.github/workflows/prepare-tanssi-relay-binary.yml
@@ -30,7 +30,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install protobuf-compiler
       - name: Build Node
-        run: cargo build --profile=production -p tanssi-relay
+        run: cargo build --profile=production -p tanssi-relay --features=include-git-hash-in-version
 
       - name: Copy relaychain node binaries
         uses: ./.github/workflow-templates/copy-relaychain-node-binaries

--- a/.github/workflows/publish-binary-tanssi-solochain.yml
+++ b/.github/workflows/publish-binary-tanssi-solochain.yml
@@ -43,7 +43,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install protobuf-compiler
       - name: Build Node
-        run: cargo build --profile=production -p tanssi-relay
+        run: cargo build --profile=production -p tanssi-relay --features=include-git-hash-in-version
 
       - name: Copy relaychain node binaries
         uses: ./.github/workflow-templates/copy-relaychain-node-binaries

--- a/.github/workflows/publish-binary.yml
+++ b/.github/workflows/publish-binary.yml
@@ -44,7 +44,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install protobuf-compiler
       - name: Build Node
-        run: cargo build --profile=production --all
+        run: cargo build --profile=production --all --features=include-git-hash-in-version
 
       - name: Copy parachain node binaries
         uses: ./.github/workflow-templates/copy-parachain-node-binaries

--- a/chains/container-chains/nodes/frontier/Cargo.toml
+++ b/chains/container-chains/nodes/frontier/Cargo.toml
@@ -122,6 +122,7 @@ substrate-build-script-utils = { workspace = true }
 
 [features]
 default = []
+include-git-hash-in-version = []
 runtime-benchmarks = [
 	"container-chain-template-frontier-runtime/runtime-benchmarks",
 	"cumulus-primitives-core/runtime-benchmarks",

--- a/chains/container-chains/nodes/frontier/build.rs
+++ b/chains/container-chains/nodes/frontier/build.rs
@@ -14,10 +14,33 @@
 // You should have received a copy of the GNU General Public License
 // along with Tanssi.  If not, see <http://www.gnu.org/licenses/>.
 
-use substrate_build_script_utils::{generate_cargo_keys, rerun_if_git_head_changed};
-
 fn main() {
-    generate_cargo_keys();
+    #[cfg(feature = "include-git-hash-in-version")]
+    {
+        substrate_build_script_utils::generate_cargo_keys();
+        substrate_build_script_utils::rerun_if_git_head_changed();
+    }
+    #[cfg(not(feature = "include-git-hash-in-version"))]
+    {
+        let commit = "dev";
+        println!("cargo:rustc-env=SUBSTRATE_CLI_COMMIT_HASH={commit}");
+        println!(
+            "cargo:rustc-env=SUBSTRATE_CLI_IMPL_VERSION={}",
+            get_version(&commit)
+        );
+        // Never re-run this build script
+        println!("cargo:rerun-if-changed=build.rs");
+    }
+}
 
-    rerun_if_git_head_changed();
+#[cfg(not(feature = "include-git-hash-in-version"))]
+fn get_version(impl_commit: &str) -> String {
+    let commit_dash = if impl_commit.is_empty() { "" } else { "-" };
+
+    format!(
+        "{}{}{}",
+        std::env::var("CARGO_PKG_VERSION").unwrap_or_default(),
+        commit_dash,
+        impl_commit
+    )
 }

--- a/chains/container-chains/nodes/simple/Cargo.toml
+++ b/chains/container-chains/nodes/simple/Cargo.toml
@@ -106,6 +106,7 @@ substrate-build-script-utils = { workspace = true }
 
 [features]
 default = []
+include-git-hash-in-version = []
 runtime-benchmarks = [
 	"container-chain-template-simple-runtime/runtime-benchmarks",
 	"cumulus-primitives-core/runtime-benchmarks",

--- a/chains/container-chains/nodes/simple/build.rs
+++ b/chains/container-chains/nodes/simple/build.rs
@@ -14,10 +14,33 @@
 // You should have received a copy of the GNU General Public License
 // along with Tanssi.  If not, see <http://www.gnu.org/licenses/>.
 
-use substrate_build_script_utils::{generate_cargo_keys, rerun_if_git_head_changed};
-
 fn main() {
-    generate_cargo_keys();
+    #[cfg(feature = "include-git-hash-in-version")]
+    {
+        substrate_build_script_utils::generate_cargo_keys();
+        substrate_build_script_utils::rerun_if_git_head_changed();
+    }
+    #[cfg(not(feature = "include-git-hash-in-version"))]
+    {
+        let commit = "dev";
+        println!("cargo:rustc-env=SUBSTRATE_CLI_COMMIT_HASH={commit}");
+        println!(
+            "cargo:rustc-env=SUBSTRATE_CLI_IMPL_VERSION={}",
+            get_version(&commit)
+        );
+        // Never re-run this build script
+        println!("cargo:rerun-if-changed=build.rs");
+    }
+}
 
-    rerun_if_git_head_changed();
+#[cfg(not(feature = "include-git-hash-in-version"))]
+fn get_version(impl_commit: &str) -> String {
+    let commit_dash = if impl_commit.is_empty() { "" } else { "-" };
+
+    format!(
+        "{}{}{}",
+        std::env::var("CARGO_PKG_VERSION").unwrap_or_default(),
+        commit_dash,
+        impl_commit
+    )
 }

--- a/chains/orchestrator-paras/node/Cargo.toml
+++ b/chains/orchestrator-paras/node/Cargo.toml
@@ -162,4 +162,5 @@ try-runtime = [
 ]
 
 fast-runtime = [ "dancebox-runtime/fast-runtime", "flashbox-runtime/fast-runtime" ]
+include-git-hash-in-version = []
 metadata-hash = [ "dancebox-runtime/metadata-hash", "flashbox-runtime/metadata-hash" ]

--- a/chains/orchestrator-paras/node/build.rs
+++ b/chains/orchestrator-paras/node/build.rs
@@ -12,12 +12,35 @@
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with Tanssi.  If not, see <http://www.gnu.org/licenses/>
-
-use substrate_build_script_utils::{generate_cargo_keys, rerun_if_git_head_changed};
+// along with Tanssi.  If not, see <http://www.gnu.org/licenses/>.
 
 fn main() {
-    generate_cargo_keys();
+    #[cfg(feature = "include-git-hash-in-version")]
+    {
+        substrate_build_script_utils::generate_cargo_keys();
+        substrate_build_script_utils::rerun_if_git_head_changed();
+    }
+    #[cfg(not(feature = "include-git-hash-in-version"))]
+    {
+        let commit = "dev";
+        println!("cargo:rustc-env=SUBSTRATE_CLI_COMMIT_HASH={commit}");
+        println!(
+            "cargo:rustc-env=SUBSTRATE_CLI_IMPL_VERSION={}",
+            get_version(&commit)
+        );
+        // Never re-run this build script
+        println!("cargo:rerun-if-changed=build.rs");
+    }
+}
 
-    rerun_if_git_head_changed();
+#[cfg(not(feature = "include-git-hash-in-version"))]
+fn get_version(impl_commit: &str) -> String {
+    let commit_dash = if impl_commit.is_empty() { "" } else { "-" };
+
+    format!(
+        "{}{}{}",
+        std::env::var("CARGO_PKG_VERSION").unwrap_or_default(),
+        commit_dash,
+        impl_commit
+    )
 }

--- a/chains/orchestrator-relays/client/cli/Cargo.toml
+++ b/chains/orchestrator-relays/client/cli/Cargo.toml
@@ -60,6 +60,7 @@ cli = [
 db = [ "polkadot-service/db" ]
 fast-runtime = [ "polkadot-service?/fast-runtime", "tanssi-relay-service?/fast-runtime" ]
 full-node = [ "polkadot-service/full-node" ]
+include-git-hash-in-version = []
 pyroscope = [ "pyro", "pyroscope_pprofrs" ]
 runtime-benchmarks = [
 	"frame-benchmarking-cli?/runtime-benchmarks",

--- a/chains/orchestrator-relays/client/cli/build.rs
+++ b/chains/orchestrator-relays/client/cli/build.rs
@@ -18,8 +18,34 @@ fn main() {
     if let Ok(profile) = std::env::var("PROFILE") {
         println!("cargo:rustc-cfg=build_type=\"{}\"", profile);
     }
-    substrate_build_script_utils::generate_cargo_keys();
-    // For the node/worker version check, make sure we always rebuild the node when the version
-    // changes.
-    substrate_build_script_utils::rerun_if_git_head_changed();
+    #[cfg(feature = "include-git-hash-in-version")]
+    {
+        substrate_build_script_utils::generate_cargo_keys();
+        // For the node/worker version check, make sure we always rebuild the node and binary workers
+        // when the version changes.
+        substrate_build_script_utils::rerun_if_git_head_changed();
+    }
+    #[cfg(not(feature = "include-git-hash-in-version"))]
+    {
+        let commit = "dev";
+        println!("cargo:rustc-env=SUBSTRATE_CLI_COMMIT_HASH={commit}");
+        println!(
+            "cargo:rustc-env=SUBSTRATE_CLI_IMPL_VERSION={}",
+            get_version(&commit)
+        );
+        // Never re-run this build script
+        println!("cargo:rerun-if-changed=build.rs");
+    }
+}
+
+#[cfg(not(feature = "include-git-hash-in-version"))]
+fn get_version(impl_commit: &str) -> String {
+    let commit_dash = if impl_commit.is_empty() { "" } else { "-" };
+
+    format!(
+        "{}{}{}",
+        std::env::var("CARGO_PKG_VERSION").unwrap_or_default(),
+        commit_dash,
+        impl_commit
+    )
 }

--- a/chains/orchestrator-relays/node/tanssi-relay/Cargo.toml
+++ b/chains/orchestrator-relays/node/tanssi-relay/Cargo.toml
@@ -47,14 +47,14 @@ substrate-build-script-utils = { workspace = true }
 [features]
 fast-runtime = [ "tanssi-relay-cli/fast-runtime" ]
 force-debug = [ "sp-debug-derive/force-debug" ]
+include-git-hash-in-version = []
+metadata-hash = [
+	"tanssi-relay-cli/metadata-hash",
+]
 pyroscope = [ "tanssi-relay-cli/pyroscope" ]
 runtime-benchmarks = [ "tanssi-relay-cli/runtime-benchmarks" ]
 runtime-metrics = [ "tanssi-relay-cli/runtime-metrics" ]
 try-runtime = [ "tanssi-relay-cli/try-runtime" ]
-
-metadata-hash = [
-	"tanssi-relay-cli/metadata-hash",
-]
 
 # Enables timeout-based tests supposed to be run only in CI environment as they may be flaky
 # when run locally depending on system load

--- a/chains/orchestrator-relays/node/tanssi-relay/build.rs
+++ b/chains/orchestrator-relays/node/tanssi-relay/build.rs
@@ -15,8 +15,34 @@
 // along with Tanssi.  If not, see <http://www.gnu.org/licenses/>
 
 fn main() {
-    substrate_build_script_utils::generate_cargo_keys();
-    // For the node/worker version check, make sure we always rebuild the node and binary workers
-    // when the version changes.
-    substrate_build_script_utils::rerun_if_git_head_changed();
+    #[cfg(feature = "include-git-hash-in-version")]
+    {
+        substrate_build_script_utils::generate_cargo_keys();
+        // For the node/worker version check, make sure we always rebuild the node and binary workers
+        // when the version changes.
+        substrate_build_script_utils::rerun_if_git_head_changed();
+    }
+    #[cfg(not(feature = "include-git-hash-in-version"))]
+    {
+        let commit = "dev";
+        println!("cargo:rustc-env=SUBSTRATE_CLI_COMMIT_HASH={commit}");
+        println!(
+            "cargo:rustc-env=SUBSTRATE_CLI_IMPL_VERSION={}",
+            get_version(&commit)
+        );
+        // Never re-run this build script
+        println!("cargo:rerun-if-changed=build.rs");
+    }
+}
+
+#[cfg(not(feature = "include-git-hash-in-version"))]
+fn get_version(impl_commit: &str) -> String {
+    let commit_dash = if impl_commit.is_empty() { "" } else { "-" };
+
+    format!(
+        "{}{}{}",
+        std::env::var("CARGO_PKG_VERSION").unwrap_or_default(),
+        commit_dash,
+        impl_commit
+    )
 }

--- a/client/node-common/Cargo.toml
+++ b/client/node-common/Cargo.toml
@@ -83,3 +83,6 @@ cumulus-relay-chain-interface = { workspace = true }
 
 [build-dependencies]
 substrate-build-script-utils = { workspace = true }
+
+[features]
+include-git-hash-in-version = []

--- a/client/node-common/build.rs
+++ b/client/node-common/build.rs
@@ -14,10 +14,33 @@
 // You should have received a copy of the GNU General Public License
 // along with Tanssi.  If not, see <http://www.gnu.org/licenses/>.
 
-use substrate_build_script_utils::{generate_cargo_keys, rerun_if_git_head_changed};
-
 fn main() {
-    generate_cargo_keys();
+    #[cfg(feature = "include-git-hash-in-version")]
+    {
+        substrate_build_script_utils::generate_cargo_keys();
+        substrate_build_script_utils::rerun_if_git_head_changed();
+    }
+    #[cfg(not(feature = "include-git-hash-in-version"))]
+    {
+        let commit = "dev";
+        println!("cargo:rustc-env=SUBSTRATE_CLI_COMMIT_HASH={commit}");
+        println!(
+            "cargo:rustc-env=SUBSTRATE_CLI_IMPL_VERSION={}",
+            get_version(&commit)
+        );
+        // Never re-run this build script
+        println!("cargo:rerun-if-changed=build.rs");
+    }
+}
 
-    rerun_if_git_head_changed();
+#[cfg(not(feature = "include-git-hash-in-version"))]
+fn get_version(impl_commit: &str) -> String {
+    let commit_dash = if impl_commit.is_empty() { "" } else { "-" };
+
+    format!(
+        "{}{}{}",
+        std::env::var("CARGO_PKG_VERSION").unwrap_or_default(),
+        commit_dash,
+        impl_commit
+    )
 }

--- a/client/service-container-chain/Cargo.toml
+++ b/client/service-container-chain/Cargo.toml
@@ -95,6 +95,8 @@ substrate-build-script-utils = { workspace = true }
 
 [features]
 default = []
+fast-runtime = [ "dancebox-runtime/fast-runtime" ]
+include-git-hash-in-version = []
 runtime-benchmarks = [
 	"cumulus-primitives-core/runtime-benchmarks",
 	"dancebox-runtime/runtime-benchmarks",
@@ -113,5 +115,3 @@ try-runtime = [
 	"pallet-data-preservers/try-runtime",
 	"sp-runtime/try-runtime",
 ]
-
-fast-runtime = [ "dancebox-runtime/fast-runtime" ]

--- a/client/service-container-chain/build.rs
+++ b/client/service-container-chain/build.rs
@@ -12,12 +12,35 @@
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with Tanssi.  If not, see <http://www.gnu.org/licenses/>
-
-use substrate_build_script_utils::{generate_cargo_keys, rerun_if_git_head_changed};
+// along with Tanssi.  If not, see <http://www.gnu.org/licenses/>.
 
 fn main() {
-    generate_cargo_keys();
+    #[cfg(feature = "include-git-hash-in-version")]
+    {
+        substrate_build_script_utils::generate_cargo_keys();
+        substrate_build_script_utils::rerun_if_git_head_changed();
+    }
+    #[cfg(not(feature = "include-git-hash-in-version"))]
+    {
+        let commit = "dev";
+        println!("cargo:rustc-env=SUBSTRATE_CLI_COMMIT_HASH={commit}");
+        println!(
+            "cargo:rustc-env=SUBSTRATE_CLI_IMPL_VERSION={}",
+            get_version(&commit)
+        );
+        // Never re-run this build script
+        println!("cargo:rerun-if-changed=build.rs");
+    }
+}
 
-    rerun_if_git_head_changed();
+#[cfg(not(feature = "include-git-hash-in-version"))]
+fn get_version(impl_commit: &str) -> String {
+    let commit_dash = if impl_commit.is_empty() { "" } else { "-" };
+
+    format!(
+        "{}{}{}",
+        std::env::var("CARGO_PKG_VERSION").unwrap_or_default(),
+        commit_dash,
+        impl_commit
+    )
 }

--- a/test/suites/smoke-test-common-all/test-rpc-version.ts
+++ b/test/suites/smoke-test-common-all/test-rpc-version.ts
@@ -1,0 +1,29 @@
+import "@tanssi/api-augment";
+
+import { beforeAll, describeSuite, expect } from "@moonwall/cli";
+import type { ApiPromise } from "@polkadot/api";
+
+describeSuite({
+    id: "S16",
+    title: "Ensure RPC version is not a dev version",
+    foundationMethods: "read_only",
+    testCases: ({ context, it, log }) => {
+        let api: ApiPromise;
+
+        beforeAll(async () => {
+            api = context.polkadotJs();
+        });
+
+        it({
+            id: "C100",
+            title: "should not contain dev version",
+            test: async () => {
+                const rpcVersion = (await api.rpc.system.version()).toString();
+
+                expect(rpcVersion).to.not.contain("-dev");
+                // Version should be something like 0.14.0-77200a65234
+                expect(rpcVersion).to.match(/^\d+\.\d+\.\d+-[a-z0-9]+$/);
+            },
+        });
+    },
+});


### PR DESCRIPTION
I noticed that when switching to a different git branch all binaries need to be recompiled even if their code has not changed. This adds several minutes of compilation that could be avoided.

That happens because the `build.rs` scripts are configured to re-run when the git hash changes. That's needed because the git hash is part of the version string, as in `0.14.0-77200a65234`.

So this PR adds a new feature flag to disable this by default, and instead show a version `0.14.0-dev`. This avoids the recompilations. Production builds must pass this new feature flag if they want to show the version with the git hash.

I wanted to do `if env!("PROFILE") == "production"` to detect when to use the git hash, but that doesn't work because the profile can only be "debug" or "release", so we cannot distinguish "production" from "release".

How to test:

```
cargo build --release --features fast-runtime,force-debug
git commit --allow-empty -m 'empty-commit'
cargo build --release --features fast-runtime,force-debug
# the second command should be instant, without this PR it takes a few minutes
```

Also includes a smoke test to ensure we don't deploy the `-dev` version.