### PR TITLE
reduce per origin location assets to 10

### DIFF
--- a/chains/container-chains/runtime-templates/frontier/src/xcm_config.rs
+++ b/chains/container-chains/runtime-templates/frontier/src/xcm_config.rs
@@ -473,7 +473,7 @@ impl pallet_asset_rate::Config for Runtime {
 }
 
 parameter_types! {
-    pub const TrustPolicyMaxAssets: u32 = 1000;
+    pub const TrustPolicyMaxAssets: u32 = 10;
     pub const AllNativeTrustPolicy: DefaultTrustPolicy = DefaultTrustPolicy::AllNative;
     pub const AllNeverTrustPolicy: DefaultTrustPolicy = DefaultTrustPolicy::Never;
 }

--- a/chains/container-chains/runtime-templates/simple/src/xcm_config.rs
+++ b/chains/container-chains/runtime-templates/simple/src/xcm_config.rs
@@ -433,7 +433,7 @@ pub type AssetRateAsMultiplier =
     >;
 
 parameter_types! {
-    pub const TrustPolicyMaxAssets: u32 = 1000;
+    pub const TrustPolicyMaxAssets: u32 = 10;
     pub const AllNativeTrustPolicy: DefaultTrustPolicy = DefaultTrustPolicy::AllNative;
     pub const AllNeverTrustPolicy: DefaultTrustPolicy = DefaultTrustPolicy::Never;
 }


### PR DESCRIPTION
Which should decrease the pov measured in xcm transfers on containers