### PR TITLE
change costs constants for rt api in dev tests

### DIFF
--- a/test/suites/common-tanssi/services-payment/test_service_payment_removes_tank_money_and_burns.ts
+++ b/test/suites/common-tanssi/services-payment/test_service_payment_removes_tank_money_and_burns.ts
@@ -6,6 +6,7 @@ import type { ApiPromise } from "@polkadot/api";
 import { fetchIssuance, jumpSessions } from "utils";
 import { paraIdTank } from "utils";
 import { STARLIGHT_VERSIONS_TO_EXCLUDE_FROM_SERVICES_PAYMENT, checkCallIsFiltered } from "helpers";
+import { type BN } from "@polkadot/util";
 
 describeSuite({
     id: "COMM0201",
@@ -16,7 +17,7 @@ describeSuite({
         let alice: KeyringPair;
         const blocksPerSession = 10n;
         const paraId2001 = 2001;
-        let costPerBlock = 1_000_000n;
+        let costPerBlock: bigint;
         let balanceTankBefore: bigint;
         let registerAlias: any;
         let isStarlight: boolean;
@@ -46,9 +47,7 @@ describeSuite({
                 return;
             }
 
-            if (isStarlight) {
-                costPerBlock = 30_000_000_000n;
-            }
+            costPerBlock = BigInt((await polkadotJs.call.servicesPaymentApi.blockCost(paraId2001)).toString());
 
             const sudoSignedTx = await polkadotJs.tx.sudo.sudo(tx2000OneSession).signAsync(alice);
             await context.createBlock([sudoSignedTx]);

--- a/test/suites/common-tanssi/services-payment/test_service_payment_removes_tank_money_and_burns.ts
+++ b/test/suites/common-tanssi/services-payment/test_service_payment_removes_tank_money_and_burns.ts
@@ -6,7 +6,6 @@ import type { ApiPromise } from "@polkadot/api";
 import { fetchIssuance, jumpSessions } from "utils";
 import { paraIdTank } from "utils";
 import { STARLIGHT_VERSIONS_TO_EXCLUDE_FROM_SERVICES_PAYMENT, checkCallIsFiltered } from "helpers";
-import { type BN } from "@polkadot/util";
 
 describeSuite({
     id: "COMM0201",

--- a/test/suites/common-tanssi/services-payment/test_service_payment_removes_tank_money_and_refunds.ts
+++ b/test/suites/common-tanssi/services-payment/test_service_payment_removes_tank_money_and_refunds.ts
@@ -16,7 +16,7 @@ describeSuite({
         let alice: KeyringPair;
         const blocksPerSession = 10n;
         const paraId2001 = 2001;
-        let costPerBlock = 1_000_000n;
+        let costPerBlock: bigint;
         let refundAddress: KeyringPair;
         let balanceTankBefore: bigint;
         let purchasedCredits: bigint;
@@ -50,9 +50,7 @@ describeSuite({
                 return;
             }
 
-            if (isStarlight) {
-                costPerBlock = 30_000_000_000n;
-            }
+            costPerBlock = BigInt((await polkadotJs.call.servicesPaymentApi.blockCost(paraId2001)).toString());
 
             const sudoSignedTx = await polkadotJs.tx.sudo.sudo(tx2001OneSession).signAsync(alice);
             await context.createBlock([sudoSignedTx]);

--- a/test/suites/common-tanssi/services-payment/test_services_payment_block_credit_buying_free_combined.ts
+++ b/test/suites/common-tanssi/services-payment/test_services_payment_block_credit_buying_free_combined.ts
@@ -3,9 +3,8 @@ import "@tanssi/api-augment";
 import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import type { KeyringPair } from "@moonwall/util";
 import type { ApiPromise } from "@polkadot/api";
-import { jumpSessions } from "utils";
+import { isStarlightRuntime, jumpSessions } from "utils";
 import { STARLIGHT_VERSIONS_TO_EXCLUDE_FROM_SERVICES_PAYMENT, checkCallIsFiltered } from "helpers";
-import { isStarlightRuntime } from "../../../utils/runtime.ts";
 
 describeSuite({
     id: "COMM0203",

--- a/test/suites/common-tanssi/services-payment/test_services_payment_block_credit_buying_free_combined.ts
+++ b/test/suites/common-tanssi/services-payment/test_services_payment_block_credit_buying_free_combined.ts
@@ -17,7 +17,7 @@ describeSuite({
         const blocksPerSession = 10n;
         const paraId2000 = 2000;
         const paraId2001 = 2001;
-        let costPerBlock = 1_000_000n;
+        let costPerBlock: bigint;
         let collatorAssignmentAlias: any;
         let isStarlight: boolean;
         let specVersion: number;
@@ -35,9 +35,7 @@ describeSuite({
             shouldSkipStarlightSP =
                 isStarlight && STARLIGHT_VERSIONS_TO_EXCLUDE_FROM_SERVICES_PAYMENT.includes(specVersion);
 
-            if (isStarlight) {
-                costPerBlock = 30_000_000_000n;
-            }
+            costPerBlock = BigInt((await polkadotJs.call.servicesPaymentApi.blockCost(paraId2001)).toString());
         });
 
         it({

--- a/test/suites/common-tanssi/services-payment/test_services_payment_collator_credit_buying_free_combined.ts
+++ b/test/suites/common-tanssi/services-payment/test_services_payment_collator_credit_buying_free_combined.ts
@@ -3,9 +3,8 @@ import "@tanssi/api-augment";
 import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import type { KeyringPair } from "@moonwall/util";
 import type { ApiPromise } from "@polkadot/api";
-import { jumpSessions } from "utils";
+import { isStarlightRuntime, jumpSessions } from "utils";
 import { STARLIGHT_VERSIONS_TO_EXCLUDE_FROM_SERVICES_PAYMENT, checkCallIsFiltered } from "helpers";
-import { isStarlightRuntime } from "../../../utils/runtime.ts";
 
 describeSuite({
     id: "COMM0204",

--- a/test/suites/common-tanssi/services-payment/test_services_payment_collator_credit_buying_free_combined.ts
+++ b/test/suites/common-tanssi/services-payment/test_services_payment_collator_credit_buying_free_combined.ts
@@ -16,7 +16,7 @@ describeSuite({
         let alice: KeyringPair;
         const paraId2000 = 2000;
         const paraId2001 = 2001;
-        let costPerSession = 100_000_000n;
+        let costPerSession: bigint;
         let collatorAssignmentAlias: any;
         let isStarlight: boolean;
         let specVersion: number;
@@ -34,9 +34,9 @@ describeSuite({
             shouldSkipStarlightSP =
                 isStarlight && STARLIGHT_VERSIONS_TO_EXCLUDE_FROM_SERVICES_PAYMENT.includes(specVersion);
 
-            if (isStarlight) {
-                costPerSession = 50_000_000_000_000n;
-            }
+            costPerSession = BigInt(
+                (await polkadotJs.call.servicesPaymentApi.collatorAssignmentCost(paraId2001)).toString()
+            );
         });
 
         it({

--- a/test/suites/common-tanssi/services-payment/test_services_payment_no_free_credits.ts
+++ b/test/suites/common-tanssi/services-payment/test_services_payment_no_free_credits.ts
@@ -3,9 +3,8 @@ import "@tanssi/api-augment";
 import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import type { KeyringPair } from "@moonwall/util";
 import type { ApiPromise } from "@polkadot/api";
-import { jumpSessions } from "utils";
+import { isStarlightRuntime, jumpSessions } from "utils";
 import { STARLIGHT_VERSIONS_TO_EXCLUDE_FROM_SERVICES_PAYMENT, checkCallIsFiltered } from "helpers";
-import { isStarlightRuntime } from "../../../utils/runtime.ts";
 
 describeSuite({
     id: "COMM0205",

--- a/test/suites/common-tanssi/services-payment/test_services_payment_no_free_credits.ts
+++ b/test/suites/common-tanssi/services-payment/test_services_payment_no_free_credits.ts
@@ -16,8 +16,8 @@ describeSuite({
         let alice: KeyringPair;
         const paraId2000 = 2000;
         const paraId2001 = 2001;
-        let costPerSession = 100_000_000n;
-        let costPerBlock = 1_000_000n;
+        let costPerSession: bigint;
+        let costPerBlock: bigint;
         const blocksPerSession = 10n;
         let collatorAssignmentAlias: any;
         let isStarlight: boolean;
@@ -36,10 +36,11 @@ describeSuite({
             shouldSkipStarlightSP =
                 isStarlight && STARLIGHT_VERSIONS_TO_EXCLUDE_FROM_SERVICES_PAYMENT.includes(specVersion);
 
-            if (isStarlight) {
-                costPerSession = 50_000_000_000_000n;
-                costPerBlock = 30_000_000_000n;
-            }
+            costPerBlock = BigInt((await polkadotJs.call.servicesPaymentApi.blockCost(paraId2001)).toString());
+
+            costPerSession = BigInt(
+                (await polkadotJs.call.servicesPaymentApi.collatorAssignmentCost(paraId2001)).toString()
+            );
         });
         it({
             id: "E01",

--- a/test/suites/dev-tanssi-relay/services-payment/test_services_payment_block_credits.ts
+++ b/test/suites/dev-tanssi-relay/services-payment/test_services_payment_block_credits.ts
@@ -18,7 +18,7 @@ describeSuite({
         let isStarlight: boolean;
         let specVersion: number;
         let shouldSkipStarlightSP: boolean;
-        let costPerBlock = 1_000_000n;
+        let costPerBlock: bigint;
 
         beforeAll(async () => {
             polkadotJs = context.polkadotJs();
@@ -29,9 +29,7 @@ describeSuite({
             shouldSkipStarlightSP =
                 isStarlight && STARLIGHT_VERSIONS_TO_EXCLUDE_FROM_SERVICES_PAYMENT.includes(specVersion);
 
-            if (isStarlight) {
-                costPerBlock = 30_000_000_000n;
-            }
+            costPerBlock = BigInt((await polkadotJs.call.servicesPaymentApi.blockCost(1000)).toString());
         });
         it({
             id: "E01",

--- a/test/suites/dev-tanssi-relay/services-payment/test_services_payment_block_credits.ts
+++ b/test/suites/dev-tanssi-relay/services-payment/test_services_payment_block_credits.ts
@@ -3,9 +3,8 @@ import "@tanssi/api-augment";
 import { beforeAll, customDevRpcRequest, describeSuite, expect } from "@moonwall/cli";
 import { type KeyringPair, generateKeyringPair } from "@moonwall/util";
 import type { ApiPromise } from "@polkadot/api";
-import { jumpSessions, jumpToSession, paraIdTank } from "utils";
+import { isStarlightRuntime, jumpSessions, jumpToSession, paraIdTank } from "utils";
 import { STARLIGHT_VERSIONS_TO_EXCLUDE_FROM_SERVICES_PAYMENT, checkCallIsFiltered } from "helpers";
-import { isStarlightRuntime } from "../../../utils/runtime.ts";
 
 describeSuite({
     id: "DEVT1201",

--- a/test/suites/dev-tanssi-relay/services-payment/test_services_payment_collator_credits.ts
+++ b/test/suites/dev-tanssi-relay/services-payment/test_services_payment_collator_credits.ts
@@ -18,7 +18,7 @@ describeSuite({
         let isStarlight: boolean;
         let specVersion: number;
         let shouldSkipStarlightSP: boolean;
-        let costPerSession = 100_000_000n;
+        let costPerSession: bigint;
 
         beforeAll(async () => {
             polkadotJs = context.polkadotJs();
@@ -27,9 +27,7 @@ describeSuite({
             specVersion = polkadotJs.consts.system.version.specVersion.toNumber();
             shouldSkipStarlightSP =
                 isStarlight && STARLIGHT_VERSIONS_TO_EXCLUDE_FROM_SERVICES_PAYMENT.includes(specVersion);
-            if (isStarlight) {
-                costPerSession = 50_000_000_000_000n;
-            }
+            costPerSession = BigInt((await polkadotJs.call.servicesPaymentApi.collatorAssignmentCost(1000)).toString());
         });
         it({
             id: "E01",

--- a/test/suites/dev-tanssi-relay/services-payment/test_services_payment_collator_credits.ts
+++ b/test/suites/dev-tanssi-relay/services-payment/test_services_payment_collator_credits.ts
@@ -3,9 +3,8 @@ import "@tanssi/api-augment";
 import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { type KeyringPair, generateKeyringPair } from "@moonwall/util";
 import type { ApiPromise } from "@polkadot/api";
-import { jumpSessions, jumpToSession, paraIdTank } from "utils";
+import { isStarlightRuntime, jumpSessions, jumpToSession, paraIdTank } from "utils";
 import { STARLIGHT_VERSIONS_TO_EXCLUDE_FROM_SERVICES_PAYMENT, checkCallIsFiltered } from "helpers";
-import { isStarlightRuntime } from "../../../utils/runtime.ts";
 
 describeSuite({
     id: "DEVT1202",

--- a/test/suites/dev-tanssi-relay/services-payment/test_services_payment_cost_values.ts
+++ b/test/suites/dev-tanssi-relay/services-payment/test_services_payment_cost_values.ts
@@ -1,0 +1,33 @@
+import "@tanssi/api-augment";
+
+import { beforeAll, customDevRpcRequest, describeSuite, expect } from "@moonwall/cli";
+import type { ApiPromise } from "@polkadot/api";
+import { isStarlightRuntime } from "../../../utils/runtime.ts";
+
+describeSuite({
+    id: "DEVT1204",
+    title: "Services payment RPC",
+    foundationMethods: "dev",
+    testCases: ({ it, context }) => {
+        let polkadotJs: ApiPromise;
+        beforeAll(async () => {
+            polkadotJs = context.polkadotJs();
+        });
+        it({
+            id: "E01",
+            title: "Services payment RPC",
+            test: async () => {
+                const isStarlight = isStarlightRuntime(polkadotJs);
+                const costPerBlock = isStarlight ? 30_000_000_000n : 1_000_000n;
+                const costPerSession = isStarlight ? 50_000_000_000_000n : 100_000_000n;
+
+                const chainBlockCost = BigInt((await polkadotJs.call.servicesPaymentApi.blockCost(1000)).toString());
+                const chainSessionCost = BigInt(
+                    (await polkadotJs.call.servicesPaymentApi.collatorAssignmentCost(1000)).toString()
+                );
+                expect(costPerBlock).eq(chainBlockCost);
+                expect(chainSessionCost).eq(costPerSession);
+            },
+        });
+    },
+});

--- a/test/suites/dev-tanssi-relay/services-payment/test_services_payment_cost_values.ts
+++ b/test/suites/dev-tanssi-relay/services-payment/test_services_payment_cost_values.ts
@@ -1,6 +1,6 @@
 import "@tanssi/api-augment";
 
-import { beforeAll, customDevRpcRequest, describeSuite, expect } from "@moonwall/cli";
+import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import type { ApiPromise } from "@polkadot/api";
 import { isStarlightRuntime } from "../../../utils/runtime.ts";
 

--- a/test/suites/dev-tanssi-relay/services-payment/test_services_payment_cost_values.ts
+++ b/test/suites/dev-tanssi-relay/services-payment/test_services_payment_cost_values.ts
@@ -2,7 +2,7 @@ import "@tanssi/api-augment";
 
 import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import type { ApiPromise } from "@polkadot/api";
-import { isStarlightRuntime } from "../../../utils/runtime.ts";
+import { isStarlightRuntime } from "utils";
 
 describeSuite({
     id: "DEVT1204",

--- a/test/suites/dev-tanssi-relay/xcm/test-export-errors-if-no-channel.ts
+++ b/test/suites/dev-tanssi-relay/xcm/test-export-errors-if-no-channel.ts
@@ -1,9 +1,8 @@
 import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { type KeyringPair, generateKeyringPair } from "@moonwall/util";
 import { type ApiPromise, Keyring } from "@polkadot/api";
-import { XcmFragment, TESTNET_ETHEREUM_NETWORK_ID } from "utils";
+import { isStarlightRuntime, XcmFragment, TESTNET_ETHEREUM_NETWORK_ID } from "utils";
 import { STARLIGHT_VERSIONS_TO_EXCLUDE_FROM_CONTAINER_EXPORTS } from "helpers";
-import { isStarlightRuntime } from "../../../utils/runtime.ts";
 
 describeSuite({
     id: "DEVT1907",

--- a/test/suites/dev-tanssi-relay/xcm/test-export-errors-if-no-token-registration.ts
+++ b/test/suites/dev-tanssi-relay/xcm/test-export-errors-if-no-token-registration.ts
@@ -1,9 +1,8 @@
 import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { type KeyringPair, generateKeyringPair } from "@moonwall/util";
 import { type ApiPromise, Keyring } from "@polkadot/api";
-import { XcmFragment, TESTNET_ETHEREUM_NETWORK_ID } from "utils";
+import { isStarlightRuntime, XcmFragment, TESTNET_ETHEREUM_NETWORK_ID } from "utils";
 import { STARLIGHT_VERSIONS_TO_EXCLUDE_FROM_CONTAINER_EXPORTS } from "helpers";
-import { isStarlightRuntime } from "../../../utils/runtime.ts";
 
 describeSuite({
     id: "DEVT1908",

--- a/test/suites/dev-tanssi-relay/xcm/test-export-expected--errors.ts
+++ b/test/suites/dev-tanssi-relay/xcm/test-export-expected--errors.ts
@@ -2,14 +2,13 @@ import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { type KeyringPair, generateKeyringPair } from "@moonwall/util";
 import { type ApiPromise, Keyring } from "@polkadot/api";
 import { u8aToHex } from "@polkadot/util";
-import { XcmFragment, TESTNET_ETHEREUM_NETWORK_ID } from "utils";
+import { isStarlightRuntime, XcmFragment, TESTNET_ETHEREUM_NETWORK_ID } from "utils";
 import {
     STARLIGHT_VERSIONS_TO_EXCLUDE_FROM_CONTAINER_EXPORTS,
     retrieveDispatchErrors,
     retrieveSudoDispatchErrors,
     retrieveBatchDispatchErrors,
 } from "helpers";
-import { isStarlightRuntime } from "../../../utils/runtime.ts";
 
 describeSuite({
     id: "DEVT1906",

--- a/test/suites/dev-tanssi-relay/xcm/test-export-expected-errors.ts
+++ b/test/suites/dev-tanssi-relay/xcm/test-export-expected-errors.ts
@@ -2,14 +2,13 @@ import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { type KeyringPair, generateKeyringPair } from "@moonwall/util";
 import { type ApiPromise, Keyring } from "@polkadot/api";
 import { u8aToHex } from "@polkadot/util";
-import { XcmFragment, TESTNET_ETHEREUM_NETWORK_ID } from "utils";
+import { isStarlightRuntime, XcmFragment, TESTNET_ETHEREUM_NETWORK_ID } from "utils";
 import {
     STARLIGHT_VERSIONS_TO_EXCLUDE_FROM_CONTAINER_EXPORTS,
     retrieveDispatchErrors,
     retrieveSudoDispatchErrors,
     retrieveBatchDispatchErrors,
 } from "helpers";
-import { isStarlightRuntime } from "../../../utils/runtime.ts";
 
 describeSuite({
     id: "DEVT1906",

--- a/test/suites/dev-tanssi-relay/xcm/test-export-message-faking-para-origin.ts
+++ b/test/suites/dev-tanssi-relay/xcm/test-export-message-faking-para-origin.ts
@@ -1,9 +1,8 @@
 import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { type KeyringPair, generateKeyringPair } from "@moonwall/util";
 import { type ApiPromise, Keyring } from "@polkadot/api";
-import { XcmFragment, TESTNET_ETHEREUM_NETWORK_ID } from "utils";
+import { isStarlightRuntime, XcmFragment, TESTNET_ETHEREUM_NETWORK_ID } from "utils";
 import { STARLIGHT_VERSIONS_TO_EXCLUDE_FROM_CONTAINER_EXPORTS } from "helpers";
-import { isStarlightRuntime } from "../../../utils/runtime.ts";
 
 describeSuite({
     id: "DEVT1905",

--- a/test/suites/dev-tanssi-relay/xcm/test-export-message-from-para.ts
+++ b/test/suites/dev-tanssi-relay/xcm/test-export-message-from-para.ts
@@ -5,7 +5,7 @@ import {
     type RawXcmMessage,
     XcmFragment,
     injectUmpMessageAndSeal,
-    ,
+    isStarlightRuntime,
     jumpToSession,
     TESTNET_ETHEREUM_NETWORK_ID,
 } from "utils";

--- a/test/suites/dev-tanssi-relay/xcm/test-export-message-from-para.ts
+++ b/test/suites/dev-tanssi-relay/xcm/test-export-message-from-para.ts
@@ -8,8 +8,7 @@ import {
     jumpToSession,
     TESTNET_ETHEREUM_NETWORK_ID,
 } from "utils";
-import { STARLIGHT_VERSIONS_TO_EXCLUDE_FROM_CONTAINER_EXPORTS } from "helpers";
-import { isStarlightRuntime } from "../../../utils/runtime.ts";
+import { isStarlightRuntime, STARLIGHT_VERSIONS_TO_EXCLUDE_FROM_CONTAINER_EXPORTS } from "helpers";
 import type { EventRecord } from "@polkadot/types/interfaces";
 
 describeSuite({

--- a/test/suites/dev-tanssi-relay/xcm/test-export-message-from-para.ts
+++ b/test/suites/dev-tanssi-relay/xcm/test-export-message-from-para.ts
@@ -5,10 +5,11 @@ import {
     type RawXcmMessage,
     XcmFragment,
     injectUmpMessageAndSeal,
+    ,
     jumpToSession,
     TESTNET_ETHEREUM_NETWORK_ID,
 } from "utils";
-import { isStarlightRuntime, STARLIGHT_VERSIONS_TO_EXCLUDE_FROM_CONTAINER_EXPORTS } from "helpers";
+import { STARLIGHT_VERSIONS_TO_EXCLUDE_FROM_CONTAINER_EXPORTS } from "helpers";
 import type { EventRecord } from "@polkadot/types/interfaces";
 
 describeSuite({

--- a/test/suites/dev-tanssi-relay/xcm/test-export-without-sufficient-balance-sovereign.ts
+++ b/test/suites/dev-tanssi-relay/xcm/test-export-without-sufficient-balance-sovereign.ts
@@ -1,9 +1,8 @@
 import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { type KeyringPair, generateKeyringPair } from "@moonwall/util";
 import { type ApiPromise, Keyring } from "@polkadot/api";
-import { XcmFragment, TESTNET_ETHEREUM_NETWORK_ID } from "utils";
+import { isStarlightRuntime, XcmFragment, TESTNET_ETHEREUM_NETWORK_ID } from "utils";
 import { STARLIGHT_VERSIONS_TO_EXCLUDE_FROM_CONTAINER_EXPORTS } from "helpers";
-import { isStarlightRuntime } from "../../../utils/runtime.ts";
 
 describeSuite({
     id: "DEVT1909",

--- a/test/suites/smoke-test-common-all/test-consistency-services-payment.ts
+++ b/test/suites/smoke-test-common-all/test-consistency-services-payment.ts
@@ -24,14 +24,8 @@ describeSuite({
             chain = api.consts.system.version.specName.toString();
             blocksPerSession =
                 chain === "dancebox" || chain === "dancelight" ? 600n : chain === "flashbox" ? 50n : 3600n;
-            costPerSession =
-                chain === "dancebox" || chain === "dancelight" || chain === "flashbox" || runtimeVersion < 1500
-                    ? 100_000_000n
-                    : 50_000_000_000_000n;
-            costPerBlock =
-                chain === "dancebox" || chain === "dancelight" || chain === "flashbox" || runtimeVersion < 1500
-                    ? 1_000_000n
-                    : 30_000_000_000n;
+            costPerSession = BigInt((await api.call.servicesPaymentApi.collatorAssignmentCost(1000)).toString());
+            costPerBlock = BigInt((await api.call.servicesPaymentApi.blockCost(1000)).toString());
         });
 
         it({

--- a/test/suites/smoke-test-common-all/test-services-payment-costs.ts
+++ b/test/suites/smoke-test-common-all/test-services-payment-costs.ts
@@ -21,8 +21,8 @@ describeSuite({
             test: async () => {
                 const isStarlight = isStarlightRuntime(api);
                 const runtimeVersion = api.runtimeVersion.specVersion.toNumber();
-                const costPerBlock = isStarlight || runtimeVersion < 1500 ? 30_000_000_000n : 1_000_000n;
-                const costPerSession = isStarlight || runtimeVersion < 1500 ? 50_000_000_000_000n : 100_000_000n;
+                const costPerBlock = isStarlight && runtimeVersion >= 1500 ? 30_000_000_000n : 1_000_000n;
+                const costPerSession = isStarlight && runtimeVersion >= 1500 ? 50_000_000_000_000n : 100_000_000n;
 
                 const chainBlockCost = BigInt((await api.call.servicesPaymentApi.blockCost(1000)).toString());
                 const chainSessionCost = BigInt(

--- a/test/suites/smoke-test-common-all/test-services-payment-costs.ts
+++ b/test/suites/smoke-test-common-all/test-services-payment-costs.ts
@@ -1,0 +1,36 @@
+import "@tanssi/api-augment";
+
+import { beforeAll, describeSuite, expect } from "@moonwall/cli";
+import type { ApiPromise } from "@polkadot/api";
+import { isStarlightRuntime } from "../../utils";
+
+describeSuite({
+    id: "S11",
+    title: "Verify payment costs",
+    foundationMethods: "read_only",
+    testCases: ({ context, it, log }) => {
+        let api: ApiPromise;
+
+        beforeAll(async () => {
+            api = context.polkadotJs();
+        });
+
+        it({
+            id: "C100",
+            title: "should have value > 0",
+            test: async () => {
+                const isStarlight = isStarlightRuntime(api);
+                const runtimeVersion = api.runtimeVersion.specVersion.toNumber();
+                const costPerBlock = isStarlight || runtimeVersion < 1500 ? 30_000_000_000n : 1_000_000n;
+                const costPerSession = isStarlight || runtimeVersion < 1500 ? 50_000_000_000_000n : 100_000_000n;
+
+                const chainBlockCost = BigInt((await api.call.servicesPaymentApi.blockCost(1000)).toString());
+                const chainSessionCost = BigInt(
+                    (await api.call.servicesPaymentApi.collatorAssignmentCost(1000)).toString()
+                );
+                expect(costPerBlock).eq(chainBlockCost);
+                expect(chainSessionCost).eq(costPerSession);
+            },
+        });
+    },
+});

--- a/test/suites/smoke-test-common-solo/test-configuration-consistency.ts
+++ b/test/suites/smoke-test-common-solo/test-configuration-consistency.ts
@@ -24,7 +24,7 @@ describeSuite({
         let costPerSession: bigint;
         let costPerBlock: bigint;
         const blockNumberToDebug = getBlockNumberForDebug();
-        beforeAll(() => {
+        beforeAll(async () => {
             api = context.polkadotJs();
             const chain = api.consts.system.version.specName.toString();
             blocksPerSession = chain === "dancelight" ? 600n : 3600n;

--- a/test/suites/smoke-test-common-solo/test-configuration-consistency.ts
+++ b/test/suites/smoke-test-common-solo/test-configuration-consistency.ts
@@ -14,13 +14,13 @@ describeSuite({
         let blocksPerSession: bigint;
         let costPerSession: bigint;
         let costPerBlock: bigint;
-        beforeAll(() => {
+        beforeAll(async () => {
             api = context.polkadotJs();
             const runtimeVersion = api.runtimeVersion.specVersion.toNumber();
             const chain = api.consts.system.version.specName.toString();
             blocksPerSession = chain === "dancelight" ? 600n : 3600n;
-            costPerSession = chain === "dancelight" || runtimeVersion < 1500 ? 100_000_000n : 50_000_000_000_000n;
-            costPerBlock = chain === "dancelight" || runtimeVersion < 1500 ? 1_000_000n : 30_000_000_000n;
+            costPerSession = BigInt((await api.call.servicesPaymentApi.collatorAssignmentCost(1000)).toString());
+            costPerBlock = BigInt((await api.call.servicesPaymentApi.blockCost(1000)).toString());
         });
 
         it({

--- a/test/utils/index.ts
+++ b/test/utils/index.ts
@@ -15,3 +15,4 @@ export * from "./typescript";
 export * from "./xcm";
 export * from "./zombie";
 export * from "./light-client";
+export * from "./runtime";


### PR DESCRIPTION
this PRs changes cost constants for calls to the runtime-api itself. My plan is to have a test that tests the specific values, but then the rest should work with the runtime-api