### PR TITLE
Remove unused env variable CARGO_TARGET_DIR from CI

### DIFF
--- a/.github/workflows/cmd.yml
+++ b/.github/workflows/cmd.yml
@@ -57,8 +57,6 @@ jobs:
     needs: ["is-org-member"]
     runs-on: self-hosted
     env:
-      TMP_TARGET: "/tmp/target"
-      CARGO_TARGET_DIR: "target"
       RUSTC_WRAPPER: "sccache"
       CARGO_INCREMENTAL: "0"
       SCCACHE_CACHE_SIZE: "100GB"

--- a/.github/workflows/merge-when-ready.yml
+++ b/.github/workflows/merge-when-ready.yml
@@ -18,8 +18,6 @@ jobs:
     build:
         runs-on: self-hosted
         env:
-          TMP_TARGET: "/tmp/target"
-          CARGO_TARGET_DIR: "target"
           RUSTC_WRAPPER: "sccache"
           CARGO_INCREMENTAL: "0"
           SCCACHE_CACHE_SIZE: "100GB"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,8 +96,6 @@ jobs:
         runs-on: self-hosted
         needs: ["set-tags", "build"]
         env:
-          TMP_TARGET: "/tmp/target"
-          CARGO_TARGET_DIR: "target"
           RUSTC_WRAPPER: "sccache"
           CARGO_INCREMENTAL: "0"
           SCCACHE_CACHE_SIZE: "100GB"
@@ -202,8 +200,6 @@ jobs:
         runs-on: self-hosted
         needs: ["set-tags"]
         env:
-          TMP_TARGET: "/tmp/target"
-          CARGO_TARGET_DIR: "target"
           RUSTC_WRAPPER: "sccache"
           CARGO_INCREMENTAL: "0"
           SCCACHE_CACHE_SIZE: "100GB"
@@ -432,8 +428,6 @@ jobs:
       runs-on: self-hosted
       needs: ["set-tags", "build"]
       env:
-        TMP_TARGET: "/tmp/target"
-        CARGO_TARGET_DIR: "target"
         RUSTC_WRAPPER: "sccache"
         CARGO_INCREMENTAL: "0"
         SCCACHE_CACHE_SIZE: "100GB"

--- a/.github/workflows/run-zombienet-tests.yml
+++ b/.github/workflows/run-zombienet-tests.yml
@@ -100,9 +100,6 @@ jobs:
   build:
     runs-on: self-hosted
     needs: [ "get-tests" ]
-    env:
-      TMP_TARGET: "/tmp/target"
-      CARGO_TARGET_DIR: "target"
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -133,7 +130,7 @@ jobs:
       - name: Package all runtime Wasm into tarball
         run: |
           mkdir -p runtimes
-          cd $CARGO_TARGET_DIR
+          cd ${CARGO_TARGET_DIR:-target}
           # gather all .wasm paths (relative to $CARGO_TARGET_DIR)…
           find . -type f -name '*.wasm' > wasm_files.txt
           # …then tar them up into a gzipped archive in the workspace
@@ -164,8 +161,6 @@ jobs:
   run-tests:
     runs-on: self-hosted
     needs: [ "get-tests", "build" ]
-    env:
-      CARGO_TARGET_DIR: "target"
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.get-tests.outputs.matrix) }}
@@ -190,9 +185,9 @@ jobs:
       - name: Extract runtimes back into target/
         run: |
           # ensure the target dir exists
-          mkdir -p $CARGO_TARGET_DIR
+          mkdir -p ${CARGO_TARGET_DIR:-target}
           # unpack, preserving all sub‑dirs exactly as they were
-          tar xzf runtimes/runtimes.tar.gz -C $CARGO_TARGET_DIR
+          tar xzf runtimes/runtimes.tar.gz -C ${CARGO_TARGET_DIR:-target}
       - name: Run Zombienet Test ${{ matrix.test_name }}
         uses: ./.github/workflow-templates/zombienet-tests
         with:

--- a/.github/workflows/test-all-benchmarks-schedule.yml
+++ b/.github/workflows/test-all-benchmarks-schedule.yml
@@ -15,8 +15,6 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 720
     env:
-      TMP_TARGET: "/tmp/target"
-      CARGO_TARGET_DIR: "target"
       RUSTC_WRAPPER: "sccache"
       CARGO_INCREMENTAL: "0"
       SCCACHE_CACHE_SIZE: "100GB"


### PR DESCRIPTION
The default value is already "target" if the env variable does not exist