### PR TITLE
Wait for first assignment for db_cleanup

### DIFF
--- a/client/service-container-chain-spawner/src/spawner.rs
+++ b/client/service-container-chain-spawner/src/spawner.rs
@@ -749,14 +749,14 @@ impl<
         // then the real assignment is used.
         // Except in solochain mode, then the initial assignment is None.
         if validator && !solochain {
-            self.handle_update_assignment(Some(orchestrator_para_id), None)
+            self.handle_update_assignment(Some(orchestrator_para_id), None, true)
                 .await;
         }
 
         while let Some(msg) = rx.recv().await {
             match msg {
                 CcSpawnMsg::UpdateAssignment { current, next } => {
-                    self.handle_update_assignment(current, next).await;
+                    self.handle_update_assignment(current, next, false).await;
                 }
             }
         }
@@ -770,8 +770,8 @@ impl<
     }
 
     /// Handle `CcSpawnMsg::UpdateAssignment`
-    async fn handle_update_assignment(&mut self, current: Option<ParaId>, next: Option<ParaId>) {
-        if !self.db_folder_cleanup_done {
+    async fn handle_update_assignment(&mut self, current: Option<ParaId>, next: Option<ParaId>, disable_db_folder_cleanup: bool) {
+        if !disable_db_folder_cleanup && !self.db_folder_cleanup_done {
             self.db_folder_cleanup_done = true;
 
             // Disabled when running with --keep-db

--- a/client/service-container-chain-spawner/src/spawner.rs
+++ b/client/service-container-chain-spawner/src/spawner.rs
@@ -770,7 +770,12 @@ impl<
     }
 
     /// Handle `CcSpawnMsg::UpdateAssignment`
-    async fn handle_update_assignment(&mut self, current: Option<ParaId>, next: Option<ParaId>, disable_db_folder_cleanup: bool) {
+    async fn handle_update_assignment(
+        &mut self,
+        current: Option<ParaId>,
+        next: Option<ParaId>,
+        disable_db_folder_cleanup: bool,
+    ) {
         if !disable_db_folder_cleanup && !self.db_folder_cleanup_done {
             self.db_folder_cleanup_done = true;
 

--- a/test/suites/zombie_tanssi_keep_db/test_zombie_tanssi_keep_db.ts
+++ b/test/suites/zombie_tanssi_keep_db/test_zombie_tanssi_keep_db.ts
@@ -16,6 +16,8 @@ import {
     signAndSendAndInclude,
     sleep,
     waitSessions,
+    verifyCanary,
+    snapshotCanary,
 } from "utils";
 
 describeSuite({
@@ -202,8 +204,13 @@ describeSuite({
 
         it({
             id: "T11",
+            timeout: 90_000,
             title: "Test restarting both container chain collators",
             test: async () => {
+                const dbPath01 = `${getTmpZombiePath()}/Collator2000-01/data/containers/chains/simple_container_2000/paritydb/full-container-2000`;
+                const dbPath02 = `${getTmpZombiePath()}/Collator2000-02/data/containers/chains/simple_container_2000/paritydb/full-container-2000`;
+                // Prepare canaries
+                const [snap01, snap02] = await Promise.all([snapshotCanary(dbPath01), snapshotCanary(dbPath02)]);
                 // Fetch block number before restarting because the RPC may no longer work after the restart
                 blockNumberOfRestart = (await container2000Api.rpc.chain.getBlock()).block.header.number.toNumber();
                 // Fetch authorities for a later test
@@ -223,13 +230,19 @@ describeSuite({
                 // Check that both collators have been stopped
                 expect(isProcessRunning(pidCollator200001)).to.be.false;
                 expect(isProcessRunning(pidCollator200002)).to.be.false;
-
                 // Check db has not been deleted
-                const dbPath01 = `${getTmpZombiePath()}/Collator2000-01/data/containers/chains/simple_container_2000/paritydb/full-container-2000`;
-                const dbPath02 = `${getTmpZombiePath()}/Collator2000-02/data/containers/chains/simple_container_2000/paritydb/full-container-2000`;
-
                 expect(await directoryExists(dbPath01)).to.be.true;
                 expect(await directoryExists(dbPath02)).to.be.true;
+                // Check canary files to handle edge case of directory deleted and then created again
+                await Promise.all([verifyCanary(snap01), verifyCanary(snap02)]);
+
+                // Wait for nodes to restart. This is to test that they don't delete the db on start.
+                await sleep(30_000);
+                // Check db has not been deleted
+                expect(await directoryExists(dbPath01)).to.be.true;
+                expect(await directoryExists(dbPath02)).to.be.true;
+                // Check canary files to handle edge case of directory deleted and then created again
+                await Promise.all([verifyCanary(snap01), verifyCanary(snap02)]);
             },
         });
 

--- a/test/utils/dir-canary.ts
+++ b/test/utils/dir-canary.ts
@@ -1,0 +1,53 @@
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
+
+/**
+ * dir-canary.ts — tiny test helper to detect directory recreation.
+ *
+ * Use case:
+ *   In some tests we check that directories are not deleted by doing directory.exists().
+ *   That works in most cases but it fails on the edge case of the directory being
+ *   deleted and then created again.
+ *
+ * Approach:
+ *   We write a one-off ".test-canary" file with a random UUID inside the target directory.
+ *   If the directory truly persists, the same file with the same contents will still be
+ *   there later. If the directory was removed/recreated (or cleaned), the canary will be
+ *   missing or have different contents.
+ */
+
+export type CanarySnapshot = { file: string; value: string };
+
+/**
+ * Create the canary for this directory; throw if it already exists.
+ */
+export async function snapshotCanary(dir: string): Promise<CanarySnapshot> {
+    const file = path.join(dir, ".test-canary");
+    const value = randomUUID();
+    try {
+        await fs.writeFile(file, value, { flag: "wx", encoding: "utf8" }); // fail if exists
+        return { file, value };
+    } catch (e) {
+        const err = e as NodeJS.ErrnoException;
+        if (err.code === "EEXIST") throw new Error(`Canary already exists: ${file}`);
+        if (err.code === "ENOENT") throw new Error(`Directory not found for canary: ${dir}`);
+        throw err;
+    }
+}
+
+/** Throws if the canary value changed (dir likely deleted & recreated). */
+export async function verifyCanary(s: CanarySnapshot): Promise<void> {
+    try {
+        const now = await fs.readFile(s.file, "utf8");
+        if (now !== s.value) {
+            throw new Error(`Canary changed: ${s.file} — directory was likely removed and recreated`);
+        }
+    } catch (e: any) {
+        if (e.code === "ENOENT") {
+            // Canary (or its dir) is gone ⇒ dir was likely deleted/recreated
+            throw new Error(`Canary missing: ${s.file} — directory was likely removed and recreated`);
+        }
+        throw e; // surface unexpected I/O errors
+    }
+}

--- a/test/utils/index.ts
+++ b/test/utils/index.ts
@@ -2,6 +2,7 @@ export * from "./account";
 export * from "./author";
 export * from "./block";
 export * from "./constants";
+export * from "./dir-canary";
 export * from "./ethereum";
 export * from "./ethereum-contracts";
 export * from "./genesis-data";


### PR DESCRIPTION
This PR fixes a bug where collator container chain folder are always deleted on startup. Only affects orchestrator collators (dancebox & flashbox), solochain collators are not affected (dancelight & starlight not affected).

Collators start assigned to the orchestrator chain by default. The db cleanup task runs on the first assignment, so it will remove all container chain folders. The fix is to skip the db_cleanup task in this first assignment, and wait for the real assignment with the container chain para ids.

Also fix the tests to handle this case.