### PR TITLE
new labels required for runtime affected and its version

### DIFF
--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -7,6 +7,7 @@ jobs:
   enforce-noteworthiness-label:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: yogevbd/enforce-label-action@2.2.2
         with:
           REQUIRED_LABELS_ANY: "B0-silent,B5-clientnoteworthy,B7-runtimenoteworthy"


### PR DESCRIPTION
It introduces a new requirement to put in the labels. For devs:

- if B7-runtimeworthy is present, they need to indicate any of these:

`R1-flashbox, R1-flashbox, R2-dancebox, R3-dancelight, R4-starlight, R5-allpara, R6-orchestratorpara, R7-container ,R8-orchestratorsolo, R9-all`

- if B7-runtimeworthy is present, they need to indicate any of VXXXX, where XXXX is the version. some labels until version 2000 have been created, but if not, a dev can simply create a new one:


Susscesful run: https://github.com/moondance-labs/tanssi/actions/runs/18773100841/job/53561466419?pr=1339
