### PR TITLE
Fix for smoke test in case if the chain is de-registered and invulnerable not in the assignment list

### DIFF
--- a/test/suites/smoke-test-common-solo/test-invulnerables-priority.ts
+++ b/test/suites/smoke-test-common-solo/test-invulnerables-priority.ts
@@ -98,7 +98,7 @@ export const checkIfInvulnerableWasAssignedAfterFullRotation = async (
             const eventJSON = event.toHuman() as {
                 section: string;
                 method: string;
-                data: { fullRotation: boolean };
+                data: Record<string, unknown>;
             };
             if (eventJSON.section === "tanssiCollatorAssignment" && eventJSON.method === "NewPendingAssignment") {
                 const fullRotation = eventJSON.data?.fullRotation;


### PR DESCRIPTION
### Description
Sometimes it can be a situation, when the chain has been de-registered and invulnerable, that has been assigned not in the collator assignment list. We check if it was in the list right after the full rotation - `tanssiCollatorAssignment`.`NewPendingAssignment` - `full_rotation` : `true`.