### PR TITLE
Add polkadot-sdk cherry-pick, fix litep2p dns issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,7 +799,7 @@ dependencies = [
 [[package]]
 name = "asset-test-utils"
 version = "24.0.1"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
@@ -1182,7 +1182,7 @@ checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 [[package]]
 name = "binary-merkle-tree"
 version = "16.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "hash-db",
  "log",
@@ -1441,7 +1441,7 @@ dependencies = [
 [[package]]
 name = "bp-header-chain"
 version = "0.21.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "bp-runtime",
  "finality-grandpa",
@@ -1458,7 +1458,7 @@ dependencies = [
 [[package]]
 name = "bp-messages"
 version = "0.21.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -1474,7 +1474,7 @@ dependencies = [
 [[package]]
 name = "bp-parachains"
 version = "0.21.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
@@ -1491,7 +1491,7 @@ dependencies = [
 [[package]]
 name = "bp-polkadot-core"
 version = "0.21.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1508,7 +1508,7 @@ dependencies = [
 [[package]]
 name = "bp-relayers"
 version = "0.21.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -1526,7 +1526,7 @@ dependencies = [
 [[package]]
 name = "bp-runtime"
 version = "0.21.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1549,7 +1549,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1566,7 +1566,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.18.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1600,7 +1600,7 @@ dependencies = [
 [[package]]
 name = "bridge-hub-common"
 version = "0.14.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2867,7 +2867,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-bootnodes"
 version = "0.2.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -2893,7 +2893,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.24.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -2910,7 +2910,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.24.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -2933,7 +2933,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.24.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -2980,7 +2980,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.24.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -3012,7 +3012,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-proposer"
 version = "0.20.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3027,7 +3027,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.24.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -3054,7 +3054,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.18.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3075,7 +3075,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.24.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3103,7 +3103,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.25.1"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-channel 1.9.0",
  "cumulus-client-cli",
@@ -3143,7 +3143,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.21.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -3180,7 +3180,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -3191,7 +3191,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
 version = "22.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3204,7 +3204,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-weight-reclaim"
 version = "0.3.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "derive-where",
@@ -3223,7 +3223,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.20.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -3238,7 +3238,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.21.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "approx",
  "bounded-collections",
@@ -3264,7 +3264,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.18.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "sp-api",
  "sp-consensus-aura",
@@ -3273,7 +3273,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.19.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -3290,7 +3290,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.19.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3304,7 +3304,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.13.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -3314,7 +3314,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "12.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -3331,7 +3331,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.20.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -3341,7 +3341,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.21.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -3358,7 +3358,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.25.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -3386,7 +3386,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.24.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3406,7 +3406,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.25.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -3442,7 +3442,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.24.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3483,7 +3483,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-streams"
 version = "0.2.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "cumulus-relay-chain-interface",
  "futures 0.3.31",
@@ -3497,7 +3497,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.20.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -4719,7 +4719,7 @@ dependencies = [
 [[package]]
 name = "emulated-integration-tests-common"
 version = "22.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "asset-test-utils",
  "bp-messages",
@@ -4899,7 +4899,7 @@ dependencies = [
 [[package]]
 name = "ethereum-standards"
 version = "0.1.1"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "alloy-core",
 ]
@@ -5548,7 +5548,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "13.0.1"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -5675,7 +5675,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 [[package]]
 name = "frame-benchmarking"
 version = "41.0.1"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -5699,7 +5699,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "49.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "Inflector",
  "array-bytes 6.2.3",
@@ -5778,7 +5778,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "16.1.1"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -5789,7 +5789,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "41.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -5806,7 +5806,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "41.0.1"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -5848,7 +5848,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.9.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "array-bytes 6.2.3",
  "const-hex",
@@ -5864,7 +5864,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.52.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "futures 0.3.31",
  "indicatif",
@@ -5886,7 +5886,7 @@ dependencies = [
 [[package]]
 name = "frame-storage-access-test-runtime"
 version = "0.2.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "parity-scale-codec",
@@ -5900,7 +5900,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "41.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "aquamarine",
  "array-bytes 6.2.3",
@@ -5941,7 +5941,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "34.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -5961,7 +5961,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.3.0",
@@ -5973,7 +5973,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5983,7 +5983,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "41.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "cfg-if",
  "docify",
@@ -6002,7 +6002,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "41.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6016,7 +6016,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "37.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -6026,7 +6026,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.47.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -8714,7 +8714,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "46.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "futures 0.3.31",
  "log",
@@ -8733,7 +8733,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "41.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -9592,7 +9592,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion"
 version = "23.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9610,7 +9610,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "20.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9624,7 +9624,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "41.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9640,7 +9640,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "43.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "ethereum-standards",
  "frame-benchmarking",
@@ -9754,7 +9754,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "41.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9782,7 +9782,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "41.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9795,7 +9795,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "41.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9818,7 +9818,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "40.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "aquamarine",
  "docify",
@@ -9839,7 +9839,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "42.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9869,7 +9869,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "42.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9888,7 +9888,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "42.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "array-bytes 6.2.3",
  "binary-merkle-tree",
@@ -9913,7 +9913,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "40.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9930,7 +9930,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-messages"
 version = "0.21.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -9949,7 +9949,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.20.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -9995,7 +9995,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "40.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10044,7 +10044,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "22.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10063,7 +10063,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "41.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10097,7 +10097,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "41.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -10144,7 +10144,7 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "8.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10159,7 +10159,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "41.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10176,7 +10176,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "40.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10197,7 +10197,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "40.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10210,7 +10210,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "42.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10584,7 +10584,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "40.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10621,7 +10621,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "41.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10643,7 +10643,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "41.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -10659,7 +10659,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "40.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10697,7 +10697,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "41.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10783,7 +10783,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "44.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -10802,7 +10802,7 @@ dependencies = [
 [[package]]
 name = "pallet-meta-tx"
 version = "0.3.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10840,7 +10840,7 @@ dependencies = [
 [[package]]
 name = "pallet-migrations"
 version = "11.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10859,7 +10859,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "41.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10871,7 +10871,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "41.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10882,7 +10882,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "41.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10892,7 +10892,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "39.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10910,7 +10910,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "39.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10930,7 +10930,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "37.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -10954,7 +10954,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "40.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10969,7 +10969,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "41.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -11004,7 +11004,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.12.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11042,7 +11042,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "41.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11058,7 +11058,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "41.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -11068,7 +11068,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "41.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11086,7 +11086,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "41.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -11096,7 +11096,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "41.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -11173,7 +11173,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "alloy-core",
  "derive_more 0.99.20",
@@ -11219,7 +11219,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-fixtures"
 version = "0.4.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -11233,7 +11233,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-proc-macro"
 version = "0.3.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11243,7 +11243,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-uapi"
 version = "0.5.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "bitflags 1.3.2",
  "pallet-revive-proc-macro",
@@ -11255,7 +11255,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "17.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11268,7 +11268,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "42.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11312,7 +11312,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "41.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11333,7 +11333,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "41.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11349,7 +11349,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "41.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11366,7 +11366,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "41.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -11388,7 +11388,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-ah-client"
 version = "0.2.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11407,7 +11407,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-rc-client"
 version = "0.2.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11424,7 +11424,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "23.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -11433,7 +11433,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "27.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -11443,7 +11443,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "46.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11490,7 +11490,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "41.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11505,7 +11505,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "40.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11523,7 +11523,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "40.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11541,7 +11541,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "41.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11556,7 +11556,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "44.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -11572,7 +11572,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "41.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -11584,7 +11584,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "40.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11603,7 +11603,7 @@ dependencies = [
 [[package]]
 name = "pallet-tx-pause"
 version = "22.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -11614,7 +11614,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "41.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11629,7 +11629,7 @@ dependencies = [
 [[package]]
 name = "pallet-verify-signature"
 version = "0.4.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11644,7 +11644,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "41.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11658,7 +11658,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "40.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -11668,7 +11668,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "20.1.3"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -11694,7 +11694,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "21.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11711,7 +11711,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub"
 version = "0.17.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -11733,7 +11733,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub-router"
 version = "0.19.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "bp-xcm-bridge-hub-router",
  "frame-benchmarking",
@@ -11814,7 +11814,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "22.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -11843,7 +11843,7 @@ dependencies = [
 [[package]]
 name = "parachains-runtimes-test-utils"
 version = "23.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
@@ -12172,7 +12172,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "polkadot-approval-distribution"
 version = "24.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -12190,7 +12190,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "24.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -12205,7 +12205,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "24.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "fatality",
  "futures 0.3.31",
@@ -12228,7 +12228,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "24.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-trait",
  "fatality",
@@ -12261,7 +12261,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "25.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",
@@ -12285,7 +12285,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "24.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "bitvec",
  "fatality",
@@ -12308,7 +12308,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "18.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12319,7 +12319,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "24.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "fatality",
  "futures 0.3.31",
@@ -12341,7 +12341,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "20.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -12355,7 +12355,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "24.0.1"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -12376,7 +12376,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "24.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -12399,7 +12399,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "24.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "futures 0.3.31",
  "parity-scale-codec",
@@ -12417,7 +12417,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "24.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -12449,7 +12449,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting-parallel"
 version = "0.7.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -12473,7 +12473,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "24.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "bitvec",
  "futures 0.3.31",
@@ -12492,7 +12492,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "24.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "bitvec",
  "fatality",
@@ -12513,7 +12513,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "24.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "futures 0.3.31",
  "polkadot-node-subsystem",
@@ -12528,7 +12528,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "24.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -12550,7 +12550,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "24.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "futures 0.3.31",
  "polkadot-node-metrics",
@@ -12564,7 +12564,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "24.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -12580,7 +12580,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "24.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "fatality",
  "futures 0.3.31",
@@ -12598,7 +12598,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "24.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -12615,7 +12615,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "23.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "fatality",
  "futures 0.3.31",
@@ -12629,7 +12629,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "24.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "bitvec",
  "fatality",
@@ -12646,7 +12646,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "24.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "always-assert",
  "array-bytes 6.2.3",
@@ -12674,7 +12674,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "24.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "futures 0.3.31",
  "polkadot-node-subsystem",
@@ -12687,7 +12687,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "20.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "cpu-time",
  "futures 0.3.31",
@@ -12713,7 +12713,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-execute-worker"
 version = "20.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "cfg-if",
  "cpu-time",
@@ -12731,7 +12731,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-prepare-worker"
 version = "20.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "cfg-if",
  "libc",
@@ -12749,7 +12749,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "24.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "futures 0.3.31",
  "polkadot-node-metrics",
@@ -12764,7 +12764,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "24.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "bs58",
  "futures 0.3.31",
@@ -12781,7 +12781,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "24.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -12806,7 +12806,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "20.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -12830,7 +12830,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "24.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-overseer",
@@ -12839,7 +12839,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "24.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-trait",
  "derive_more 0.99.20",
@@ -12867,7 +12867,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "24.0.1"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "fatality",
  "futures 0.3.31",
@@ -12898,7 +12898,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "24.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -12918,7 +12918,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "17.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "bounded-collections",
  "derive_more 0.99.20",
@@ -12934,7 +12934,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "19.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "bitvec",
  "bounded-collections",
@@ -12963,7 +12963,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "25.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -12996,7 +12996,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "20.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -13046,7 +13046,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "21.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -13058,7 +13058,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "20.0.2"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -13107,7 +13107,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.10.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -13142,7 +13142,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "25.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -13250,7 +13250,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "24.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "bitvec",
  "fatality",
@@ -13270,7 +13270,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "20.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -14547,7 +14547,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "24.0.1"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -14645,7 +14645,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "21.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -15027,7 +15027,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "32.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "log",
  "sp-core",
@@ -15038,7 +15038,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.51.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -15069,7 +15069,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.50.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "futures 0.3.31",
  "log",
@@ -15090,7 +15090,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.45.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -15105,7 +15105,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "44.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "array-bytes 6.2.3",
  "docify",
@@ -15131,7 +15131,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -15142,7 +15142,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.53.1"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "array-bytes 6.2.3",
  "chrono",
@@ -15187,7 +15187,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "40.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "fnv",
  "futures 0.3.31",
@@ -15213,7 +15213,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.47.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -15241,7 +15241,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.50.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -15264,7 +15264,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.51.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -15293,7 +15293,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.51.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -15329,7 +15329,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.51.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "futures 0.3.31",
  "jsonrpsee",
@@ -15351,7 +15351,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "30.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -15385,7 +15385,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "30.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "futures 0.3.31",
  "jsonrpsee",
@@ -15405,7 +15405,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.50.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -15418,7 +15418,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.36.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "ahash",
  "array-bytes 6.2.3",
@@ -15462,7 +15462,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.36.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "finality-grandpa",
  "futures 0.3.31",
@@ -15482,7 +15482,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.52.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -15517,7 +15517,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.50.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -15540,7 +15540,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.43.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -15564,7 +15564,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.39.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "parity-scale-codec",
  "polkavm 0.24.0",
@@ -15578,7 +15578,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.36.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "log",
  "polkavm 0.24.0",
@@ -15589,7 +15589,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.39.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -15608,7 +15608,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.50.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "console",
  "futures 0.3.31",
@@ -15624,7 +15624,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "36.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "array-bytes 6.2.3",
  "parking_lot 0.12.4",
@@ -15638,7 +15638,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.21.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "array-bytes 6.2.3",
  "arrayvec 0.7.6",
@@ -15666,7 +15666,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.51.1"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -15716,7 +15716,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.49.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -15726,7 +15726,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.51.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "ahash",
  "futures 0.3.31",
@@ -15745,7 +15745,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.50.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -15766,7 +15766,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.50.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -15801,7 +15801,7 @@ dependencies = [
 [[package]]
 name = "sc-network-test"
 version = "0.8.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -15834,7 +15834,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.50.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "array-bytes 6.2.3",
  "futures 0.3.31",
@@ -15853,7 +15853,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.17.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "bs58",
  "bytes",
@@ -15874,7 +15874,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "46.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "bytes",
  "fnv",
@@ -15908,7 +15908,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.20.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -15917,7 +15917,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "46.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "futures 0.3.31",
  "jsonrpsee",
@@ -15949,7 +15949,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.50.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -15969,7 +15969,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "23.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -15993,7 +15993,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.51.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "array-bytes 6.2.3",
  "futures 0.3.31",
@@ -16026,7 +16026,7 @@ dependencies = [
 [[package]]
 name = "sc-runtime-utilities"
 version = "0.3.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "parity-scale-codec",
  "sc-executor",
@@ -16041,7 +16041,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.52.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-trait",
  "directories",
@@ -16105,7 +16105,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.39.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -16116,7 +16116,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.25.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "clap",
  "fs4",
@@ -16129,7 +16129,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.51.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -16148,7 +16148,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "43.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "derive_more 0.99.20",
  "futures 0.3.31",
@@ -16168,7 +16168,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "29.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "chrono",
  "futures 0.3.31",
@@ -16187,7 +16187,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "40.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "chrono",
  "console",
@@ -16215,7 +16215,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -16226,7 +16226,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "40.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -16257,7 +16257,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "40.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -16274,7 +16274,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "19.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-channel 1.9.0",
  "futures 0.3.31",
@@ -17012,7 +17012,7 @@ dependencies = [
 [[package]]
 name = "slot-range-helper"
 version = "18.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -17285,7 +17285,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-beacon-primitives"
 version = "0.14.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "byte-slice-cast",
  "frame-support",
@@ -17307,7 +17307,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-core"
 version = "0.14.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "bp-relayers",
  "frame-support",
@@ -17331,7 +17331,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-ethereum"
 version = "0.13.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "ethabi-decode",
  "ethbloom",
@@ -17351,7 +17351,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-inbound-queue-primitives"
 version = "0.3.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "alloy-core",
  "alloy-primitives 0.4.2",
@@ -17378,7 +17378,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-merkle-tree"
 version = "0.3.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17404,7 +17404,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-outbound-queue-primitives"
 version = "0.3.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "alloy-core",
  "ethabi-decode",
@@ -17430,7 +17430,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-outbound-queue-runtime-api"
 version = "0.14.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -17444,7 +17444,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-ethereum-client"
 version = "0.14.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -17471,7 +17471,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-ethereum-client-fixtures"
 version = "0.22.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "hex-literal",
  "snowbridge-beacon-primitives",
@@ -17483,7 +17483,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-inbound-queue"
 version = "0.14.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "alloy-core",
  "frame-benchmarking",
@@ -17509,7 +17509,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-inbound-queue-fixtures"
 version = "0.22.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "hex-literal",
  "snowbridge-beacon-primitives",
@@ -17522,7 +17522,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-outbound-queue"
 version = "0.14.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "bridge-hub-common",
  "ethabi-decode",
@@ -17545,7 +17545,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-system"
 version = "0.14.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -17566,7 +17566,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-verification-primitives"
 version = "0.3.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -17630,7 +17630,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "37.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "docify",
  "hash-db",
@@ -17652,7 +17652,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "23.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -17666,7 +17666,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "41.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17678,7 +17678,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "27.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -17692,7 +17692,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "37.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17704,7 +17704,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "37.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -17714,7 +17714,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "40.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "futures 0.3.31",
  "parity-scale-codec",
@@ -17733,7 +17733,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.43.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -17747,7 +17747,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.43.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -17763,7 +17763,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.43.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -17781,7 +17781,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "25.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17801,7 +17801,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "24.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -17818,7 +17818,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.43.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17829,7 +17829,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "37.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "array-bytes 6.2.3",
  "bitflags 1.3.2",
@@ -17890,7 +17890,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -17903,7 +17903,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "quote",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506)",
@@ -17913,7 +17913,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.4",
@@ -17922,7 +17922,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -17932,7 +17932,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.30.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -17942,7 +17942,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.18.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17954,7 +17954,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "37.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -17967,7 +17967,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "41.0.1"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "bytes",
  "docify",
@@ -17993,7 +17993,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "42.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -18003,7 +18003,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.43.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.4",
@@ -18014,7 +18014,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -18023,7 +18023,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.11.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-metadata 23.0.0",
  "parity-scale-codec",
@@ -18033,7 +18033,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.15.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18044,7 +18044,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "37.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -18061,7 +18061,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "37.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18074,7 +18074,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "37.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -18084,7 +18084,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.2"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "backtrace",
  "regex",
@@ -18093,7 +18093,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "35.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -18103,7 +18103,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "42.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "binary-merkle-tree",
  "docify",
@@ -18132,7 +18132,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "30.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -18151,7 +18151,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "19.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "Inflector",
  "expander",
@@ -18164,7 +18164,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "39.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18178,7 +18178,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "39.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -18191,7 +18191,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.46.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "hash-db",
  "log",
@@ -18211,7 +18211,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "21.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -18235,12 +18235,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 
 [[package]]
 name = "sp-storage"
 version = "22.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -18252,7 +18252,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "37.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -18264,7 +18264,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "parity-scale-codec",
  "regex",
@@ -18276,7 +18276,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "37.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -18285,7 +18285,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "37.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -18299,7 +18299,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "40.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "ahash",
  "foldhash",
@@ -18324,7 +18324,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "40.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -18341,7 +18341,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -18353,7 +18353,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "22.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -18365,7 +18365,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "32.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -18588,7 +18588,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-parachain-info"
 version = "0.21.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -18601,12 +18601,12 @@ dependencies = [
 [[package]]
 name = "staging-tracking-allocator"
 version = "2.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 
 [[package]]
 name = "staging-xcm"
 version = "17.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "array-bytes 6.2.3",
  "bounded-collections",
@@ -18627,7 +18627,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "21.1.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "environmental",
  "frame-support",
@@ -18651,7 +18651,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "20.0.1"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -18986,7 +18986,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -19011,12 +19011,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "45.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -19036,7 +19036,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.6"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "http-body-util",
  "hyper 1.6.0",
@@ -19050,7 +19050,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.50.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -19063,7 +19063,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "44.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -19080,7 +19080,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "array-bytes 6.2.3",
  "async-trait",
@@ -19105,7 +19105,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "array-bytes 6.2.3",
  "frame-executive",
@@ -19151,7 +19151,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "futures 0.3.31",
  "sc-block-builder",
@@ -19169,7 +19169,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "27.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "array-bytes 6.2.3",
  "build-helper",
@@ -20908,7 +20908,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "20.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -20919,7 +20919,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "expander",
  "proc-macro-crate 3.3.0",
@@ -21802,7 +21802,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "24.0.1"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -21909,7 +21909,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "21.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -22523,7 +22523,7 @@ dependencies = [
 [[package]]
 name = "xcm-emulator"
 version = "0.20.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "array-bytes 6.2.3",
  "cumulus-pallet-parachain-system",
@@ -22575,7 +22575,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "11.0.2"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -22586,7 +22586,7 @@ dependencies = [
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.8.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -22600,7 +22600,7 @@ dependencies = [
 [[package]]
 name = "xcm-simulator"
 version = "21.0.0"
-source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#bd8cff5d18fdf08ac97efe505cd1486b2770dbd8"
+source = "git+https://github.com/moondance-labs/polkadot-sdk?branch=tanssi-polkadot-stable2506#a48ddc6a20a6b11135c08c507e96bf59a508815b"
 dependencies = [
  "frame-support",
  "frame-system",


### PR DESCRIPTION
Allows using custom dns servers. Without this, litep2p will use 8.8.8.8 as DNS, and that doesn't work if using custom host names, for example in kubernetes.

https://github.com/moondance-labs/polkadot-sdk/commit/a48ddc6a20a6b11135c08c507e96bf59a508815b