### PR TITLE
Fix benchmarking script on CI

### DIFF
--- a/.github/workflow-templates/install-frame-omni-bencher/action.yml
+++ b/.github/workflow-templates/install-frame-omni-bencher/action.yml
@@ -8,8 +8,7 @@ runs:
     - name: Install frame-omni-bencher
       shell: bash
       run: |
-        BRANCH=$(grep 'moondance-labs/polkadot-sdk' Cargo.lock \
-          | head -n 1 \
+        BRANCH=$(grep -m1 'moondance-labs/polkadot-sdk' Cargo.lock \
           | sed -E 's/.*branch=([^#"]+).*/\1/')
         cargo install frame-omni-bencher --locked --git https://github.com/moondance-labs/polkadot-sdk --branch $BRANCH --force
         echo "$HOME/.cargo/bin" >> $GITHUB_PATH


### PR DESCRIPTION
## Description
This PR fixes the benchmarking script on CI, which fails because of broken pipe in grep.
We pick the 1st matched element instead of all.