### PR TITLE
Smok test fix

### DIFF
--- a/test/suites/smoke-test-common-solo/test-ethereum-token-transfers.ts
+++ b/test/suites/smoke-test-common-solo/test-ethereum-token-transfers.ts
@@ -314,7 +314,7 @@ describeSuite({
                                         issuedAmount.toString() === hexToBigInt(amount).toString()
                                     );
                                 }
-                            )[0];
+                            ).find(Boolean);
 
                             expect(
                                 matched,
@@ -384,7 +384,7 @@ describeSuite({
                                             burnedAmount.toString() === hexToBigInt(amount).toString()
                                         );
                                     }
-                                )[0];
+                                ).find(Boolean);
 
                                 expect(
                                     matched,


### PR DESCRIPTION
## Description
This PR fixes the smoke test, where we check the event `balances`.`Transfer` if we have extrinsic `ethereumInboundQueue`.`submit`.
If we have several transfer events, it would pick the 1st one. Instead we should filter all the matched.