### PR TITLE
clean migrations from old runtimes

### DIFF
--- a/chains/runtime-common/src/migrations.rs
+++ b/chains/runtime-common/src/migrations.rs
@@ -1472,10 +1472,10 @@ mod relay {
         fn get_migrations() -> Vec<Box<dyn Migration>> {
             /*let migrate_pallet_session_v0_to_v1 =
                 MigratePalletSessionV0toV1::<Runtime>(Default::default());
-            
+
             let migrate_snowbridge_fee_per_gas_migration_v0_to_v1 =
                 MigrateSnowbridgeFeePerGasMigrationV0ToV1::<Runtime>(Default::default());
-            
+
             let _eth_system_genesis_hashes = MigrateEthSystemGenesisHashes::<
                 Runtime,
                 snowbridge_system_migration::StarlightLocation,


### PR DESCRIPTION
Comments migrations that have passed in previous runtimes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled a set of runtime upgrade migrations, reducing the number of automated migration steps applied during upgrades. This changes the upgrade behavior by preventing certain legacy migration actions from running while preserving public interfaces and outward functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->