### PR TITLE
Fix zombienet no-bootnodes script

### DIFF
--- a/test/scripts/build-spec-dancelight-no-bootnodes.sh
+++ b/test/scripts/build-spec-dancelight-no-bootnodes.sh
@@ -16,9 +16,9 @@ mkdir -p specs
 # IF and Fallback should be removed after new version release
 # https://opslayer.atlassian.net/browse/MD-1512
 if bash ./scripts/check-export-chain-spec-cmd.sh $BINARY_FOLDER/container-chain-simple-node | grep -q "export-chain-spec"; then
-  $BINARY_FOLDER/container-chain-simple-node export-chain-spec --disable-default-bootnode --parachain-id 2000 --raw > specs/single-container-template-container-2000-no-bootnodes.json
-  $BINARY_FOLDER/container-chain-frontier-node export-chain-spec --disable-default-bootnode --parachain-id 2001 --raw > specs/single-container-template-container-2001-no-bootnodes.json
-  $BINARY_FOLDER/container-chain-simple-node export-chain-spec --disable-default-bootnode --parachain-id 2002 --raw > specs/single-container-template-container-2002-no-bootnodes.json
+  $BINARY_FOLDER/container-chain-simple-node export-chain-spec --parachain-id 2000 --raw > specs/single-container-template-container-2000-no-bootnodes.json
+  $BINARY_FOLDER/container-chain-frontier-node export-chain-spec --parachain-id 2001 --raw > specs/single-container-template-container-2001-no-bootnodes.json
+  $BINARY_FOLDER/container-chain-simple-node export-chain-spec --parachain-id 2002 --raw > specs/single-container-template-container-2002-no-bootnodes.json
   $BINARY_FOLDER/tanssi-relay export-chain-spec --chain dancelight-local --add-container-chain specs/single-container-template-container-2000-no-bootnodes.json --add-container-chain specs/single-container-template-container-2001-no-bootnodes.json --invulnerable "Collator-01" --invulnerable "Collator-02" --invulnerable "Collator-03" --invulnerable "Collator-04" --invulnerable "Collator-05" --invulnerable "Collator-06" > specs/tanssi-relay-no-bootnodes.json
 
   # Also need to build the genesis-state to be able to register the container 2002 later


### PR DESCRIPTION
--disable-default-bootnode is the default with export-chain-spec command

Fix #1465 